### PR TITLE
feat(terminal): run Git Bash or cmd in Windows panes, with a shell picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8332,6 +8332,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "gpui",
+ "oximux-shell-env",
  "serde",
  "tempfile",
  "toml 0.8.23",
@@ -8343,6 +8344,8 @@ name = "oximux-shell-env"
 version = "0.1.18"
 dependencies = [
  "portable-pty",
+ "serde",
+ "serde_json",
  "which 6.0.3",
 ]
 

--- a/apps/desktop/src/app_settings/terminal_settings.rs
+++ b/apps/desktop/src/app_settings/terminal_settings.rs
@@ -21,8 +21,10 @@ use notify_debouncer_full::{
 use oximux_settings::TerminalSettings;
 use tokio::sync::mpsc;
 
+use oximux_shell_env::ResolvedShell;
+
 use crate::shell::terminal_view::{
-    set_shell_integration_enabled, set_spawn_scrollback, set_spawn_shell,
+    set_shell_integration_enabled, set_spawn_scrollback, set_spawn_shell_resolved,
 };
 
 
@@ -91,8 +93,37 @@ fn seed_default_if_absent() {
 fn apply(cx: &mut App, settings: TerminalSettings) {
     set_spawn_scrollback(settings.scrollback_lines);
     set_shell_integration_enabled(settings.shell_integration);
-    set_spawn_shell(settings.shell.clone());
+    set_spawn_shell_resolved(resolve_spawn_shell(&settings));
     cx.set_global(settings);
+}
+
+/// Turn the terminal settings into the shell a new pane should spawn.
+///
+/// A non-empty free-form `shell` override wins on every platform. Otherwise,
+/// on Windows, the [`WindowsShell`](oximux_settings::WindowsShell) choice is
+/// resolved to a concrete program + argv + env (Git Bash detection, pwsh vs
+/// inbox PowerShell). Off Windows there is nothing to resolve — `None` lets
+/// the spawn fall back to the inherited `$SHELL` / POSIX default.
+fn resolve_spawn_shell(settings: &TerminalSettings) -> Option<ResolvedShell> {
+    let override_path = settings.shell.trim();
+    if !override_path.is_empty() {
+        return Some(ResolvedShell {
+            program: override_path.to_string(),
+            args: Vec::new(),
+            env: Vec::new(),
+        });
+    }
+    #[cfg(windows)]
+    let resolved = Some(oximux_shell_env::resolve_windows_shell(
+        settings.windows_shell,
+        settings.windows_powershell,
+    ));
+    #[cfg(not(windows))]
+    let resolved = {
+        let _ = settings;
+        None
+    };
+    resolved
 }
 
 /// Resolved app data dir (where `terminal.toml` + sibling configs live).

--- a/apps/desktop/src/shell/settings_modal/pane_terminal.rs
+++ b/apps/desktop/src/shell/settings_modal/pane_terminal.rs
@@ -3,7 +3,7 @@
 //! `terminal.toml`; the live-reload watcher re-applies to open panes.
 
 use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px};
-use oximux_settings::{BellStyle, Density, Theme, Typography};
+use oximux_settings::{BellStyle, Density, Theme, Typography, WindowsPowerShell, WindowsShell};
 
 use super::SettingsModal;
 use super::controls::{stepper, toggle_switch};
@@ -123,6 +123,81 @@ pub(super) fn entries(
         cx,
     );
 
+    // Windows-only: which shell family new panes run, and which PowerShell
+    // binary the PowerShell family resolves to. Built unconditionally (the
+    // enums are cross-platform) but only surfaced as rows on Windows below.
+    let windows_shell = segmented(
+        "term-winshell",
+        vec![
+            Segment::new(
+                "PowerShell",
+                t.windows_shell == WindowsShell::PowerShell,
+                |this, _w, cx| {
+                    this.terminal.windows_shell = WindowsShell::PowerShell;
+                    this.persist_terminal(cx);
+                },
+            ),
+            Segment::new(
+                "Command Prompt",
+                t.windows_shell == WindowsShell::CommandPrompt,
+                |this, _w, cx| {
+                    this.terminal.windows_shell = WindowsShell::CommandPrompt;
+                    this.persist_terminal(cx);
+                },
+            ),
+            Segment::new(
+                "Git Bash",
+                t.windows_shell == WindowsShell::GitBash,
+                |this, _w, cx| {
+                    this.terminal.windows_shell = WindowsShell::GitBash;
+                    this.persist_terminal(cx);
+                },
+            ),
+            Segment::new("Auto", t.windows_shell == WindowsShell::Auto, |this, _w, cx| {
+                this.terminal.windows_shell = WindowsShell::Auto;
+                this.persist_terminal(cx);
+            }),
+        ],
+        theme,
+        density,
+        typography,
+        cx,
+    );
+
+    let windows_powershell = segmented(
+        "term-winps",
+        vec![
+            Segment::new(
+                "Auto",
+                t.windows_powershell == WindowsPowerShell::Auto,
+                |this, _w, cx| {
+                    this.terminal.windows_powershell = WindowsPowerShell::Auto;
+                    this.persist_terminal(cx);
+                },
+            ),
+            Segment::new(
+                "pwsh 7",
+                t.windows_powershell == WindowsPowerShell::Pwsh,
+                |this, _w, cx| {
+                    this.terminal.windows_powershell = WindowsPowerShell::Pwsh;
+                    this.persist_terminal(cx);
+                },
+            ),
+            Segment::new(
+                "Windows",
+                t.windows_powershell == WindowsPowerShell::Windows,
+                |this, _w, cx| {
+                    this.terminal.windows_powershell = WindowsPowerShell::Windows;
+                    this.persist_terminal(cx);
+                },
+            ),
+        ],
+        theme,
+        density,
+        typography,
+        cx,
+    );
+
     let cursor_blink = toggle_switch(
         "term-cursorblink",
         t.cursor_blink,
@@ -167,7 +242,28 @@ pub(super) fn entries(
         cx,
     );
 
-    vec![
+    let mut rows: Vec<SettingEntry> = Vec::new();
+
+    // The Windows shell picker leads the pane, matching the "Windows Shell"
+    // section other terminals surface. Only meaningful on Windows; off it the
+    // shell is `$SHELL` / the POSIX default, so these rows are hidden.
+    if cfg!(windows) {
+        rows.push(entry(
+            "Default shell",
+            "Shell new terminal panes run on Windows. Auto prefers Git Bash when Git for Windows is installed.",
+            windows_shell,
+        ));
+        rows.push(entry(
+            "PowerShell edition",
+            "Which PowerShell the PowerShell option uses: Auto (pwsh 7 when present), pwsh 7, or inbox Windows PowerShell.",
+            windows_powershell,
+        ));
+    } else {
+        // Keep the controls "used" on non-Windows without rendering them.
+        let _ = (&windows_shell, &windows_powershell);
+    }
+
+    rows.extend([
         entry(
             "Scrollback",
             "Maximum lines kept in scrollback history.",
@@ -204,5 +300,7 @@ pub(super) fn entries(
             "Copy text to the clipboard as soon as a selection is made.",
             copy_on_select,
         ),
-    ]
+    ]);
+
+    rows
 }

--- a/apps/desktop/src/shell/terminal/terminal_view/mod.rs
+++ b/apps/desktop/src/shell/terminal/terminal_view/mod.rs
@@ -154,7 +154,9 @@ pub fn terminal_settings(cx: &App) -> TerminalSettings {
 }
 
 mod spawn_settings;
-pub use spawn_settings::{set_shell_integration_enabled, set_spawn_scrollback, set_spawn_shell};
+pub use spawn_settings::{
+    set_shell_integration_enabled, set_spawn_scrollback, set_spawn_shell, set_spawn_shell_resolved,
+};
 pub(crate) use spawn_settings::shell_integration_enabled;
 use spawn_settings::{shell_spawn_config, spawn_scrollback};
 

--- a/apps/desktop/src/shell/terminal/terminal_view/spawn_settings.rs
+++ b/apps/desktop/src/shell/terminal/terminal_view/spawn_settings.rs
@@ -140,4 +140,86 @@ mod shell_override_tests {
         // Restore so a later test in this process isn't spawning it.
         set_spawn_shell(String::new());
     }
+
+    /// End-to-end: the Windows Git Bash choice must resolve, build a spawn
+    /// config, survive the OSC-133 augmentation, and launch a shell that runs
+    /// a command in the pane's cwd. Self-skipping when Git for Windows is not
+    /// installed (CI images without it), exactly like the shell-env resolver
+    /// test. The real production functions are used at every step — no
+    /// reimplementation — so this is the live proof of the whole path.
+    #[cfg(windows)]
+    #[test]
+    fn git_bash_choice_spawns_a_working_pane() {
+        use std::time::{Duration, Instant};
+
+        use oximux_pty::backend::TerminalBackend;
+        use oximux_pty::events::TerminalEvent;
+        use oximux_pty::portable_pty_backend::PortablePtyBackend;
+
+        let _serial = crate::platform::serialize_input_state();
+
+        // Resolve exactly as the settings loader's `apply` does.
+        let resolved = oximux_shell_env::resolve_windows_shell(
+            oximux_shell_env::WindowsShell::GitBash,
+            oximux_shell_env::WindowsPowerShell::Auto,
+        );
+        let is_git_bash = std::path::Path::new(&resolved.program)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.eq_ignore_ascii_case("bash.exe"))
+            .unwrap_or(false);
+        if !is_git_bash {
+            // No Git for Windows here — nothing to verify.
+            return;
+        }
+        set_spawn_shell_resolved(Some(resolved));
+
+        // Build the config through the real helper, then run the real OSC-133
+        // augmentation (writes the overlay + prepends `--rcfile`).
+        let cwd = std::env::temp_dir();
+        let mut cfg = shell_spawn_config(cwd.clone(), Vec::new(), 100, 32);
+        crate::shell::terminal::shell_integration::augment_spawn_config(&mut cfg);
+        assert!(
+            cfg.args.iter().any(|a| a == "-i"),
+            "git bash must launch interactive: {:?}",
+            cfg.args
+        );
+        assert!(
+            cfg.env.iter().any(|(k, _)| k == "CHERE_INVOKING"),
+            "git bash must keep the pane cwd"
+        );
+
+        let mut backend = PortablePtyBackend::new();
+        let id = backend.spawn(cfg).expect("spawn git bash pane");
+
+        // Drive it: answer device queries, then type a command whose output is
+        // a unique marker, and wait for it to render.
+        let t0 = Instant::now();
+        let mut typed = false;
+        let mut found = false;
+        while t0.elapsed() < Duration::from_secs(15) && !found {
+            for ev in backend.drain_events() {
+                if let TerminalEvent::PtyReply { bytes, .. } = ev {
+                    let _ = backend.write(id, &bytes);
+                }
+            }
+            if !typed && t0.elapsed() > Duration::from_millis(1500) {
+                let _ = backend.write(id, b"echo OXIMUXLIVE_$((6*7))\r\n");
+                typed = true;
+            }
+            if let Ok(snap) = backend.snapshot(id) {
+                found = snap.cells.iter().any(|row| {
+                    let s: String = row.iter().map(|c| c.ch).collect();
+                    // The command line echoes the literal `$((6*7))`; only the
+                    // expanded output proves the shell actually ran it.
+                    s.contains("OXIMUXLIVE_42")
+                });
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        backend.close(id).ok();
+        set_spawn_shell_resolved(None);
+
+        assert!(found, "git bash pane never rendered the expanded command output");
+    }
 }

--- a/apps/desktop/src/shell/terminal/terminal_view/spawn_settings.rs
+++ b/apps/desktop/src/shell/terminal/terminal_view/spawn_settings.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 
 use oximux_pty::SpawnConfig;
+use oximux_shell_env::ResolvedShell;
 
 /// Process-wide mirror of `TerminalSettings::scrollback_lines`. The PTY spawn
 /// helpers are `cx`-less free functions, so they read scrollback here instead
@@ -48,43 +49,67 @@ pub(crate) fn shell_integration_enabled() -> bool {
     SHELL_INTEGRATION_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Process-wide mirror of `TerminalSettings::shell`. Same reason as the two
-/// above: the spawn helpers are `cx`-less. Empty means the user set no
-/// override, and the spawning process picks.
-static SPAWN_SHELL: std::sync::RwLock<String> = std::sync::RwLock::new(String::new());
+/// Process-wide mirror of the resolved spawn shell. Same reason as the two
+/// above: the spawn helpers are `cx`-less. `None` means "no explicit pick"
+/// and the spawn falls back to `SpawnConfig::default().shell`.
+///
+/// Unlike the bare-string it replaced, this carries the argv and env a shell
+/// needs to launch (Git Bash's `-i` / `MSYSTEM` / `CHERE_INVOKING`), resolved
+/// once by the settings loader from the user's [`WindowsShell`] choice.
+static SPAWN_SHELL: std::sync::RwLock<Option<ResolvedShell>> = std::sync::RwLock::new(None);
 
-/// Update the shell-override mirror from settings. Called once at startup and
-/// on every settings reload.
-pub fn set_spawn_shell(shell: String) {
+/// Set the resolved spawn shell from settings. Called once at startup and on
+/// every settings reload. `None` clears any prior override.
+pub fn set_spawn_shell_resolved(shell: Option<ResolvedShell>) {
     let mut slot = SPAWN_SHELL
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     *slot = shell;
 }
 
-/// The user's shell override, or `None` when they have not set one.
-fn spawn_shell() -> Option<String> {
-    let slot = SPAWN_SHELL
-        .read()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    (!slot.is_empty()).then(|| slot.clone())
+/// Back-compat setter for a bare program path (used by tests and any caller
+/// that only knows a path). Empty clears the override.
+pub fn set_spawn_shell(shell: String) {
+    set_spawn_shell_resolved((!shell.is_empty()).then(|| ResolvedShell {
+        program: shell,
+        args: Vec::new(),
+        env: Vec::new(),
+    }));
 }
 
-/// A [`SpawnConfig`] whose shell honors the user's override, falling back to
-/// whatever the platform resolver picked.
+/// The resolved spawn shell, or `None` when none was set.
+fn spawn_shell() -> Option<ResolvedShell> {
+    SPAWN_SHELL
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+/// A [`SpawnConfig`] whose shell honors the user's resolved choice, falling
+/// back to whatever the platform resolver picked.
+///
+/// The resolved shell's own env is prepended so the caller's context env
+/// (passed in `env`) still wins on any key collision — the backend applies
+/// `cfg.env` last, so a later duplicate key overrides an earlier one.
 ///
 /// Only for interactive shells. A spawn that names its own program — an agent
 /// CLI, an ACP embedded terminal — must not have the user's shell substituted
 /// under it.
 pub(super) fn shell_spawn_config(cwd: PathBuf, env: Vec<(String, String)>, cols: u16, rows: u16) -> SpawnConfig {
     let base = SpawnConfig::default();
+    let (shell, args, mut merged_env) = match spawn_shell() {
+        Some(resolved) => (resolved.program, resolved.args, resolved.env),
+        None => (base.shell, base.args.clone(), Vec::new()),
+    };
+    merged_env.extend(env);
     SpawnConfig {
         cwd,
-        env,
+        env: merged_env,
         cols,
         rows,
         scrollback: spawn_scrollback(),
-        shell: spawn_shell().unwrap_or(base.shell),
+        shell,
+        args,
         ..base
     }
 }

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -17,6 +17,9 @@ gpui = ["dep:gpui"]
 
 [dependencies]
 gpui = { workspace = true, optional = true }
+# The Windows-shell choice enums persisted in `terminal.toml` live in
+# shell-env (one source of truth with the resolver that consumes them).
+oximux-shell-env = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -46,7 +46,7 @@ pub use fonts::FontChoice;
 pub use keybindings::KeybindingOverrides;
 pub use motion::{Motion, ease_out_spring};
 pub use project_scripts::{ProjectScripts, ScriptKind, load_for_project};
-pub use terminal::{BellStyle, TerminalSettings};
+pub use terminal::{BellStyle, TerminalSettings, WindowsPowerShell, WindowsShell};
 #[cfg(feature = "gpui")]
 pub use theme::{GitDecorations, SyntaxPalette, Theme};
 #[cfg(feature = "gpui")]

--- a/crates/settings/src/terminal.rs
+++ b/crates/settings/src/terminal.rs
@@ -12,6 +12,7 @@
 
 #[cfg(feature = "gpui")]
 use gpui::Global;
+pub use oximux_shell_env::{WindowsPowerShell, WindowsShell};
 use serde::{Deserialize, Serialize};
 
 /// How a terminal bell (BEL / `\a`) is surfaced.
@@ -75,6 +76,13 @@ pub struct TerminalSettings {
     /// the spawning process, which for a relay-backed terminal is the daemon,
     /// whose `PATH` need not match the app's.
     pub shell: String,
+    /// Which shell family new panes run on Windows: PowerShell (default),
+    /// Command Prompt, Git Bash, or Auto (Git Bash when installed, else
+    /// PowerShell). Ignored off Windows and overridden by a non-empty `shell`.
+    pub windows_shell: WindowsShell,
+    /// Which PowerShell binary the PowerShell family resolves to on Windows:
+    /// Auto (pwsh 7 when present, else inbox), Pwsh, or Windows PowerShell.
+    pub windows_powershell: WindowsPowerShell,
     /// How a bell is surfaced.
     pub bell: BellStyle,
 }
@@ -99,6 +107,8 @@ impl Default for TerminalSettings {
             copy_on_select: false,
             shell_integration: true,
             shell: String::new(),
+            windows_shell: WindowsShell::default(),
+            windows_powershell: WindowsPowerShell::default(),
             bell: BellStyle::Visual,
         }
     }
@@ -226,6 +236,27 @@ mod tests {
             .expect("parse")
             .sanitized();
         assert!(blank.shell.is_empty());
+    }
+
+    #[test]
+    fn windows_shell_defaults_to_powershell_and_round_trips() {
+        // Default follows the prior behavior (PowerShell / auto pwsh).
+        let d = TerminalSettings::default();
+        assert_eq!(d.windows_shell, WindowsShell::PowerShell);
+        assert_eq!(d.windows_powershell, WindowsPowerShell::Auto);
+
+        // A file selecting Git Bash keeps every other default.
+        let s = TerminalSettings::from_toml_str(
+            "windows_shell = \"git-bash\"\nwindows_powershell = \"pwsh\"\n",
+        )
+        .expect("parse");
+        assert_eq!(s.windows_shell, WindowsShell::GitBash);
+        assert_eq!(s.windows_powershell, WindowsPowerShell::Pwsh);
+        assert_eq!(s.scrollback_lines, 5000);
+
+        // Full default round-trips through TOML unchanged.
+        let toml = d.to_toml_string();
+        assert_eq!(TerminalSettings::from_toml_str(&toml).expect("round-trip"), d);
     }
 
     #[test]

--- a/crates/shell-env/Cargo.toml
+++ b/crates/shell-env/Cargo.toml
@@ -17,7 +17,15 @@ test-support = []
 # depend on portable-pty, so this adds nothing to either dependency graph.
 portable-pty = { workspace = true }
 
+# Derive on the Windows-shell choice enums so `oximux-settings` can persist
+# them in `terminal.toml` without a parallel copy of the same variants.
+serde = { workspace = true }
+
 # PATH + PATHEXT resolution for the Windows shell probe. The same crate the
 # agent-CLI detector uses, so `.exe`/`.cmd` handling has one implementation.
 [target.'cfg(windows)'.dependencies]
 which = { workspace = true }
+
+[dev-dependencies]
+# Round-trips the Windows-shell enums to assert their stable TOML spellings.
+serde_json = { workspace = true }

--- a/crates/shell-env/src/lib.rs
+++ b/crates/shell-env/src/lib.rs
@@ -63,6 +63,9 @@ pub struct ResolvedShell {
     pub env: Vec<(String, String)>,
 }
 
+// Only the Windows resolver builds a program-only shell; gate the helper so
+// it isn't dead code on other platforms (CI builds with `-D warnings`).
+#[cfg(windows)]
 impl ResolvedShell {
     fn program(program: String) -> Self {
         Self {

--- a/crates/shell-env/src/lib.rs
+++ b/crates/shell-env/src/lib.rs
@@ -8,6 +8,70 @@
 //! no other dependency (the daemon deliberately avoids the grid emulator).
 
 use portable_pty::CommandBuilder;
+use serde::{Deserialize, Serialize};
+
+/// Which shell family a new terminal pane runs on Windows.
+///
+/// Stored in `terminal.toml` (via `oximux-settings`) and surfaced as a
+/// segmented control in the settings UI. Ignored off Windows, where the shell
+/// is the inherited `$SHELL` or the POSIX fallback chain (see [`default_shell`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum WindowsShell {
+    /// Windows PowerShell or PowerShell 7, per [`WindowsPowerShell`]. The
+    /// default, matching every prior release.
+    #[default]
+    #[serde(rename = "powershell")]
+    PowerShell,
+    /// The classic command processor, `cmd.exe`.
+    #[serde(rename = "cmd")]
+    CommandPrompt,
+    /// Git for Windows' `bash.exe`, resolved from the standard install
+    /// locations (or `OXIMUX_GIT_BASH_PATH`). Falls back to PowerShell when
+    /// Git for Windows is not installed.
+    #[serde(rename = "git-bash")]
+    GitBash,
+    /// Prefer Git Bash when Git for Windows is installed, else PowerShell.
+    #[serde(rename = "auto")]
+    Auto,
+}
+
+/// Which PowerShell binary the `PowerShell` family resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum WindowsPowerShell {
+    /// PowerShell 7+ (`pwsh.exe`) when present, else inbox Windows PowerShell.
+    #[default]
+    Auto,
+    /// Force PowerShell 7+ (`pwsh.exe`); still falls back to inbox PowerShell
+    /// if `pwsh.exe` cannot be found, so a terminal always opens.
+    Pwsh,
+    /// Force inbox Windows PowerShell 5.1 (`powershell.exe`).
+    #[serde(rename = "powershell")]
+    Windows,
+}
+
+/// A resolved shell to spawn: the program plus the argv and environment its
+/// launch needs. `args`/`env` are empty for shells that need neither.
+///
+/// The shell-integration layer may still prepend its own argv (bash
+/// `--rcfile`, PowerShell `-Command`) on top of these — see the desktop app's
+/// `augment_spawn_config`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedShell {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+impl ResolvedShell {
+    fn program(program: String) -> Self {
+        Self {
+            program,
+            args: Vec::new(),
+            env: Vec::new(),
+        }
+    }
+}
 
 /// The program a new terminal runs when the caller asks for a plain shell.
 ///
@@ -55,25 +119,215 @@ fn unix_shell() -> String {
 /// inside their own root — no Win32 API can spawn it. Honoring `$SHELL` on
 /// Windows therefore turns "user has Git for Windows installed", which is
 /// nearly all of them, into "terminals do not open".
+///
+/// This is the daemon/relay fallback and the `SpawnConfig::default` shell; the
+/// desktop app resolves the user's [`WindowsShell`] choice through
+/// [`resolve_windows_shell`] instead. Both keep PowerShell as the default.
 #[cfg(windows)]
 fn windows_shell() -> String {
-    // PATHEXT resolution lives in the `which` crate, so `pwsh` finds `pwsh.exe`
-    // and would equally find a `.cmd` shim if someone installed one.
-    for name in ["pwsh", "powershell"] {
-        if let Ok(path) = which::which(name) {
-            return path.to_string_lossy().into_owned();
+    resolve_windows_shell(WindowsShell::PowerShell, WindowsPowerShell::Auto).program
+}
+
+/// Resolve a Windows shell choice into a spawnable program + argv + env.
+///
+/// - `GitBash` / `Auto` probe for Git for Windows and fall back to PowerShell
+///   when it is absent, so the terminal always opens.
+/// - Git Bash launches interactive and NON-login (`-i`, no `-l`): the login
+///   profile ignores the `--rcfile` the shell-integration layer prepends,
+///   which would drop the OSC 133 marks. A non-login interactive shell still
+///   rebuilds the full MSYS `PATH` via `/etc/bash.bashrc`. `CHERE_INVOKING`
+///   keeps it in the pane's cwd; `MSYSTEM`/`LANG` seed the MSYS locale that
+///   the (skipped) login profile would otherwise set.
+/// - PowerShell/cmd carry no argv here; the shell-integration layer adds
+///   PowerShell's `-Command` bootstrap, and an empty argv is what lets it.
+#[cfg(windows)]
+pub fn resolve_windows_shell(shell: WindowsShell, powershell: WindowsPowerShell) -> ResolvedShell {
+    match shell {
+        WindowsShell::CommandPrompt => ResolvedShell::program(cmd_path()),
+        WindowsShell::PowerShell => ResolvedShell::program(powershell_path(powershell)),
+        WindowsShell::GitBash | WindowsShell::Auto => git_bash_shell()
+            .unwrap_or_else(|| ResolvedShell::program(powershell_path(powershell))),
+    }
+}
+
+/// A [`ResolvedShell`] for Git for Windows' bash, or `None` when it is not
+/// installed. See [`resolve_windows_shell`] for why these args/env are chosen.
+#[cfg(windows)]
+fn git_bash_shell() -> Option<ResolvedShell> {
+    let program = git_bash_path()?;
+    Some(ResolvedShell {
+        program,
+        // `-i` only; `--rcfile` (added later) is honoured only for a non-login
+        // interactive shell.
+        args: vec!["-i".to_string()],
+        env: vec![
+            // 64-bit MSYS runtime — Git for Windows' default. Without it a
+            // non-login shell can pick the wrong mount table.
+            ("MSYSTEM".to_string(), "MINGW64".to_string()),
+            // Stay in the directory the pane was spawned in rather than $HOME.
+            ("CHERE_INVOKING".to_string(), "1".to_string()),
+            // The login profile would set this; seed it so multibyte paths and
+            // output are UTF-8 rather than the C locale.
+            ("LANG".to_string(), "en_US.UTF-8".to_string()),
+        ],
+    })
+}
+
+/// Locate Git for Windows' `bash.exe`.
+///
+/// Order: `OXIMUX_GIT_BASH_PATH` override, then the standard per-machine and
+/// per-user install roots, then the install `git` on `PATH` resolves to. Only
+/// a real Git-for-Windows layout counts, so a WSL/Cygwin `bash.exe` on `PATH`
+/// is never mistaken for it.
+#[cfg(windows)]
+fn git_bash_path() -> Option<String> {
+    use std::path::{Path, PathBuf};
+
+    // 1. Operator override for a non-standard install (mirrors Claude Code's
+    //    CLAUDE_CODE_GIT_BASH_PATH).
+    if let Ok(custom) = std::env::var("OXIMUX_GIT_BASH_PATH")
+        && Path::new(&custom).is_file()
+    {
+        return Some(custom);
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // 2. Standard install roots. `ProgramW6432` is the 64-bit Program Files
+    //    even for a 32-bit process; `Programs\Git` under LOCALAPPDATA is the
+    //    per-user (winget) install.
+    for var in ["ProgramW6432", "ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"] {
+        let Ok(root) = std::env::var(var) else { continue };
+        let root = PathBuf::from(root);
+        for suffix in [
+            r"Git\bin\bash.exe",
+            r"Git\usr\bin\bash.exe",
+            r"Programs\Git\bin\bash.exe",
+            r"Programs\Git\usr\bin\bash.exe",
+        ] {
+            candidates.push(root.join(suffix));
         }
     }
-    // A sparse PATH is a real possibility for a GUI-launched process, and both
-    // remaining candidates ship at fixed locations, so fall back to those
-    // rather than to a bare name the spawn would have to resolve itself.
-    let root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
-    let windows_powershell = std::path::Path::new(&root)
-        .join(r"System32\WindowsPowerShell\v1.0\powershell.exe");
-    if windows_powershell.exists() {
-        return windows_powershell.to_string_lossy().into_owned();
+
+    // 3. Whatever install the `git` on PATH belongs to (Scoop, Chocolatey,
+    //    PortableGit). Climb the ancestors of `git.exe` and probe the two
+    //    bash locations under each — the root is a couple of levels up
+    //    (`<root>\cmd\git.exe`, `<root>\mingw64\bin\git.exe`).
+    if let Ok(git) = which::which("git") {
+        let mut dir = git.parent();
+        let mut hops = 0;
+        while let Some(d) = dir {
+            candidates.push(d.join(r"bin\bash.exe"));
+            candidates.push(d.join(r"usr\bin\bash.exe"));
+            hops += 1;
+            if hops >= 4 {
+                break;
+            }
+            dir = d.parent();
+        }
     }
+
+    candidates
+        .into_iter()
+        .find(|c| c.is_file() && is_git_for_windows_bash(c))
+        .map(|c| c.to_string_lossy().into_owned())
+}
+
+/// True when `path` is a Git-for-Windows (or PortableGit) `bash.exe`, as
+/// opposed to a WSL/Cygwin/MSYS2-standalone one. The Git layout always places
+/// bash under `...\bin\bash.exe` or `...\usr\bin\bash.exe` with `git` or
+/// `portablegit` in an ancestor directory name.
+#[cfg(windows)]
+fn is_git_for_windows_bash(path: &std::path::Path) -> bool {
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    (lower.ends_with(r"\bin\bash.exe") || lower.ends_with(r"\usr\bin\bash.exe"))
+        && (lower.contains(r"\git\") || lower.contains(r"\portablegit\"))
+}
+
+/// Resolve the `PowerShell` family to a concrete, spawnable exe.
+///
+/// `Auto`/`Pwsh` prefer PowerShell 7 (`pwsh.exe`) from its standard install
+/// roots (skipping the Microsoft Store app-execution-alias stubs that ConPTY
+/// cannot launch), then fall back to inbox Windows PowerShell, then `cmd.exe`
+/// so a terminal always opens.
+#[cfg(windows)]
+fn powershell_path(powershell: WindowsPowerShell) -> String {
+    match powershell {
+        WindowsPowerShell::Windows => windows_powershell_path(),
+        WindowsPowerShell::Auto | WindowsPowerShell::Pwsh => {
+            pwsh_path().unwrap_or_else(windows_powershell_path)
+        }
+    }
+}
+
+/// PowerShell 7+ (`pwsh.exe`), or `None` if not installed. Rejects the
+/// zero-byte Store app-execution-alias reparse points under `\WindowsApps\`,
+/// which ConPTY's `CreateProcessW(lpApplicationName)` refuses with
+/// ERROR_ACCESS_DENIED.
+#[cfg(windows)]
+fn pwsh_path() -> Option<String> {
+    use std::path::{Path, PathBuf};
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for var in ["ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"] {
+        if let Ok(root) = std::env::var(var) {
+            for major in ["7", "8", "6"] {
+                candidates.push(Path::new(&root).join("PowerShell").join(major).join("pwsh.exe"));
+            }
+        }
+    }
+    if let Ok(local) = std::env::var("LOCALAPPDATA") {
+        for major in ["7", "8", "6"] {
+            candidates.push(
+                Path::new(&local)
+                    .join(r"Microsoft\PowerShell")
+                    .join(major)
+                    .join("pwsh.exe"),
+            );
+        }
+    }
+    if let Ok(on_path) = which::which("pwsh") {
+        candidates.push(on_path);
+    }
+    candidates
+        .into_iter()
+        .find(|c| is_real_executable(c))
+        .map(|c| c.to_string_lossy().into_owned())
+}
+
+/// Inbox Windows PowerShell 5.1 at its fixed location, then a PATH lookup,
+/// then `cmd.exe` as the last resort.
+#[cfg(windows)]
+fn windows_powershell_path() -> String {
+    let root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+    let inbox = std::path::Path::new(&root).join(r"System32\WindowsPowerShell\v1.0\powershell.exe");
+    if inbox.exists() {
+        return inbox.to_string_lossy().into_owned();
+    }
+    if let Ok(on_path) = which::which("powershell") {
+        return on_path.to_string_lossy().into_owned();
+    }
+    cmd_path()
+}
+
+/// `%ComSpec%`, else `cmd.exe` at its fixed location.
+#[cfg(windows)]
+fn cmd_path() -> String {
+    let root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
     std::env::var("COMSPEC").unwrap_or_else(|_| format!(r"{root}\System32\cmd.exe"))
+}
+
+/// True for a real, launchable exe. Rejects the Microsoft Store
+/// app-execution-alias stubs (zero-byte reparse points under `\WindowsApps\`)
+/// that resolve on PATH but cannot be spawned via ConPTY.
+#[cfg(windows)]
+fn is_real_executable(path: &std::path::Path) -> bool {
+    if path.to_string_lossy().to_ascii_lowercase().contains(r"\windowsapps\") {
+        return false;
+    }
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false)
 }
 
 /// Seed a UTF-8 locale on a spawned shell when the environment supplies none.
@@ -236,6 +490,87 @@ mod tests {
         } else {
             assert!(!seeded, "nothing should seed LANG off unix");
         }
+    }
+
+    #[test]
+    fn windows_shell_choices_have_stable_toml_spellings() {
+        // These strings are what lands in `terminal.toml`; changing one
+        // silently invalidates every user's saved choice.
+        for (choice, spelling) in [
+            (WindowsShell::PowerShell, "\"powershell\""),
+            (WindowsShell::CommandPrompt, "\"cmd\""),
+            (WindowsShell::GitBash, "\"git-bash\""),
+            (WindowsShell::Auto, "\"auto\""),
+        ] {
+            let json = serde_json::to_string(&choice).expect("serialize");
+            assert_eq!(json, spelling, "{choice:?} serialized wrong");
+            let back: WindowsShell = serde_json::from_str(spelling).expect("deserialize");
+            assert_eq!(back, choice);
+        }
+        for (choice, spelling) in [
+            (WindowsPowerShell::Auto, "\"auto\""),
+            (WindowsPowerShell::Pwsh, "\"pwsh\""),
+            (WindowsPowerShell::Windows, "\"powershell\""),
+        ] {
+            let json = serde_json::to_string(&choice).expect("serialize");
+            assert_eq!(json, spelling, "{choice:?} serialized wrong");
+        }
+    }
+
+    #[test]
+    fn windows_shell_and_powershell_default_to_powershell_auto() {
+        assert_eq!(WindowsShell::default(), WindowsShell::PowerShell);
+        assert_eq!(WindowsPowerShell::default(), WindowsPowerShell::Auto);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_resolves_to_an_exe_that_exists() {
+        // The default family must always land on a spawnable program.
+        let resolved = resolve_windows_shell(WindowsShell::PowerShell, WindowsPowerShell::Auto);
+        assert!(
+            std::path::Path::new(&resolved.program).exists(),
+            "resolved PowerShell {:?} does not exist",
+            resolved.program
+        );
+        assert!(resolved.args.is_empty(), "PowerShell carries no argv here");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn git_bash_choice_resolves_and_carries_msys_env_when_installed() {
+        // Self-skipping: only asserts when Git for Windows is actually present,
+        // exactly like the NO_COLOR wiring test.
+        let resolved = resolve_windows_shell(WindowsShell::GitBash, WindowsPowerShell::Auto);
+        let name = std::path::Path::new(&resolved.program)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if name == "bash.exe" {
+            assert!(is_git_for_windows_bash(std::path::Path::new(&resolved.program)));
+            assert_eq!(resolved.args, vec!["-i".to_string()]);
+            assert!(
+                resolved.env.iter().any(|(k, _)| k == "CHERE_INVOKING"),
+                "git bash must stay in the pane cwd"
+            );
+        } else {
+            // No Git for Windows here — must have fallen back to PowerShell.
+            assert!(
+                name == "pwsh.exe" || name == "powershell.exe",
+                "git-bash fallback should be PowerShell, got {name:?}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_store_alias_stub_is_never_a_real_executable() {
+        // Any path under \WindowsApps\ is rejected outright, whether or not it
+        // exists, because ConPTY cannot spawn the alias reparse points there.
+        assert!(!is_real_executable(std::path::Path::new(
+            r"C:\Users\x\AppData\Local\Microsoft\WindowsApps\pwsh.exe"
+        )));
     }
 }
 


### PR DESCRIPTION
## What

New terminal panes on Windows can now run **Git Bash** or the **Command Prompt** instead of PowerShell, chosen in **Settings → Terminal → Default shell** (PowerShell / Command Prompt / Git Bash / Auto). A second control, **PowerShell edition**, picks Auto (pwsh 7 when present), pwsh 7, or inbox Windows PowerShell.

PowerShell stays the default, so existing installs are unchanged.

## How

- **`resolve_windows_shell`** (shell-env) turns the choice into a spawnable program + argv + env.
  - Git Bash detection: `OXIMUX_GIT_BASH_PATH` override, then the standard per-machine and per-user (winget) install roots, then whatever the `git` on `PATH` belongs to (Scoop/Choco/PortableGit). A WSL/Cygwin `bash.exe` is never mistaken for it.
  - pwsh: prefers PowerShell 7 from its install roots, rejects the zero-byte Microsoft Store app-execution-alias stubs ConPTY cannot launch, then falls back to inbox PowerShell, then `cmd.exe`, so a terminal always opens.
- **Git Bash launches interactive non-login** (`-i`, not `-l -i`): a login shell ignores the `--rcfile` the OSC-133 integration prepends, which would drop the prompt/output marks. A non-login interactive shell still rebuilds the full MSYS `PATH` via `/etc/bash.bashrc`; `MSYSTEM` / `CHERE_INVOKING` / `LANG` seed what the skipped login profile would have set.
- The resolved program + argv + env flow through the existing spawn mirror, so both in-process and relay-backed panes honour the choice. A non-empty free-form `shell` override still wins everywhere.
- Persisted in `terminal.toml` as `windows_shell` / `windows_powershell`; absent keys default to PowerShell/auto.

## Verification

- New unit tests in shell-env (enum TOML spellings, resolution, Store-alias rejection) and settings (defaults + round-trip).
- A self-skipping live end-to-end test spawns a real Git Bash pane through `PortablePtyBackend` with the real OSC-133 augmentation and asserts the expanded command output renders.
- `cargo check` + `clippy --all-targets` clean across the workspace.
- Manually confirmed in the GUI: both controls render, and a resolved Git Bash pane runs `pwd` / `git --version` / `uname -o` with the working directory preserved.

https://claude.ai/code/session_01Uq85r8pAQoou48VCHg8B2x
