### PR TITLE
feat: reliability gates, worktree provisioning, rate-limit retry, and a render-fidelity floor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,21 @@ docs/skills/*.md text eol=lf
 *.tiff binary
 *.ico binary
 *.icns binary
+
+# Compared byte-for-byte, so a checkout that rewrites their line endings is a
+# test failure rather than a formatting detail. `assert_snapshot_text` asserts
+# `expected == actual` on the raw string: the pinned file comes off disk, the
+# actual transcript comes from `serde_json` and is always LF, so a CRLF worktree
+# fails every pinned transcript at once. It fails *confusingly*, too — the diff
+# reporter compares with `str::lines()`, which strips `\r`, so every line matches
+# and the first difference is reported one line past the end of both.
+#
+# The fixtures are pinned for a stronger reason than the snapshots: they are
+# captured provider wire bytes. A checkout must not rewrite them, or the thing
+# under test is no longer what the provider actually sent.
+#
+# Same reasoning as `docs/skills/*.md` above, and found the same way — green on
+# macOS and Linux, three failures on the Windows runner.
+*.transcript.json text eol=lf
+**/testdata/*.jsonl text eol=lf
+**/testdata/*.sql text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8393,6 +8393,7 @@ name = "oximux-worktree-ops"
 version = "0.1.19"
 dependencies = [
  "async-trait",
+ "ignore",
  "oximux-core",
  "oximux-git",
  "oximux-no-window",

--- a/apps/cli/src/render.rs
+++ b/apps/cli/src/render.rs
@@ -219,6 +219,13 @@ pub fn render_event(event: &ThreadEvent) -> Option<String> {
         ThreadEvent::Diagnostic(text) => Some(format!("! {}", one_line(text))),
         ThreadEvent::Error(text) => Some(format!("✗ {}", one_line(text))),
         ThreadEvent::Rewound { ordinal } => Some(format!("— rewound to turn {ordinal} —")),
+        // Only a refusal is worth a line. `allowed` and `allowed_warning`
+        // readings arrive every time a percentage ticks over, and printing them
+        // would bury the transcript in meter noise.
+        ThreadEvent::RateLimitUpdated(info) if info.is_rejected() => Some(match &info.limit_type {
+            Some(kind) => format!("· rate limited ({kind})"),
+            None => "· rate limited".into(),
+        }),
         // Streaming deltas: the finalized event carries the authoritative text.
         ThreadEvent::AssistantTextDelta(_)
         | ThreadEvent::ThinkingDelta(_)
@@ -239,6 +246,10 @@ pub fn render_event(event: &ThreadEvent) -> Option<String> {
         | ThreadEvent::AuthOutcome { .. }
         | ThreadEvent::ModeChanged { .. }
         | ThreadEvent::ControlsUpdated
+        | ThreadEvent::RateLimitUpdated(_)
+        // Typed detail for the `TurnEnded` right behind it, which prints the
+        // message a person reads.
+        | ThreadEvent::TurnFailed { .. }
         | ThreadEvent::TitleUpdated { .. } => None,
     }
 }

--- a/apps/desktop/src/app_settings/agent_retry_settings.rs
+++ b/apps/desktop/src/app_settings/agent_retry_settings.rs
@@ -1,0 +1,49 @@
+//! App-side loader + persistence for [`AgentRetrySettings`].
+//!
+//! Reads `agent_retry.toml` from the app data dir on boot (default if absent)
+//! and installs it as a GPUI global. No file watcher: like the auto-update
+//! settings beside it, these two values are only ever written by the settings
+//! pane, which updates the global itself.
+//!
+//! A parse failure falls back to the shipped default — retries on, capped at a
+//! day. Falling back to *off* would be the quieter choice and the wrong one: a
+//! corrupt settings file would silently remove a feature the user is relying on
+//! to survive a rate limit, and nothing would say so.
+
+use std::path::PathBuf;
+
+use gpui::App;
+use oximux_settings::agent_retry::AgentRetrySettings;
+
+fn settings_path() -> Option<PathBuf> {
+    crate::app_paths::data_dir().map(|d| d.join(AgentRetrySettings::FILE_NAME))
+}
+
+fn load() -> AgentRetrySettings {
+    let Some(path) = settings_path() else {
+        return AgentRetrySettings::shipped();
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(text) => AgentRetrySettings::from_toml_str(&text).unwrap_or_else(|err| {
+            tracing::warn!(?path, %err, "agent_retry.toml parse failed; using defaults");
+            AgentRetrySettings::shipped()
+        }),
+        Err(_) => AgentRetrySettings::shipped(),
+    }
+}
+
+/// Persist `settings` and swap the global, so the caller's next read sees it.
+pub fn save(settings: &AgentRetrySettings, cx: &mut App) -> std::io::Result<()> {
+    cx.set_global(*settings);
+    let path = settings_path()
+        .ok_or_else(|| std::io::Error::other("no app data dir for agent_retry.toml"))?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    std::fs::write(&path, settings.to_toml_string())
+}
+
+/// Load settings and install the global. Call once from the app's `run` closure.
+pub fn install(cx: &mut App) {
+    cx.set_global(load());
+}

--- a/apps/desktop/src/app_settings/mod.rs
+++ b/apps/desktop/src/app_settings/mod.rs
@@ -8,6 +8,7 @@
 //! paths keep resolving.
 
 pub mod agent_launch_settings;
+pub mod agent_retry_settings;
 pub mod appearance_settings;
 pub mod commit_message_ai_settings;
 pub mod auto_update_settings;

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -46,7 +46,8 @@ pub use agent_glue::{
 pub use shell::agent_chat::clear_stale_screen_control_grants;
 #[doc(inline)]
 pub use app_settings::{
-    agent_launch_settings, appearance_settings, auto_update_settings, commit_message_ai_settings,
+    agent_launch_settings, agent_retry_settings, appearance_settings, auto_update_settings,
+    commit_message_ai_settings,
     computer_use_settings, dictation_settings, font_settings, keybindings_settings, motion_settings,
     port_label_settings, scm_layout_settings, terminal_settings,
 };

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -368,6 +368,7 @@ fn main() {
         // The answer is only acted on where there is an updater to have
         // performed the upgrade; the settings install itself still has to run.
         #[cfg_attr(not(any(target_os = "macos", windows)), allow(unused_variables))]
+        oximux_app::agent_retry_settings::install(cx);
         let upgraded_this_boot = oximux_app::auto_update_settings::install(cx);
         // The indicator that appears while an agent can drive the screen — a
         // menu-bar item on macOS, a notification-area icon on Windows. Watches

--- a/apps/desktop/src/project_panes_factory.rs
+++ b/apps/desktop/src/project_panes_factory.rs
@@ -222,6 +222,22 @@ fn restore_chat_thinking_level(
         .unwrap_or_default()
 }
 
+/// The retry a restored chat had armed when it was last saved, so a turn held
+/// for a provider window resumes at its reset across a quit. `None` when the
+/// blob predates the field, the session isn't found, or nothing was armed.
+///
+/// Whether the retry is actually re-armed is decided by
+/// [`AgentChatView::restore_pending_retry`], which re-reads the current settings
+/// and drops a wake time the app slept through — this only carries the record.
+fn restore_chat_pending_retry(
+    snap: &PersistedTabs,
+    session_id: Option<&str>,
+) -> Option<crate::persisted_chat::PersistedRetry> {
+    session_id
+        .and_then(|sid| snap.chat_transcripts.iter().find(|t| t.session_id == sid))
+        .and_then(|t| t.pending_retry.clone())
+}
+
 /// The persisted backend posture for a restored chat, so a reopened session
 /// resumes under the same choice rather than a default. Empty when the blob
 /// predates the fields, the session isn't found, or the backend has no posture.
@@ -440,11 +456,13 @@ pub(crate) fn build_project_panes(
                             );
                             let resume_id = restore_chat_resume_id(&snap, session_id.as_deref());
                             let posture = restore_chat_posture(&snap, session_id.as_deref());
+                            let pending_retry =
+                                restore_chat_pending_retry(&snap, session_id.as_deref());
                             group.update(cx, |g, cx| {
                                 g.open_agent_chat_tab_restored(
                                     chat_cwd, model, backend, resume_id, entries, slash_commands,
-                                    session_meta, thinking_level, posture, draft, queued, window,
-                                    cx,
+                                    session_meta, thinking_level, posture, pending_retry, draft,
+                                    queued, window, cx,
                                 );
                             });
                         }
@@ -626,9 +644,12 @@ fn restore_multi_group(
                             );
                             let resume_id = restore_chat_resume_id(&snap, session_id.as_deref());
                             let posture = restore_chat_posture(&snap, session_id.as_deref());
+                            let pending_retry =
+                                restore_chat_pending_retry(&snap, session_id.as_deref());
                             p.open_agent_chat_in_group_restore(
                                 group_id, chat_cwd, model, backend, resume_id, entries, slash_commands,
-                                session_meta, thinking_level, posture, draft, queued, window, cx,
+                                session_meta, thinking_level, posture, pending_retry, draft, queued,
+                                window, cx,
                             );
                         }
                         p.place_restored_last_tab(Some(group_id), meta, cx);
@@ -2111,6 +2132,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         let snap = PersistedTabs {
@@ -2203,6 +2225,7 @@ mod tests {
                 pi_posture: None,
                 omp_posture: None,
                 claude_fast_mode: None,
+                pending_retry: None,
                 choices: Default::default(),
             }],
             ..PersistedTabs::default()
@@ -2251,6 +2274,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         let snap =

--- a/apps/desktop/src/remote_control/session_catalog.rs
+++ b/apps/desktop/src/remote_control/session_catalog.rs
@@ -436,6 +436,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices,
         }
     }

--- a/apps/desktop/src/session_restore/persisted_chat.rs
+++ b/apps/desktop/src/session_restore/persisted_chat.rs
@@ -166,6 +166,31 @@ pub struct PersistedChatTranscript {
     /// that offers no choices.
     #[serde(default)]
     pub choices: PersistedChoices,
+    /// A retry this chat had armed when it was last saved, so a turn held for a
+    /// five-hour or seven-day window resumes at its reset even if the app was
+    /// quit in between — which is the ordinary case for a window that long.
+    ///
+    /// Persisting it also carries the attempt count across the restart. Without
+    /// that the cap would silently reset on every relaunch, and a chat that
+    /// relaunched between attempts could exceed the four the policy allows.
+    ///
+    /// `#[serde(default)]` (→ `None`) keeps every older blob loadable; those
+    /// restore with nothing armed, which is the pre-existing behaviour.
+    #[serde(default)]
+    pub pending_retry: Option<PersistedRetry>,
+}
+
+/// A retry armed at save time. Deliberately the *decision* (when, why, how many
+/// attempts are spent) and not the timer: the timer is a `gpui::Task` that dies
+/// with the process, and is rebuilt from these three fields on restore.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PersistedRetry {
+    /// Unix ms the retry was scheduled to fire at.
+    pub wake_at_ms: i64,
+    /// The short human reason shown on the card ("Usage limit reached").
+    pub reason: String,
+    /// Automatic attempts already spent on the held turn.
+    pub attempt: u32,
 }
 
 /// Write one transcript blob. A serialize failure is logged and skipped rather
@@ -236,6 +261,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: Some(true),
+            pending_retry: None,
             choices: Default::default(),
         };
         save_chat_transcript(&repo, &t);
@@ -267,6 +293,7 @@ mod tests {
             pi_posture: Some(PiPosture { tools: TOOLS_READ_ONLY.into(), context_files: false }),
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         save_chat_transcript(&repo, &t);
@@ -301,6 +328,7 @@ mod tests {
             pi_posture: None,
             omp_posture: Some(OmpPosture::AlwaysAsk),
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         save_chat_transcript(&repo, &t);
@@ -326,6 +354,80 @@ mod tests {
         assert_eq!(loaded.provider, Transport::StreamJson);
     }
 
+    /// Every blob already on disk predates `pending_retry`, so the field must be
+    /// defaultable or a restore would drop the whole transcript rather than one
+    /// unknown key. Checked against the shapes that actually exist: the oldest
+    /// (three keys, from before providers were recorded) and the newest.
+    #[test]
+    fn blobs_predating_pending_retry_still_load() {
+        let repo = repo();
+        let oldest = r#"{"session_id":"old","model":"sonnet","entries":[]}"#;
+        repo.set(&chat_settings_key("old"), oldest).expect("seed");
+        let loaded = load_chat_transcript(&repo, "old").expect("oldest shape must still load");
+        assert_eq!(loaded.pending_retry, None, "absent means nothing armed, not a parse error");
+
+        // The current shape with exactly this one key deleted — derived from the
+        // struct rather than hand-written, so it cannot drift out of date and
+        // start passing for the wrong reason.
+        let full = serde_json::to_value(transcript("new")).expect("serialize");
+        let mut obj = full.as_object().expect("object").clone();
+        assert!(obj.remove("pending_retry").is_some(), "the field must be there to remove");
+        repo.set(&chat_settings_key("new"), &serde_json::Value::Object(obj).to_string())
+            .expect("seed");
+        let loaded = load_chat_transcript(&repo, "new").expect("current shape minus the key");
+        assert_eq!(loaded.pending_retry, None);
+    }
+
+    /// A transcript with every field at its default, for tests that need a
+    /// current-shaped blob without pinning one by hand.
+    fn transcript(session_id: &str) -> PersistedChatTranscript {
+        PersistedChatTranscript {
+            session_id: session_id.into(),
+            model: None,
+            entries: vec![ThreadEntry::User {
+                text: "hi".into(),
+                images: vec![],
+                checkpoint: None,
+            }],
+            slash_commands: vec![],
+            session_meta: Default::default(),
+            thinking_level: Default::default(),
+            provider: Transport::StreamJson,
+            acp_command: None,
+            acp_args: vec![],
+            adapter_id: None,
+            launch_profile: None,
+            codex_posture: None,
+            pi_posture: None,
+            omp_posture: None,
+            claude_fast_mode: None,
+            pending_retry: None,
+            choices: Default::default(),
+        }
+    }
+
+    /// And a blob that *does* carry one round-trips all three fields. The
+    /// attempt count is the one worth asserting: losing it silently resets the
+    /// cap on every launch, which no single session's behaviour would reveal.
+    #[test]
+    fn an_armed_retry_round_trips_through_the_blob() {
+        let repo = repo();
+        let mut t = transcript("held");
+        t.pending_retry = Some(PersistedRetry {
+            wake_at_ms: 1_788_462_000_000,
+            reason: "Usage limit reached".into(),
+            attempt: 3,
+        });
+        save_chat_transcript(&repo, &t);
+        let loaded = load_chat_transcript(&repo, "held").expect("blob loads");
+        assert_eq!(loaded.pending_retry, t.pending_retry);
+
+        t.pending_retry = None;
+        save_chat_transcript(&repo, &t);
+        let loaded = load_chat_transcript(&repo, "held").expect("blob loads");
+        assert_eq!(loaded.pending_retry, None, "clearing must not leave a stale retry behind");
+    }
+
     #[test]
     fn round_trips_a_transcript() {
         let repo = repo();
@@ -348,6 +450,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         save_chat_transcript(&repo, &t);
@@ -385,6 +488,7 @@ mod tests {
             pi_posture: None,
             omp_posture: None,
             claude_fast_mode: None,
+            pending_retry: None,
             choices: Default::default(),
         };
         save_chat_transcript(&repo, &t);

--- a/apps/desktop/src/shell/agent_chat/assemble.rs
+++ b/apps/desktop/src/shell/agent_chat/assemble.rs
@@ -307,6 +307,7 @@ impl AgentChatView {
             backend,
             composer,
             session_detail_open: false,
+            retry: super::retry::ChatRetry::default(),
             last_notify: std::time::Instant::now(),
             flush_scheduled: false,
             focus_handle: focus.clone(),

--- a/apps/desktop/src/shell/agent_chat/mod.rs
+++ b/apps/desktop/src/shell/agent_chat/mod.rs
@@ -47,6 +47,8 @@ mod jump_menu;
 mod login_card;
 mod message_rail;
 mod pending_edit;
+mod retry;
+mod retry_card;
 mod plan_approval_card;
 mod plan_panel;
 mod publish_throttle;
@@ -652,6 +654,8 @@ pub struct AgentChatView {
     /// respawns with `--resume`. Distinct from `disconnected` (an unexpected
     /// crash, which stays unavailable), so an intentional Stop shows no error.
     interrupted: bool,
+    /// Automatic re-send of a turn that failed on a provider limit.
+    retry: retry::ChatRetry,
     /// A restored chat that has not spawned its subprocess yet. Restoring a
     /// layout with many chat tabs must not launch one agent CLI per tab — a
     /// resumed CLI re-reads its whole session file, so a boot with several
@@ -1950,6 +1954,10 @@ impl AgentChatView {
         if text.is_empty() && images.is_empty() {
             return;
         }
+        // The user is driving again: drop any armed retry and reset the attempt
+        // count. The cap is per turn, so a conversation that hits a limit once
+        // an hour must not eventually lock itself out.
+        self.retry.clear();
         // `/clear` is a UI command (blank the transcript + free context), not
         // agent input — reset in place rather than transmitting the literal text
         // to the subprocess (matching the CLI's own TUI). `/compact` stays a
@@ -2110,100 +2118,6 @@ impl AgentChatView {
                 });
             }
         }));
-    }
-
-    /// Re-send the last user prompt after a turn ended in error (or the child
-    /// crashed). Reachable only from the idle error / disconnected tail cards —
-    /// gated on `!turn_active` so it never double-sends mid-turn. A crashed or
-    /// stopped child is respawned (via `--resume`) before the prompt is
-    /// retransmitted; the prompt bubble is already the tail entry, so it is NOT
-    /// pushed again.
-    fn retry_last_turn(&mut self, cx: &mut Context<Self>) {
-        if self.thread.turn_active {
-            return; // a turn is already streaming — nothing to retry
-        }
-        // A crashed / stopped child can't receive input — bring it back first.
-        if self.disconnected || self.interrupted {
-            self.respawn(cx);
-            if self.disconnected {
-                // Respawn failed (e.g. the resume file is gone); `respawn` left
-                // its own error text — keep the card rather than silently no-op.
-                cx.notify();
-                return;
-            }
-        }
-        let last_user_idx = self
-            .thread
-            .entries
-            .iter()
-            .rposition(|e| matches!(e, ThreadEntry::User { .. }));
-        let last_user = last_user_idx.and_then(|i| match &self.thread.entries[i] {
-            ThreadEntry::User { text, images, .. } => Some((i, text.clone(), images.clone())),
-            _ => None,
-        });
-        match last_user {
-            Some((idx, text, images)) => {
-                let sent = match &self.connection {
-                    Some(conn) => match conn.send_user_message_with_images(&text, &images) {
-                        Ok(()) => {
-                            self.thread.last_error = None;
-                            self.thread.turn_active = true;
-                            true
-                        }
-                        Err(e) => {
-                            self.thread.last_error = Some(format!("Send failed: {e}"));
-                            false
-                        }
-                    },
-                    None => false,
-                };
-                // Re-anchor the pre-turn checkpoint to the retried turn (as a
-                // fresh send would), so the "restore files" rewind affordance
-                // keeps tracking repo changes for it.
-                if sent {
-                    self.take_checkpoint_for(idx, cx);
-                }
-            }
-            None => {
-                // No prompt to replay (the connection failed before any turn) —
-                // the respawn above already restored a working, error-free idle
-                // state, so just drop the card.
-                self.thread.last_error = None;
-            }
-        }
-        self.follow_bottom();
-        self.sync_composer(cx);
-        cx.notify();
-    }
-
-    /// A small "Retry" control for the error / disconnected tail cards. Its
-    /// click re-sends the last user prompt (respawning the child first if it
-    /// crashed or was stopped).
-    fn retry_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = self.theme;
-        let typo = &self.typography;
-        div()
-            .id("chat-retry-turn")
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(5.0))
-            .px(px(10.0))
-            .py(px(4.0))
-            .rounded(px(self.density.r_xs))
-            .cursor_pointer()
-            .bg(theme.status_error.opacity(0.15))
-            .text_size(px(typo.t_body_sm))
-            .text_color(theme.status_error)
-            .hover(|s| s.bg(theme.status_error.opacity(0.28)))
-            .child(
-                Icon::default()
-                    .path("icons/refresh-cw.svg")
-                    .size(px(13.0))
-                    .text_color(theme.status_error),
-            )
-            .child(SharedString::from("Retry"))
-            .on_click(cx.listener(|this, _e, _window, cx| this.retry_last_turn(cx)))
     }
 
     /// True when the latest turn looks like an auth failure the user can fix by
@@ -3178,6 +3092,7 @@ impl AgentChatView {
             feature_values: HashMap::new(),
             disconnected: false,
             interrupted: false,
+            retry: retry::ChatRetry::default(),
             dormant: false,
             publish_throttle: publish_throttle::PublishThrottle::new(),
             last_saved_revision: std::cell::Cell::new(u64::MAX),
@@ -3628,7 +3543,19 @@ impl AgentChatView {
         // after an intentional Stop (`interrupted`) or a dead process
         // (`disconnected`), where there is nothing live to send to; those leave
         // the queued chips in place, to drain on the next send or be cancelled.
-        if was_active && !self.thread.turn_active && !self.interrupted && !self.disconnected {
+        // A turn that just ended in error may be one a provider limit closed
+        // on. Arm before the queued-message flush below so a retry suppresses
+        // it — releasing the user's next message into an account that is
+        // refusing requests would fail it too, and burn nothing but goodwill.
+        if was_active && !self.thread.turn_active && self.thread.last_error.is_some() {
+            self.arm_retry_if_limited(cx);
+        }
+        if was_active
+            && !self.thread.turn_active
+            && !self.interrupted
+            && !self.disconnected
+            && !self.retry.is_armed()
+        {
             // A turn just completed — decide whether it changed repo state, so
             // the rewind "restore files" affordance only lights up when there's
             // something to restore. Background compare against the pre-turn sha.

--- a/apps/desktop/src/shell/agent_chat/retry.rs
+++ b/apps/desktop/src/shell/agent_chat/retry.rs
@@ -1,0 +1,319 @@
+//! Automatic re-send of a turn that failed on a provider limit.
+//!
+//! The policy — what counts as retryable, how long to wait, how many times —
+//! lives in `oximux_agents::retry` and is pure. This module holds only the
+//! per-chat state and the timer, so the decision stays testable without a view.
+//!
+//! The re-send itself reuses `retry_last_turn`, the same path the manual Retry
+//! button drives: it respawns a stopped child, resends the last user entry
+//! verbatim, and re-anchors the turn checkpoint. An automatic retry that sent
+//! by some other route would drift from the manual one, and the two would
+//! disagree about exactly the edge cases that are hard to test.
+
+use gpui::Task;
+use oximux_agents::retry::{RetrySettings as AgentRetryPolicy, classify_failure};
+use oximux_settings::agent_retry::AgentRetrySettings;
+
+// The sibling modules (`transcript`, `assemble`, …) all glob the parent for the
+// shared gpui + view vocabulary; matching them keeps this file's imports from
+// drifting out of step as that vocabulary moves.
+use super::*;
+
+/// A retry the app has committed to, holding the timer that will fire it.
+///
+/// Dropping this cancels the retry: the `Task` is aborted on drop, so Cancel,
+/// a new user send, and closing the tab all need no extra teardown.
+pub(super) struct PendingRetry {
+    /// Unix ms the retry fires at — rendered as a countdown.
+    pub wake_at_ms: i64,
+    /// Short human reason ("Usage limit reached", "Provider overloaded").
+    pub reason: String,
+    /// Cancels on drop. Never read.
+    pub _task: Task<()>,
+}
+
+/// Per-chat retry state.
+#[derive(Default)]
+pub(super) struct ChatRetry {
+    /// Automatic attempts already spent on the turn currently being retried.
+    ///
+    /// Reset when the user sends something new or a turn succeeds — the cap is
+    /// per turn, not per session, so a long conversation that hits a limit once
+    /// an hour is not eventually locked out.
+    pub attempt: u32,
+    /// The armed retry, if any.
+    pub pending: Option<PendingRetry>,
+}
+
+impl ChatRetry {
+    /// Forget any armed retry and reset the attempt count. Called when the user
+    /// takes over — a new send, or an explicit Cancel.
+    pub fn clear(&mut self) {
+        self.pending = None;
+        self.attempt = 0;
+    }
+
+    /// Whether a retry is currently armed.
+    pub fn is_armed(&self) -> bool {
+        self.pending.is_some()
+    }
+}
+
+/// The one-line reason shown on the card for a class.
+pub(super) fn reason_for(class: oximux_agents::retry::RetryClass) -> String {
+    use oximux_agents::retry::RetryClass;
+    match class {
+        RetryClass::Window { .. } => "Usage limit reached".into(),
+        RetryClass::Overload => "Provider overloaded".into(),
+        // Never armed, so never rendered; kept total rather than `unreachable!`
+        // so a future class cannot panic the transcript.
+        RetryClass::Spend | RetryClass::Other => "Turn failed".into(),
+    }
+}
+
+impl AgentChatView {
+    /// Decide whether the turn that just failed should be re-sent
+    /// automatically, and arm a timer if so.
+    ///
+    /// Everything about *whether* and *when* is delegated to the pure policy in
+    /// `oximux_agents::retry`; this method only supplies the inputs and holds
+    /// the timer. Three conditions are checked here rather than there because
+    /// they are properties of this view, not of the failure: an interrupted
+    /// turn is one the user stopped, a disconnected child has nothing to send
+    /// to, and a disabled setting means never.
+    pub(super) fn arm_retry_if_limited(&mut self, cx: &mut Context<Self>) {
+        if self.interrupted || self.disconnected {
+            return;
+        }
+        let settings = cx
+            .try_global::<AgentRetrySettings>()
+            .copied()
+            .unwrap_or_else(AgentRetrySettings::shipped);
+        if !settings.enabled {
+            return;
+        }
+        let class = classify_failure(
+            self.thread.last_rate_limit.as_ref(),
+            self.thread.last_turn_failure.clone(),
+        );
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let policy =
+            AgentRetryPolicy { max_automatic_wait: settings.max_automatic_wait.duration() };
+        // The seed must differ per *thread*, not per call: threads on one
+        // account see the same reset time, and a shared seed would give them
+        // all the same jitter — the storm the jitter exists to prevent. The
+        // session id is the stable per-thread value; the clock breaks ties
+        // between two chats that somehow hash alike.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&self.remote_session_id, &mut hasher);
+        std::hash::Hash::hash(&now_ms, &mut hasher);
+        let seed = std::hash::Hasher::finish(&hasher);
+        let Some(wake_at_ms) =
+            oximux_agents::retry::schedule(class, self.retry.attempt, now_ms, &policy, seed)
+        else {
+            return;
+        };
+        // Clearing the error text is what swaps the error card for the queued
+        // card: the transcript renders whichever is set.
+        self.thread.last_error = None;
+        let task = cx.spawn(async move |this, cx| {
+            loop {
+                let remaining = this
+                    .update(cx, |view, _| {
+                        view.retry.pending.as_ref().map(|p| p.wake_at_ms)
+                    })
+                    .ok()
+                    .flatten()
+                    .map(|wake| wake - chrono::Utc::now().timestamp_millis());
+                let Some(remaining) = remaining else { return };
+                if remaining <= 0 {
+                    break;
+                }
+                // Repaint cadence, not polling: the card shows a countdown, and
+                // an idle chat repaints for no other reason. Coarse while the
+                // wait is long (the card reads "3h 10m"), per-second once it is
+                // short enough for the seconds to be the thing being read.
+                let step = if remaining <= 60_000 { 1_000 } else { 30_000 };
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(step.min(remaining) as u64))
+                    .await;
+                if this.update(cx, |_, cx| cx.notify()).is_err() {
+                    return;
+                }
+            }
+            let _ = this.update(cx, |view, cx| {
+                // Attempt is counted at fire time, not at arm time, so a retry
+                // the user cancels costs nothing.
+                view.retry.pending = None;
+                view.retry.attempt += 1;
+                view.retry_last_turn(cx);
+            });
+        });
+        self.retry.pending = Some(PendingRetry {
+            wake_at_ms,
+            reason: reason_for(class),
+            _task: task,
+        });
+        cx.notify();
+    }
+
+    /// Fire an armed retry immediately (the card's "Send now").
+    pub(super) fn send_retry_now(&mut self, cx: &mut Context<Self>) {
+        if self.retry.pending.take().is_none() {
+            return;
+        }
+        self.retry.attempt += 1;
+        self.retry_last_turn(cx);
+    }
+
+    /// Drop an armed retry (the card's "Cancel").
+    ///
+    /// Restores the error the retry replaced, so cancelling leaves the user
+    /// looking at why the turn failed rather than at a blank tail.
+    pub(super) fn cancel_retry(&mut self, cx: &mut Context<Self>) {
+        let Some(pending) = self.retry.pending.take() else { return };
+        self.thread.last_error = Some(format!("{} — retry cancelled.", pending.reason));
+        self.retry.attempt = 0;
+        cx.notify();
+    }
+
+    /// "Send now" on the queued-retry card — fire the held turn immediately
+    /// instead of waiting out the countdown.
+    pub(super) fn retry_send_now_button(&self, cx: &mut Context<Self>) -> AnyElement {
+        let (theme, typo) = (self.theme, &self.typography);
+        div()
+            .id("chat-retry-send-now")
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(5.0))
+            .px(px(10.0))
+            .py(px(4.0))
+            .rounded(px(self.density.r_xs))
+            .cursor_pointer()
+            .bg(theme.status_warning.opacity(0.18))
+            .text_size(px(typo.t_body_sm))
+            .text_color(theme.status_warning)
+            .hover(|s| s.bg(theme.status_warning.opacity(0.3)))
+            .child(SharedString::from("Send now"))
+            .on_click(cx.listener(|this, _e, _window, cx| this.send_retry_now(cx)))
+            .into_any_element()
+    }
+
+    /// "Cancel" on the queued-retry card — drop the held turn and show the
+    /// failure it came from.
+    pub(super) fn retry_cancel_button(&self, cx: &mut Context<Self>) -> AnyElement {
+        let (theme, typo) = (self.theme, &self.typography);
+        div()
+            .id("chat-retry-cancel")
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(5.0))
+            .px(px(10.0))
+            .py(px(4.0))
+            .rounded(px(self.density.r_xs))
+            .cursor_pointer()
+            .text_size(px(typo.t_body_sm))
+            .text_color(theme.fg_muted)
+            .hover(|s| s.bg(theme.bg_panel_alt))
+            .child(SharedString::from("Cancel"))
+            .on_click(cx.listener(|this, _e, _window, cx| this.cancel_retry(cx)))
+            .into_any_element()
+    }
+
+    /// Re-send the last user prompt after a turn ended in error (or the child
+    /// crashed). Reachable only from the idle error / disconnected tail cards —
+    /// gated on `!turn_active` so it never double-sends mid-turn. A crashed or
+    /// stopped child is respawned (via `--resume`) before the prompt is
+    /// retransmitted; the prompt bubble is already the tail entry, so it is NOT
+    /// pushed again.
+    pub(super) fn retry_last_turn(&mut self, cx: &mut Context<Self>) {
+        if self.thread.turn_active {
+            return; // a turn is already streaming — nothing to retry
+        }
+        // A crashed / stopped child can't receive input — bring it back first.
+        if self.disconnected || self.interrupted {
+            self.respawn(cx);
+            if self.disconnected {
+                // Respawn failed (e.g. the resume file is gone); `respawn` left
+                // its own error text — keep the card rather than silently no-op.
+                cx.notify();
+                return;
+            }
+        }
+        let last_user_idx = self
+            .thread
+            .entries
+            .iter()
+            .rposition(|e| matches!(e, ThreadEntry::User { .. }));
+        let last_user = last_user_idx.and_then(|i| match &self.thread.entries[i] {
+            ThreadEntry::User { text, images, .. } => Some((i, text.clone(), images.clone())),
+            _ => None,
+        });
+        match last_user {
+            Some((idx, text, images)) => {
+                let sent = match &self.connection {
+                    Some(conn) => match conn.send_user_message_with_images(&text, &images) {
+                        Ok(()) => {
+                            self.thread.last_error = None;
+                            self.thread.turn_active = true;
+                            true
+                        }
+                        Err(e) => {
+                            self.thread.last_error = Some(format!("Send failed: {e}"));
+                            false
+                        }
+                    },
+                    None => false,
+                };
+                // Re-anchor the pre-turn checkpoint to the retried turn (as a
+                // fresh send would), so the "restore files" rewind affordance
+                // keeps tracking repo changes for it.
+                if sent {
+                    self.take_checkpoint_for(idx, cx);
+                }
+            }
+            None => {
+                // No prompt to replay (the connection failed before any turn) —
+                // the respawn above already restored a working, error-free idle
+                // state, so just drop the card.
+                self.thread.last_error = None;
+            }
+        }
+        self.follow_bottom();
+        self.sync_composer(cx);
+        cx.notify();
+    }
+
+    /// A small "Retry" control for the error / disconnected tail cards. Its
+    /// click re-sends the last user prompt (respawning the child first if it
+    /// crashed or was stopped).
+    pub(super) fn retry_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = self.theme;
+        let typo = &self.typography;
+        div()
+            .id("chat-retry-turn")
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(5.0))
+            .px(px(10.0))
+            .py(px(4.0))
+            .rounded(px(self.density.r_xs))
+            .cursor_pointer()
+            .bg(theme.status_error.opacity(0.15))
+            .text_size(px(typo.t_body_sm))
+            .text_color(theme.status_error)
+            .hover(|s| s.bg(theme.status_error.opacity(0.28)))
+            .child(
+                Icon::default()
+                    .path("icons/refresh-cw.svg")
+                    .size(px(13.0))
+                    .text_color(theme.status_error),
+            )
+            .child(SharedString::from("Retry"))
+            .on_click(cx.listener(|this, _e, _window, cx| this.retry_last_turn(cx)))
+    }
+
+}

--- a/apps/desktop/src/shell/agent_chat/retry.rs
+++ b/apps/desktop/src/shell/agent_chat/retry.rs
@@ -14,10 +14,21 @@ use gpui::Task;
 use oximux_agents::retry::{RetrySettings as AgentRetryPolicy, classify_failure};
 use oximux_settings::agent_retry::AgentRetrySettings;
 
+use crate::persisted_chat::PersistedRetry;
+
 // The sibling modules (`transcript`, `assemble`, …) all glob the parent for the
 // shared gpui + view vocabulary; matching them keeps this file's imports from
 // drifting out of step as that vocabulary moves.
 use super::*;
+
+/// How far past its wake time a restored retry may be and still fire.
+///
+/// Sized for "quit the laptop lid, reopened it a few minutes later", not for
+/// "came back the next morning". A retry whose reset passed while the app was
+/// closed for longer than this is dropped: the turn is still there and the
+/// manual Retry button still works, but nothing sends on the user's behalf for
+/// a limit that expired without them.
+const RESTORE_GRACE_MS: i64 = 5 * 60 * 1000;
 
 /// A retry the app has committed to, holding the timer that will fire it.
 ///
@@ -56,6 +67,16 @@ impl ChatRetry {
     /// Whether a retry is currently armed.
     pub fn is_armed(&self) -> bool {
         self.pending.is_some()
+    }
+
+    /// The armed retry as the three durable fields the transcript blob keeps.
+    /// `None` when nothing is armed — the timer itself is never persisted.
+    pub fn persisted(&self) -> Option<PersistedRetry> {
+        self.pending.as_ref().map(|p| PersistedRetry {
+            wake_at_ms: p.wake_at_ms,
+            reason: p.reason.clone(),
+            attempt: self.attempt,
+        })
     }
 }
 
@@ -116,6 +137,16 @@ impl AgentChatView {
         // Clearing the error text is what swaps the error card for the queued
         // card: the transcript renders whichever is set.
         self.thread.last_error = None;
+        self.hold_turn_until(wake_at_ms, reason_for(class), cx);
+    }
+
+    /// Arm the countdown that fires `retry_last_turn` at `wake_at_ms`.
+    ///
+    /// Shared by the live arming path and by restore, so a retry rebuilt from a
+    /// blob counts down, repaints and fires by exactly the same code as one
+    /// armed a moment ago — the two cannot drift into disagreeing about the
+    /// edge cases (a wake time already past, a view closed mid-wait).
+    fn hold_turn_until(&mut self, wake_at_ms: i64, reason: String, cx: &mut Context<Self>) {
         let task = cx.spawn(async move |this, cx| {
             loop {
                 let remaining = this
@@ -146,15 +177,66 @@ impl AgentChatView {
                 // the user cancels costs nothing.
                 view.retry.pending = None;
                 view.retry.attempt += 1;
+                view.mark_retry_dirty();
                 view.retry_last_turn(cx);
             });
         });
-        self.retry.pending = Some(PendingRetry {
-            wake_at_ms,
-            reason: reason_for(class),
-            _task: task,
-        });
+        self.retry.pending = Some(PendingRetry { wake_at_ms, reason, _task: task });
+        self.mark_retry_dirty();
         cx.notify();
+    }
+
+    /// Flag the blob as out of date because the *armed retry* changed.
+    ///
+    /// Needed because the retry lives on the view, not in `ChatThread`, so it
+    /// does not move the thread's revision counter — and the save path skips a
+    /// chat whose revision has not moved. Without this an armed retry would be
+    /// dropped by the very save that was supposed to carry it across a restart.
+    fn mark_retry_dirty(&self) {
+        self.meta_dirty.set(true);
+    }
+
+    /// Rebuild an armed retry from a restored transcript blob.
+    ///
+    /// Three things can refuse the rebuild, and each is a case where firing
+    /// would be wrong rather than merely late:
+    ///
+    /// * auto-retry has since been switched off — the setting is read now, not
+    ///   at the time the retry was armed;
+    /// * the wake time is further past than [`RESTORE_GRACE_MS`] — the app was
+    ///   closed across the whole window, and re-sending a turn the user last
+    ///   saw hours or days ago is a surprise, not a resumption;
+    /// * the remaining wait exceeds the current `max_automatic_wait` — the user
+    ///   has since shortened how long OxiMux may hold a turn.
+    ///
+    /// The attempt count is restored with it, so the cap of four counts the
+    /// attempts a turn has actually cost rather than resetting on every launch.
+    pub fn restore_pending_retry(&mut self, saved: PersistedRetry, cx: &mut Context<Self>) {
+        let settings = cx
+            .try_global::<AgentRetrySettings>()
+            .copied()
+            .unwrap_or_else(AgentRetrySettings::shipped);
+        if !settings.enabled {
+            return;
+        }
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let remaining = saved.wake_at_ms - now_ms;
+        if remaining < -RESTORE_GRACE_MS {
+            return;
+        }
+        // `None` is "No limit" — nothing to exceed.
+        if let Some(max) = settings.max_automatic_wait.duration()
+            && remaining > max.as_millis() as i64
+        {
+            return;
+        }
+        self.retry.attempt = saved.attempt;
+        // The blob is the on-disk state until something changes, and a restored
+        // retry is not a change — `hold_turn_until` marks the chat dirty, so
+        // clear that again below to keep a restored-but-untouched chat clean.
+        let was_dirty = self.meta_dirty.get();
+        self.hold_turn_until(saved.wake_at_ms, saved.reason, cx);
+        self.meta_dirty.set(was_dirty);
     }
 
     /// Fire an armed retry immediately (the card's "Send now").
@@ -163,6 +245,7 @@ impl AgentChatView {
             return;
         }
         self.retry.attempt += 1;
+        self.mark_retry_dirty();
         self.retry_last_turn(cx);
     }
 
@@ -174,6 +257,7 @@ impl AgentChatView {
         let Some(pending) = self.retry.pending.take() else { return };
         self.thread.last_error = Some(format!("{} — retry cancelled.", pending.reason));
         self.retry.attempt = 0;
+        self.mark_retry_dirty();
         cx.notify();
     }
 
@@ -231,6 +315,15 @@ impl AgentChatView {
     pub(super) fn retry_last_turn(&mut self, cx: &mut Context<Self>) {
         if self.thread.turn_active {
             return; // a turn is already streaming — nothing to retry
+        }
+        // A restored retry can fire on a tab that has never been rendered — a
+        // background chat whose reset simply came up. `ensure_connected` is what
+        // consumes the dormant mark, so it has to run here rather than being
+        // left to the first render: respawning directly would leave the mark
+        // set, and that render would then reap this turn's fresh child and
+        // spawn a second one on top of the turn the retry had just started.
+        if self.dormant {
+            self.ensure_connected(false, cx);
         }
         // A crashed / stopped child can't receive input — bring it back first.
         if self.disconnected || self.interrupted {
@@ -316,4 +409,231 @@ impl AgentChatView {
             .on_click(cx.listener(|this, _e, _window, cx| this.retry_last_turn(cx)))
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use gpui::TestAppContext;
+    use oximux_agents::thread::{
+        ChatBackend, SessionMeta, StubConnection, ThreadEntry, Transport,
+    };
+    use oximux_settings::agent_retry::MaxAutomaticWait;
+    use oximux_settings::{Density, Theme, Typography};
+
+    use super::super::AgentChatView;
+    use super::*;
+
+    fn saved(offset_ms: i64, attempt: u32) -> PersistedRetry {
+        PersistedRetry {
+            wake_at_ms: chrono::Utc::now().timestamp_millis() + offset_ms,
+            reason: "Usage limit reached".into(),
+            attempt,
+        }
+    }
+
+    /// Build a chat view with a stub backend and the given retry settings in
+    /// place, then hand it to `f`. The settings are set as a global because
+    /// that is where `restore_pending_retry` reads them from — deliberately at
+    /// restore time rather than from the blob, so a user who switched the
+    /// feature off while the app was closed is obeyed.
+    async fn with_view<F>(cx: &mut TestAppContext, settings: AgentRetrySettings, f: F)
+    where
+        F: FnOnce(&mut AgentChatView, &mut Context<AgentChatView>),
+    {
+        cx.update(gpui_component::init);
+        cx.update(|cx| cx.set_global(settings));
+        let window = cx.add_window(|window, cx| {
+            AgentChatView::with_connection_for_test(
+                Arc::new(StubConnection::default()),
+                Theme::default(),
+                Density::default(),
+                Typography::default(),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        window.update(cx, |view, _window, cx| f(view, cx)).expect("window update");
+    }
+
+    /// The point of persisting a retry at all: a five-hour window outlives the
+    /// app session that hit it, so the held turn must come back armed.
+    #[gpui::test]
+    async fn a_retry_whose_reset_is_still_ahead_comes_back_armed(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.restore_pending_retry(saved(60_000, 2), cx);
+            assert!(view.retry.is_armed(), "a reset still ahead must re-arm");
+            // The attempt count rides along, so the cap of four counts what the
+            // turn has actually cost. Restoring it as 0 would let a chat that
+            // relaunched between attempts exceed the cap without ever showing a
+            // fifth attempt in any single session.
+            assert_eq!(view.retry.attempt, 2, "attempts spent must survive the restart");
+        })
+        .await;
+    }
+
+    /// The half that keeps this feature from being a surprise: an app closed
+    /// across the whole window must not wake up and send on the user's behalf
+    /// for a limit that expired hours ago. The turn is still there and the
+    /// manual Retry button still works — nothing fires by itself.
+    #[gpui::test]
+    async fn a_retry_the_app_slept_through_is_dropped(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.restore_pending_retry(saved(-60 * 60 * 1000, 1), cx);
+            assert!(!view.retry.is_armed(), "a long-past reset must not fire on launch");
+            assert_eq!(view.retry.attempt, 0, "a dropped retry spends nothing");
+        })
+        .await;
+    }
+
+    /// Just inside the grace window — a lid closed over the reset, not a night
+    /// away — still fires. This is the boundary the test above only bounds from
+    /// the other side; without it, `RESTORE_GRACE_MS` could be zero and both
+    /// the drop test and this one would still look satisfied by one of them.
+    #[gpui::test]
+    async fn a_reset_that_passed_moments_ago_still_fires(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.restore_pending_retry(saved(-30_000, 0), cx);
+            assert!(view.retry.is_armed(), "just past the reset is late, not stale");
+        })
+        .await;
+    }
+
+    /// The setting is read at restore, not baked into the blob: switching the
+    /// feature off must take effect on the next launch for retries armed before
+    /// it was switched off.
+    #[gpui::test]
+    async fn a_disabled_setting_refuses_the_rebuild(cx: &mut TestAppContext) {
+        let off = AgentRetrySettings { enabled: false, ..AgentRetrySettings::shipped() };
+        with_view(cx, off, |view, cx| {
+            view.restore_pending_retry(saved(60_000, 0), cx);
+            assert!(!view.retry.is_armed(), "auto-retry off means nothing re-arms");
+        })
+        .await;
+    }
+
+    /// Shortening `max_automatic_wait` while the app was closed also applies:
+    /// a seven-day reset armed under "No limit" must not be honoured by a
+    /// session that now allows at most six hours.
+    #[gpui::test]
+    async fn a_wait_longer_than_the_current_setting_is_refused(cx: &mut TestAppContext) {
+        let short =
+            AgentRetrySettings { enabled: true, max_automatic_wait: MaxAutomaticWait::SixHours };
+        with_view(cx, short, |view, cx| {
+            view.restore_pending_retry(saved(7 * 24 * 60 * 60 * 1000, 0), cx);
+            assert!(!view.retry.is_armed(), "a wait past the current cap must be refused");
+        })
+        .await;
+    }
+
+    /// A restore is not a change: the blob a chat was just built from is still
+    /// the on-disk state, so a quit immediately after launch must not rewrite
+    /// every restored transcript.
+    #[gpui::test]
+    async fn restoring_a_retry_leaves_the_blob_clean(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.last_saved_revision.set(view.thread.revision());
+            view.meta_dirty.set(false);
+            view.restore_pending_retry(saved(60_000, 1), cx);
+            assert!(view.retry.is_armed());
+            assert!(!view.transcript_out_of_date(), "a restored retry is not a mutation");
+        })
+        .await;
+    }
+
+    /// Arming one *is* a change, though — the retry lives on the view, not in
+    /// `ChatThread`, so it moves no revision counter. Without an explicit dirty
+    /// mark the save path would skip the very chat holding the retry, and the
+    /// blob written at quit would not contain it.
+    #[gpui::test]
+    async fn arming_a_retry_marks_the_blob_for_saving(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.thread.session_id = Some("sid-retry".into());
+            view.thread.push_user_message("hello");
+            view.last_saved_revision.set(view.thread.revision());
+            view.meta_dirty.set(false);
+            view.hold_turn_until(
+                chrono::Utc::now().timestamp_millis() + 60_000,
+                "Usage limit reached".into(),
+                cx,
+            );
+            assert!(view.transcript_out_of_date(), "an armed retry must reach the next save");
+            let blob = view.transcript_snapshot().expect("persistable transcript");
+            let held = blob.pending_retry.expect("armed retry rides the blob");
+            assert_eq!(held.reason, "Usage limit reached");
+            assert_eq!(held.attempt, 0, "nothing has fired yet");
+        })
+        .await;
+    }
+
+    /// A restored retry can come due on a tab the user never opened, and firing
+    /// it is the whole point — but the chat is still marked dormant, and the
+    /// dormant mark is what the first render uses to decide it must connect.
+    /// Firing without consuming it means that render reaps the child this retry
+    /// just spawned and starts another on top of the in-flight turn.
+    ///
+    /// The ACP backend carries an empty command so the connect refuses
+    /// synchronously: the assertion is about the mark being consumed, and this
+    /// keeps the test from spawning a process to prove it.
+    #[gpui::test]
+    async fn a_retry_firing_before_first_render_consumes_the_dormant_mark(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(gpui_component::init);
+        cx.update(|cx| cx.set_global(AgentRetrySettings::shipped()));
+        let backend = ChatBackend {
+            transport: Transport::Acp,
+            acp_command: Some(String::new()),
+            acp_args: Vec::new(),
+            env: Vec::new(),
+            adapter_id: None,
+            profile: None,
+        };
+        let window = cx.add_window(|window, cx| {
+            let mut view = AgentChatView::new_resumed(
+                std::env::temp_dir(),
+                None,
+                backend,
+                Some("sid-retry-dormant".into()),
+                vec![ThreadEntry::User { text: "hi".into(), images: vec![], checkpoint: None }],
+                Vec::new(),
+                SessionMeta::default(),
+                super::super::ThinkingLevel::default(),
+                super::super::RestoredPosture::default(),
+                Theme::default(),
+                Density::default(),
+                Typography::default(),
+                window,
+                cx,
+            );
+            assert!(view.dormant, "a restored chat starts dormant");
+            view.retry_last_turn(cx);
+            assert!(
+                !view.dormant,
+                "a retry that connects must consume the mark, or the first \
+                 render spawns a second child over this turn"
+            );
+            view
+        });
+        cx.run_until_parked();
+        window.update(cx, |_, _, _| {}).expect("window update");
+    }
+
+    /// A chat with nothing armed writes no retry, so a blob can never resurrect
+    /// one the user cancelled.
+    #[gpui::test]
+    async fn a_cancelled_retry_leaves_nothing_in_the_blob(cx: &mut TestAppContext) {
+        with_view(cx, AgentRetrySettings::shipped(), |view, cx| {
+            view.thread.session_id = Some("sid-cancel".into());
+            view.thread.push_user_message("hello");
+            view.restore_pending_retry(saved(60_000, 1), cx);
+            view.cancel_retry(cx);
+            let blob = view.transcript_snapshot().expect("persistable transcript");
+            assert!(blob.pending_retry.is_none(), "a cancelled retry must not persist");
+            assert!(view.transcript_out_of_date(), "the cancellation must reach disk");
+        })
+        .await;
+    }
 }

--- a/apps/desktop/src/shell/agent_chat/retry_card.rs
+++ b/apps/desktop/src/shell/agent_chat/retry_card.rs
@@ -1,0 +1,107 @@
+//! Pure (cx-free) renderer for the queued-retry card.
+//!
+//! Shown in place of the error card when a turn failed on a provider limit and
+//! the app has scheduled itself to send it again. The card exists so a waiting
+//! turn never looks like a forgotten one: it names why the turn is held, when
+//! it will go, and gives the user both overrides — send it now, or drop it.
+
+use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px};
+use oximux_settings::{Density, Theme, Typography};
+
+/// Human countdown to a wake time: `45s`, `12m`, `3h 10m`.
+///
+/// Rounds *down* to the unit shown, so "1m" never means "in 119 seconds". A
+/// wake time already past reads `now` rather than a negative or zero duration —
+/// the card can outlive its timer by a frame, and "in -1s" reads as a bug.
+pub(super) fn countdown(remaining_ms: i64) -> String {
+    if remaining_ms <= 0 {
+        return "now".into();
+    }
+    let secs = remaining_ms / 1000;
+    match secs {
+        0..=59 => format!("{secs}s"),
+        60..=3599 => format!("{}m", secs / 60),
+        _ => {
+            let (h, m) = (secs / 3600, (secs % 3600) / 60);
+            if m == 0 { format!("{h}h") } else { format!("{h}h {m}m") }
+        }
+    }
+}
+
+/// What the card says about the held turn. Grouped rather than passed loose so
+/// the renderer keeps the same `(theme, typo, density, controls)` tail shape as
+/// its neighbours in this directory.
+pub(super) struct Held<'a> {
+    /// Short human reason ("Usage limit reached").
+    pub reason: &'a str,
+    /// Milliseconds until the retry fires; may be negative for a frame.
+    pub remaining_ms: i64,
+    /// Automatic attempts already spent, zero-based.
+    pub attempt: u32,
+}
+
+/// Build the queued-retry card: why the turn is held, when it goes, and the two
+/// controls the view supplies (the clicks need a `Context`, so the view owns
+/// them while this stays pure).
+pub(super) fn retry_card(
+    held: Held<'_>,
+    theme: Theme,
+    typo: &Typography,
+    density: Density,
+    send_now: impl IntoElement,
+    cancel: impl IntoElement,
+) -> AnyElement {
+    let Held { reason, remaining_ms, attempt } = held;
+    div()
+        .flex()
+        .flex_col()
+        .gap(px(8.0))
+        .w_full()
+        // Without `min_w_0` a flex ancestor honors the longest unwrapped line
+        // and overflows the column — the same trap the markdown bodies hit.
+        .min_w_0()
+        .rounded(px(density.r_card))
+        .border_1()
+        .border_color(theme.status_warning.opacity(0.4))
+        .bg(theme.status_warning.opacity(0.08))
+        .px(px(12.0))
+        .py(px(10.0))
+        .child(
+            div()
+                .text_size(px(typo.t_label_xs))
+                .text_color(theme.fg_muted)
+                .child(format!("Attempt {} of {}", attempt + 1, oximux_agents::retry::MAX_ATTEMPTS)),
+        )
+        .child(
+            div()
+                .text_size(px(typo.t_body_sm))
+                .text_color(theme.fg_base)
+                .child(format!("{reason} — retrying in {}", countdown(remaining_ms))),
+        )
+        .child(div().flex().gap(px(8.0)).child(send_now).child(cancel))
+        .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn countdown_rounds_down_to_the_unit_it_shows() {
+        assert_eq!(countdown(45_000), "45s");
+        assert_eq!(countdown(59_999), "59s");
+        assert_eq!(countdown(60_000), "1m");
+        // 119s is "1m", never "2m" — a countdown that overstates reads as a
+        // stall when it passes.
+        assert_eq!(countdown(119_000), "1m");
+        assert_eq!(countdown(3_599_000), "59m");
+        assert_eq!(countdown(3_600_000), "1h");
+        assert_eq!(countdown(11_400_000), "3h 10m");
+    }
+
+    #[test]
+    fn a_wake_time_already_past_reads_as_now() {
+        assert_eq!(countdown(0), "now");
+        assert_eq!(countdown(-5_000), "now");
+    }
+}

--- a/apps/desktop/src/shell/agent_chat/session_persistence.rs
+++ b/apps/desktop/src/shell/agent_chat/session_persistence.rs
@@ -155,7 +155,7 @@ impl AgentChatView {
     /// Whether the persisted blob is out of date: the thread's own mutation
     /// counter moved past the last saved revision, or a view-held blob field
     /// (model pick, permission mode, thinking level, posture) was touched.
-    fn transcript_out_of_date(&self) -> bool {
+    pub(super) fn transcript_out_of_date(&self) -> bool {
         self.thread.revision() != self.last_saved_revision.get() || self.meta_dirty.get()
     }
 
@@ -229,6 +229,9 @@ impl AgentChatView {
             // opening this session once it is dormant has no backend to ask, and
             // making the desktop spawn one to fill two dropdowns would undo
             // serving its history from disk.
+            // The armed retry, so a turn held for a five-hour window resumes
+            // at its reset even across a quit. `None` whenever nothing is armed.
+            pending_retry: self.retry.persisted(),
             choices: PersistedChoices {
                 models: self.connection.as_ref().map(|c| c.models()).unwrap_or_default(),
                 modes: self.connection.as_ref().map(|c| c.permission_modes()).unwrap_or_default(),

--- a/apps/desktop/src/shell/agent_chat/transcript.rs
+++ b/apps/desktop/src/shell/agent_chat/transcript.rs
@@ -1175,6 +1175,27 @@ impl AgentChatView {
             // actionable version of the same state.
             let action = self.open_login_terminal_button(cx);
             col = col.child(login_card::login_card(self.provider_label(), theme, &typo, density, action));
+        } else if let Some((wake_at_ms, reason, attempt)) = self
+            .retry
+            .pending
+            .as_ref()
+            .map(|p| (p.wake_at_ms, p.reason.clone(), self.retry.attempt))
+        {
+            // A turn held for a provider limit. Takes precedence over the error
+            // card below: the failure is real, but it is being handled, and
+            // showing a bare error next to a countdown would read as two
+            // different states at once.
+            let remaining = wake_at_ms - chrono::Utc::now().timestamp_millis();
+            let send_now = self.retry_send_now_button(cx);
+            let cancel = self.retry_cancel_button(cx);
+            col = col.child(retry_card::retry_card(
+                retry_card::Held { reason: &reason, remaining_ms: remaining, attempt },
+                theme,
+                &typo,
+                density,
+                send_now,
+                cancel,
+            ));
         } else if let Some(err) = self.thread.last_error.clone() {
             // An idle turn that ended in error: surface it inline at the tail
             // with a Retry. This is the ONLY place a failure after the first

--- a/apps/desktop/src/shell/pane_group/tabs.rs
+++ b/apps/desktop/src/shell/pane_group/tabs.rs
@@ -900,6 +900,7 @@ impl PaneGroup {
         session_meta: oximux_agents::thread::SessionMeta,
         thinking_level: crate::shell::agent_chat::ThinkingLevel,
         posture: crate::shell::agent_chat::RestoredPosture,
+        pending_retry: Option<crate::persisted_chat::PersistedRetry>,
         draft: Option<String>,
         queued: Vec<String>,
         window: &mut Window,
@@ -930,6 +931,12 @@ impl PaneGroup {
         });
         if draft.is_some() || !queued.is_empty() {
             view.update(cx, |v, cx| v.seed_draft_and_queue(draft, queued, window, cx));
+        }
+        // After construction, for the same reason the draft is: `new_resumed`
+        // is shared with paths that have no persisted blob behind them (fork,
+        // import), and only a real restore can have a retry to rebuild.
+        if let Some(saved) = pending_retry {
+            view.update(cx, |v, cx| v.restore_pending_retry(saved, cx));
         }
         self.push_agent_chat_view(view, cwd, model, window, cx)
     }
@@ -1134,6 +1141,9 @@ impl PaneGroup {
                     session_meta.clone(),
                     *thinking_level,
                     Default::default(), // posture — Fork is Claude-only
+                    // pending retry — a fork or a history reopen has no armed
+                    // retry to rebuild; only a real session restore can.
+                    None,
                     None,
                     Vec::new(),
                     window,
@@ -1552,6 +1562,9 @@ impl PaneGroup {
                     // policy isn't re-applied, so the user re-picks via the
                     // composer's Approvals/Sandbox controls if they want it stricter.
                     Default::default(),
+                    // pending retry — a fork or a history reopen has no armed
+                    // retry to rebuild; only a real session restore can.
+                    None,
                     None,
                     Vec::new(),
                     window,
@@ -1578,6 +1591,9 @@ impl PaneGroup {
                     Default::default(),
                     crate::shell::agent_chat::ThinkingLevel::default(),
                     Default::default(), // posture — Claude session-history reopen
+                    // pending retry — a fork or a history reopen has no armed
+                    // retry to rebuild; only a real session restore can.
+                    None,
                     None,
                     Vec::new(),
                     window,
@@ -1655,6 +1671,9 @@ impl PaneGroup {
             // like the Codex arm above: the session file records no posture, and
             // inventing one would misreport what the agent may do.
             Default::default(),
+            // pending retry — a fork or a history reopen has no armed
+            // retry to rebuild; only a real session restore can.
+            None,
             None,
             Vec::new(),
             window,
@@ -1738,6 +1757,9 @@ impl PaneGroup {
             // spawn flag is always explicit, so omp's own yolo default is
             // unreachable). The rollout records no posture to restore.
             Default::default(),
+            // pending retry — a fork or a history reopen has no armed
+            // retry to rebuild; only a real session restore can.
+            None,
             None,
             Vec::new(),
             window,

--- a/apps/desktop/src/shell/project_panes/ops.rs
+++ b/apps/desktop/src/shell/project_panes/ops.rs
@@ -1073,6 +1073,7 @@ impl ProjectPanes {
         session_meta: oximux_agents::thread::SessionMeta,
         thinking_level: crate::shell::agent_chat::ThinkingLevel,
         posture: crate::shell::agent_chat::RestoredPosture,
+        pending_retry: Option<crate::persisted_chat::PersistedRetry>,
         draft: Option<String>,
         queued: Vec<String>,
         window: &mut Window,
@@ -1084,7 +1085,7 @@ impl ProjectPanes {
         group.update(cx, |g, cx| {
             g.open_agent_chat_tab_restored(
                 cwd, model, backend, session_id, entries, slash_commands, session_meta, thinking_level,
-                posture, draft, queued, window, cx,
+                posture, pending_retry, draft, queued, window, cx,
             );
         });
     }

--- a/apps/desktop/src/shell/settings_modal/mod.rs
+++ b/apps/desktop/src/shell/settings_modal/mod.rs
@@ -83,6 +83,8 @@ pub struct SettingsModal {
     pub(crate) terminal: TerminalSettings,
     /// Working copy of the AI commit-message settings; same contract.
     pub(crate) ai: CommitMessageAiSettings,
+    /// Working copy of the rate-limit retry settings.
+    pub(crate) retry: oximux_settings::agent_retry::AgentRetrySettings,
     /// Working copy of the per-agent launch defaults; reseeded from the live
     /// global at each `open()`. Edits mutate this, then write
     /// `agent_launch.toml`; the watcher reloads + swaps the global.
@@ -319,6 +321,7 @@ impl SettingsModal {
             typography,
             terminal: TerminalSettings::default(),
             ai: CommitMessageAiSettings::default(),
+            retry: oximux_settings::agent_retry::AgentRetrySettings::shipped(),
             agent_launch: AgentLaunchSettings::default(),
             dictation: DictationSettings::default(),
             computer_use: ComputerUseSettings::default(),
@@ -397,6 +400,10 @@ impl SettingsModal {
             .try_global::<CommitMessageAiSettings>()
             .cloned()
             .unwrap_or_default();
+        self.retry = cx
+            .try_global::<oximux_settings::agent_retry::AgentRetrySettings>()
+            .copied()
+            .unwrap_or_else(oximux_settings::agent_retry::AgentRetrySettings::shipped);
         self.agent_launch = cx
             .try_global::<AgentLaunchSettings>()
             .cloned()
@@ -756,6 +763,18 @@ impl SettingsModal {
     }
 
     /// Persist the AI working copy to `commit_message_ai.toml`.
+    /// Persist the retry settings and swap the global, so an armed chat reads
+    /// the new ceiling on its next failure rather than after a restart.
+    pub(super) fn persist_retry(&mut self, cx: &mut Context<Self>) {
+        let settings = self.retry;
+        // `save` swaps the global itself, so an armed chat reads the new
+        // ceiling on its next failure rather than after a restart.
+        if let Err(err) = crate::agent_retry_settings::save(&settings, cx) {
+            tracing::warn!(%err, "settings modal: failed to write agent_retry.toml");
+        }
+        cx.notify();
+    }
+
     pub(super) fn persist_ai(&mut self, cx: &mut Context<Self>) {
         if let Err(err) = crate::commit_message_ai_settings::save(&self.ai) {
             tracing::warn!(%err, "settings modal: failed to write commit_message_ai.toml");

--- a/apps/desktop/src/shell/settings_modal/pane_agents.rs
+++ b/apps/desktop/src/shell/settings_modal/pane_agents.rs
@@ -9,6 +9,8 @@ use oximux_settings::{CommitMessageAiMode, Density, Theme, Typography};
 use super::SettingsModal;
 use super::controls::value_chip;
 use super::layout::{SettingEntry, card_surface, entries_card, entry, section_title};
+use oximux_settings::agent_retry::MaxAutomaticWait;
+
 use super::segmented::{Segment, segmented};
 
 /// Agent CLIs the segmented picker exposes.
@@ -227,6 +229,48 @@ fn ai_entries(
         cx,
     );
 
+    // Rate-limit retry. Lives on the agents pane rather than a pane of its own:
+    // it is one behaviour of the agent conversation, and burying it a click
+    // deeper would hide the only control over something that spends time (and,
+    // if the classifier were ever wrong, money) on the user's behalf.
+    let retry_enabled = segmented(
+        "retry-enabled",
+        [true, false]
+            .into_iter()
+            .map(|on| {
+                Segment::new(
+                    if on { "On" } else { "Off" },
+                    modal.retry.enabled == on,
+                    move |this, _w, cx| {
+                        this.retry.enabled = on;
+                        this.persist_retry(cx);
+                    },
+                )
+            })
+            .collect(),
+        theme,
+        density,
+        typography,
+        cx,
+    );
+    let retry_wait = segmented(
+        "retry-wait",
+        MaxAutomaticWait::ALL
+            .iter()
+            .copied()
+            .map(|w| {
+                Segment::new(w.label(), modal.retry.max_automatic_wait == w, move |this, _w, cx| {
+                    this.retry.max_automatic_wait = w;
+                    this.persist_retry(cx);
+                })
+            })
+            .collect(),
+        theme,
+        density,
+        typography,
+        cx,
+    );
+
     let mut entries = vec![entry(
         "Commit-message AI",
         "How commit messages are generated from the staged diff.",
@@ -240,6 +284,19 @@ fn ai_entries(
             agent_id,
         ));
         entries.push(entry("Model", "Model name passed to the agent CLI.", model));
+    }
+
+    entries.push(entry(
+        "Retry after a rate limit",
+        "Re-send a turn by itself when a usage window closes. Spend limits are never retried.",
+        retry_enabled,
+    ));
+    if modal.retry.enabled {
+        entries.push(entry(
+            "Maximum automatic wait",
+            "A reset farther out than this is reported as an error instead of being held.",
+            retry_wait,
+        ));
     }
 
     entries

--- a/apps/desktop/src/shell/tasks_view/row.rs
+++ b/apps/desktop/src/shell/tasks_view/row.rs
@@ -426,6 +426,9 @@ pub(super) fn create_action(
                         Some(AgentAdapter::ClaudeCode),
                         Some(issue_url.clone()),
                         Some(linked_issue.clone()),
+                        // No setup picker on a task row — the project's
+                        // `auto_setup` decides, same as before this existed.
+                        oximux_settings::SetupDecision::Inherit,
                         true,
                         window,
                         cx,

--- a/apps/desktop/src/shell/workspace/workspace_dialog.rs
+++ b/apps/desktop/src/shell/workspace/workspace_dialog.rs
@@ -24,7 +24,7 @@ use gpui_component::{
 };
 use oximux_core::{AgentAdapter, Project, Workspace};
 use oximux_git::derive_slug;
-use oximux_settings::{Density, Theme, Typography};
+use oximux_settings::{Density, SetupDecision, Theme, Typography};
 
 use crate::shell::forge::ref_parse::parse_forge_ref;
 use crate::shell::forge::{Forge, fetch_ref_title};
@@ -77,6 +77,12 @@ pub struct WorkspaceDialogSubmit {
     pub linked_issue: Option<String>,
     /// Optional agent to auto-spawn after Created. `None` = Skip.
     pub agent: Option<AgentAdapter>,
+    /// Per-request answer for the project's `setup` script. Defaults to
+    /// [`SetupDecision::Inherit`], which is the project's committed
+    /// `auto_setup` — the dropdown exists so a throwaway worktree can skip a
+    /// ten-minute install, and a one-off can opt in, without editing a file
+    /// the whole team shares.
+    pub setup: SetupDecision,
 }
 
 pub type OnSubmit = Box<dyn Fn(WorkspaceDialogSubmit, &mut Window, &mut App) + Send + 'static>;
@@ -94,6 +100,8 @@ pub struct WorkspaceDialog {
     /// `None` = "Skip (no agent)".
     selected_agent: Option<AgentAdapter>,
     agent_dropdown_open: bool,
+    selected_setup: SetupDecision,
+    setup_dropdown_open: bool,
     /// Forge reference the current name was prefilled from (`"#42"`).
     /// Cleared the moment the user edits the name again — their text wins.
     linked_issue: Option<String>,
@@ -148,6 +156,8 @@ impl WorkspaceDialog {
             project_dropdown_open: false,
             selected_agent: None,
             agent_dropdown_open: false,
+            selected_setup: SetupDecision::Inherit,
+            setup_dropdown_open: false,
             linked_issue: None,
             fetch_epoch: 0,
             fetching_title: false,
@@ -253,6 +263,8 @@ impl WorkspaceDialog {
         self.project_dropdown_open = false;
         self.selected_agent = None;
         self.agent_dropdown_open = false;
+        self.selected_setup = SetupDecision::Inherit;
+        self.setup_dropdown_open = false;
         self.linked_issue = None;
         self.fetch_epoch += 1;
         self.fetching_title = false;
@@ -278,6 +290,7 @@ impl WorkspaceDialog {
             .update(cx, |s, cx| s.set_value(&existing_name, window, cx));
         self.project_dropdown_open = false;
         self.agent_dropdown_open = false;
+        self.setup_dropdown_open = false;
         let input_focus = self.name_input.read(cx).focus_handle(cx);
         window.focus(&input_focus, cx);
         cx.notify();
@@ -294,6 +307,7 @@ impl WorkspaceDialog {
         self.linked_issue = None;
         self.project_dropdown_open = false;
         self.agent_dropdown_open = false;
+        self.setup_dropdown_open = false;
         cx.notify();
     }
 
@@ -331,6 +345,7 @@ impl WorkspaceDialog {
             WorkspaceDialogMode::Rename(_) => None,
         };
         let agent = self.selected_agent;
+        let setup = self.selected_setup;
         let linked_issue = self.linked_issue.clone();
         self.close(cx);
         (self.on_submit)(
@@ -339,6 +354,7 @@ impl WorkspaceDialog {
                 name,
                 project,
                 agent,
+                setup,
                 linked_issue,
             },
             window,
@@ -402,9 +418,10 @@ impl Render for WorkspaceDialog {
                 cx.stop_propagation();
                 // First Escape collapses an open dropdown; only a bare
                 // Escape dismisses the whole dialog.
-                if this.project_dropdown_open || this.agent_dropdown_open {
+                if this.project_dropdown_open || this.agent_dropdown_open || this.setup_dropdown_open {
                     this.project_dropdown_open = false;
                     this.agent_dropdown_open = false;
+                    this.setup_dropdown_open = false;
                     cx.notify();
                 } else {
                     this.close(cx);
@@ -463,6 +480,7 @@ impl Render for WorkspaceDialog {
 
         if is_create {
             card = card.child(self.render_agent_section(cx));
+            card = card.child(self.render_setup_section(cx));
         }
 
         card = card.child(
@@ -552,6 +570,7 @@ impl WorkspaceDialog {
                         cx.listener(|this, _: &MouseDownEvent, _window, cx| {
                             this.project_dropdown_open = !this.project_dropdown_open;
                             this.agent_dropdown_open = false;
+                            this.setup_dropdown_open = false;
                             cx.notify();
                         }),
                     ),
@@ -629,6 +648,7 @@ impl WorkspaceDialog {
                         cx.listener(|this, _: &MouseDownEvent, _window, cx| {
                             this.agent_dropdown_open = !this.agent_dropdown_open;
                             this.project_dropdown_open = false;
+                            this.setup_dropdown_open = false;
                             cx.notify();
                         }),
                     ),
@@ -657,6 +677,113 @@ impl WorkspaceDialog {
         }
         col
     }
+
+    /// The per-request Setup override. Deliberately the last field: the
+    /// default answer ("Project default") is right almost always, and putting
+    /// it above the agent picker would make every create look like a decision
+    /// about setup.
+    fn render_setup_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = self.theme;
+        let density = self.density;
+        let typography = self.typography.clone();
+
+        let mut col = div()
+            .flex()
+            .flex_col()
+            .gap(px(2.0))
+            .child(
+                div()
+                    .text_size(px(typography.t_label_caps))
+                    .text_color(theme.fg_subtle)
+                    .child("Setup script"),
+            )
+            .child(
+                div()
+                    .id("ws-dialog-setup-trigger")
+                    .flex()
+                    .items_center()
+                    .h(px(FIELD_HEIGHT))
+                    .px(px(8.0))
+                    .bg(theme.bg_panel)
+                    .border_1()
+                    .border_color(theme.border_inactive)
+                    .rounded(px(density.r_xs))
+                    .cursor_pointer()
+                    .text_size(px(typography.t_body_sm))
+                    .text_color(theme.fg_base)
+                    .child(setup_label(self.selected_setup))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseDownEvent, _window, cx| {
+                            this.setup_dropdown_open = !this.setup_dropdown_open;
+                            this.project_dropdown_open = false;
+                            this.agent_dropdown_open = false;
+                            cx.notify();
+                        }),
+                    ),
+            );
+
+        if self.setup_dropdown_open {
+            let mut list = div()
+                .flex()
+                .flex_col()
+                .bg(theme.bg_panel)
+                .border_1()
+                .border_color(theme.border_inactive)
+                .rounded(px(density.r_xs));
+            for choice in SETUP_CHOICES {
+                list = list.child(setup_option_row(*choice, theme, &typography, cx));
+            }
+            col = col.child(list);
+        }
+        col
+    }
+}
+
+/// Order matters: `Inherit` first because it is the default and the answer a
+/// user should have to actively leave.
+const SETUP_CHOICES: &[SetupDecision] =
+    &[SetupDecision::Inherit, SetupDecision::Run, SetupDecision::Skip];
+
+/// Human-readable label for the setup dropdown.
+pub fn setup_label(decision: SetupDecision) -> &'static str {
+    match decision {
+        SetupDecision::Inherit => "Project default",
+        SetupDecision::Run => "Run setup",
+        SetupDecision::Skip => "Skip setup",
+    }
+}
+
+fn setup_option_row(
+    decision: SetupDecision,
+    theme: Theme,
+    typography: &Typography,
+    cx: &mut Context<WorkspaceDialog>,
+) -> impl IntoElement {
+    let id: usize = match decision {
+        SetupDecision::Inherit => 0,
+        SetupDecision::Run => 1,
+        SetupDecision::Skip => 2,
+    };
+    div()
+        .id(("ws-dialog-setup-opt", id))
+        .flex()
+        .items_center()
+        .h(px(FIELD_HEIGHT))
+        .px(px(8.0))
+        .cursor_pointer()
+        .hover(|s| s.bg(theme.hover_overlay))
+        .text_size(px(typography.t_body_sm))
+        .text_color(theme.fg_base)
+        .child(setup_label(decision))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                this.selected_setup = decision;
+                this.setup_dropdown_open = false;
+                cx.notify();
+            }),
+        )
 }
 
 fn agent_option_row(
@@ -751,11 +878,30 @@ mod tests {
             name: "fix-login".to_string(),
             project: Some(project("p1", "Acme")),
             agent: Some(AgentAdapter::ClaudeCode),
+            setup: SetupDecision::Inherit,
             linked_issue: None,
         };
         assert_eq!(payload.mode, WorkspaceDialogMode::Create);
         assert!(payload.project.is_some());
         assert_eq!(payload.agent, Some(AgentAdapter::ClaudeCode));
+    }
+
+    /// The dropdown's default must be the project's answer, or opening the
+    /// dialog and pressing Enter would silently override what the team
+    /// committed — the exact behavior change this phase is careful not to make.
+    #[test]
+    fn the_setup_dropdown_defaults_to_the_project_answer() {
+        assert_eq!(SETUP_CHOICES[0], SetupDecision::Inherit);
+        assert_eq!(setup_label(SetupDecision::Inherit), "Project default");
+        assert!(SetupDecision::Inherit.resolve(true));
+        assert!(!SetupDecision::Inherit.resolve(false));
+    }
+
+    #[test]
+    fn every_setup_choice_has_a_distinct_label() {
+        let labels: std::collections::BTreeSet<_> =
+            SETUP_CHOICES.iter().map(|c| setup_label(*c)).collect();
+        assert_eq!(labels.len(), SETUP_CHOICES.len());
     }
 
     #[test]
@@ -765,6 +911,7 @@ mod tests {
             name: "new".to_string(),
             project: None,
             agent: None,
+            setup: SetupDecision::Inherit,
             linked_issue: None,
         };
         assert!(payload.project.is_none());

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -145,8 +145,115 @@ pub(crate) fn build_add_project_dialog(
 // second implementation of the same rollback ladder. Re-exported here
 // because this module is the desktop's door to it.
 pub use oximux_worktree_ops::{
-    CreateOutcome, create_workspace_with_rollback, run_cleanup_before_remove,
+    CreateOutcome, Provision, ProvisionEvent, SetupTranscript, create_workspace_with_rollback,
+    run_cleanup_before_remove,
 };
+
+/// Upper bound on `default_tabs`. The list is repo-controlled and needs no
+/// opt-in, so it is bounded at roughly the number of tabs a person would open
+/// by hand rather than at what a config file may declare.
+const MAX_DEFAULT_TABS: usize = 8;
+
+/// Upper bound on one `default_tabs` title, in characters.
+const MAX_TAB_TITLE_CHARS: usize = 64;
+
+/// Provisioning transcripts retained per workspace slug.
+const KEEP_TRANSCRIPTS: usize = 3;
+
+/// Where one worktree's provisioning transcript lives:
+/// `<data_dir>/projects/<project_id>/provisioning/<slug>-<millis>.log`.
+///
+/// Outside the worktree deliberately. The transcript matters most when setup
+/// failed, and that is exactly when the worktree has been rolled back — a file
+/// written inside it would be deleted by the rollback that made it interesting.
+///
+/// A fresh path per attempt, not one file per slug. Overwriting in place looks
+/// tidier and is wrong: the editor activates an already-open tab for a path
+/// without re-reading it, so a second failed create would show the user the
+/// *first* failure's output while the file on disk said otherwise. Older
+/// transcripts for the same slug are pruned so this stays a log and not an
+/// archive.
+pub(crate) fn provisioning_transcript_path(project_id: &str, slug: &str) -> PathBuf {
+    let dir = crate::app_paths::data_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("projects")
+        .join(project_id)
+        .join("provisioning");
+    prune_transcripts(&dir, slug, KEEP_TRANSCRIPTS);
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    dir.join(format!("{slug}-{stamp}.log"))
+}
+
+/// Keep the `keep` newest transcripts for `slug`, delete the rest.
+///
+/// By name, not by mtime: the name carries the timestamp, and lexicographic
+/// order over a fixed-width millisecond stamp is chronological order. Every
+/// failure here is ignored — pruning a log must never be able to affect a
+/// worktree create.
+fn prune_transcripts(dir: &Path, slug: &str, keep: usize) {
+    let prefix = format!("{slug}-");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return; // first run for this project: nothing to prune
+    };
+    let mut mine: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().is_some_and(|e| e == "log")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(&prefix))
+        })
+        .collect();
+    if mine.len() < keep {
+        return;
+    }
+    mine.sort();
+    // `keep - 1`: one slot is about to be taken by the transcript this call is
+    // making a path for.
+    for stale in mine.iter().take(mine.len().saturating_sub(keep - 1)) {
+        let _ = std::fs::remove_file(stale);
+    }
+}
+
+/// Drain [`ProvisionEvent`]s into the transcript file until the sender drops.
+///
+/// Flushed per event rather than at the end so `tail -f` shows a long install
+/// progressing, and so a hard kill mid-setup still leaves the lines that
+/// explain where it got to. Every IO error here is swallowed: failing to write
+/// a log must not be able to fail a worktree creation that otherwise worked.
+pub(crate) async fn stream_provisioning(
+    path: PathBuf,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<ProvisionEvent>,
+) {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut file = match std::fs::File::create(&path) {
+        Ok(f) => f,
+        Err(err) => {
+            tracing::warn!(?err, path = %path.display(), "provisioning transcript unavailable");
+            // Still drain, or the unbounded channel grows for the whole run.
+            while rx.recv().await.is_some() {}
+            return;
+        }
+    };
+    while let Some(event) = rx.recv().await {
+        let line = match event {
+            ProvisionEvent::IncludeCopied(p) => format!("include: copied {}", p.display()),
+            ProvisionEvent::IncludeSkipped(skip) => format!("include: skipped {skip}"),
+            ProvisionEvent::SetupStarted(script) => format!("$ {script}"),
+            ProvisionEvent::SetupLine(line) => line,
+            ProvisionEvent::SetupFinished(outcome) => format!("== {}", outcome.summary()),
+        };
+        let _ = writeln!(file, "{line}");
+        let _ = file.flush();
+    }
+}
 
 /// Body of [`WorkspaceRoot::workspaces_with_primary`] as a free function so
 /// the rail gather can run it on the background executor (SQLite + a
@@ -1628,6 +1735,7 @@ impl WorkspaceRoot {
                     // prompt prefill (the linked-issue badge still records it).
                     None,
                     submit.linked_issue,
+                    submit.setup,
                     false,
                     window,
                     cx,
@@ -1650,6 +1758,10 @@ impl WorkspaceRoot {
         agent: Option<AgentAdapter>,
         agent_prompt: Option<String>,
         linked_issue: Option<String>,
+        // Per-request override for the project's `setup` script. `Inherit` —
+        // every caller but the create dialog — defers to the project's
+        // committed `auto_setup`.
+        setup_decision: oximux_settings::SetupDecision,
         activate_after: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -1710,6 +1822,19 @@ impl WorkspaceRoot {
                 );
                 return;
             }
+            // Provisioning transcript. Written to the data dir rather than
+            // into the worktree because the case that most needs reading is
+            // the one where the worktree no longer exists — a failed setup
+            // rolls it back, and a transcript inside it would go with it.
+            let transcript_path = provisioning_transcript_path(&project_id, &slug);
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ProvisionEvent>();
+            // Drained on the background executor so the file grows while setup
+            // runs: a 10-minute `pnpm install` is watchable with `tail -f`
+            // instead of appearing as a frozen window.
+            let writer = {
+                let transcript_path = transcript_path.clone();
+                cx.background_spawn(async move { stream_provisioning(transcript_path, rx).await })
+            };
             let outcome = create_workspace_with_rollback(
                 &project_root,
                 &project_id,
@@ -1718,8 +1843,18 @@ impl WorkspaceRoot {
                 &worktree_path,
                 linked_issue.as_deref(),
                 &workspace_repo,
+                // No per-request override from this path yet: the create dialog
+                // has no setup toggle, so the project's `auto_setup` decides.
+                // Reclaim opted into here and nowhere else in the desktop:
+                // this path is host-derived under the data dir, and the flow
+                // above has already looked for a workspace row naming it.
+                &Provision::new(setup_decision, tx).reclaiming_orphans(),
             )
             .await;
+            // The sender is gone with `Provision`, so the drain has ended or is
+            // about to; awaiting it means the file is complete before anything
+            // below offers to open it.
+            writer.await;
             match outcome {
                 CreateOutcome::Created(workspace) => {
                     tracing::info!(
@@ -1763,16 +1898,94 @@ impl WorkspaceRoot {
                                 cx,
                             );
                         }
-                        // Opt-in: run the project's setup script in a terminal
-                        // tab right after the worktree exists. `auto_setup`
-                        // defaults off; the Setup row is always available
-                        // manually regardless of this flag. Opened after the
-                        // agent tab, so when both fire the setup tab is the
-                        // active one — the user opted into setup, so seeing it
-                        // run is the intended focus.
-                        if crate::project_scripts_loader::load_for_project(&cwd).auto_setup {
-                            this.run_workspace_script(workspace, ScriptKind::Setup, window, cx);
+                        // `auto_setup` no longer opens a terminal tab here.
+                        // Setup now runs inside `create_workspace_with_rollback`
+                        // as provisioning, so a failure rolls the worktree back
+                        // instead of leaving a red tab beside a worktree that
+                        // reported success. By the time this runs, setup has
+                        // already succeeded — running it again would repeat a
+                        // `pnpm install`. The manual "Run setup" row is
+                        // unchanged and remains the way to re-run it.
+                        //
+                        // `default_tabs` is what opens here instead: the shell
+                        // layout a project declares every new worktree starts
+                        // in. Opened after the agent tab so the agent is not
+                        // buried, and each is a plain terminal at the worktree.
+                        // Capped because `default_tabs` comes from a committed
+                        // file and, unlike `setup`, needs no opt-in — cloning a
+                        // repo and creating a worktree is enough to act on it.
+                        // One PTY per entry with no bound would let a checked-in
+                        // list of any length spawn that many processes.
+                        let mut tabs =
+                            crate::project_scripts_loader::load_for_project(&cwd).default_tabs;
+                        if tabs.len() > MAX_DEFAULT_TABS {
+                            tracing::warn!(
+                                declared = tabs.len(),
+                                cap = MAX_DEFAULT_TABS,
+                                "default_tabs exceeds the cap; opening the first {MAX_DEFAULT_TABS}"
+                            );
+                            tabs.truncate(MAX_DEFAULT_TABS);
                         }
+                        if !tabs.is_empty()
+                            && let Some(panes) = this.active_project_panes()
+                        {
+                            panes.update(cx, |p, cx| {
+                                for title in tabs {
+                                    // Titles are repo-controlled too; a tab
+                                    // label is not a place to render a kilobyte.
+                                    let title: String =
+                                        title.chars().take(MAX_TAB_TITLE_CHARS).collect();
+                                    p.open_script_terminal_tab_in_active_group(
+                                        cwd.clone(),
+                                        title.into(),
+                                        // No command: a declared tab is a shell
+                                        // to work in, not a script to run. The
+                                        // scripts are `.oximux/scripts.toml`.
+                                        "",
+                                        window,
+                                        cx,
+                                    );
+                                }
+                            });
+                        }
+                    });
+                }
+                CreateOutcome::SetupFailed {
+                    transcript,
+                    rollback_error,
+                } => {
+                    tracing::warn!(
+                        slug = %slug,
+                        outcome = %transcript.outcome.summary(),
+                        ?rollback_error,
+                        transcript = %transcript_path.display(),
+                        "workspace create: setup failed, worktree rolled back"
+                    );
+                    let _ = weak.update_in(cx, |this, window, cx| {
+                        this.mark_rail_dirty(cx);
+                        // The transcript, not the summary, is what the user
+                        // needs — the compiler error or the missing binary is
+                        // in the script's own output. Opened in the editor so
+                        // it stays reachable after the toast goes. The path is
+                        // unique per attempt, so this is always this attempt's
+                        // output and never a cached tab from the last one.
+                        if let Some(panes) = this.active_project_panes() {
+                            panes.update(cx, |p, cx| {
+                                p.open_or_activate_editor_tab(transcript_path.clone(), window, cx);
+                            });
+                        }
+                        let detail = match &rollback_error {
+                            Some(err) => format!(
+                                "{}. Rollback also failed ({err}) — manual cleanup required.",
+                                transcript.outcome.summary()
+                            ),
+                            None => transcript.outcome.summary(),
+                        };
+                        crate::shell::toast::toast_op_error(
+                            cx,
+                            &format!("Set up workspace \u{201c}{slug}\u{201d}"),
+                            &detail,
+                        );
                     });
                 }
                 CreateOutcome::GitFailed(msg) => {

--- a/apps/desktop/src/workspace_root/render.rs
+++ b/apps/desktop/src/workspace_root/render.rs
@@ -573,8 +573,15 @@ impl Render for WorkspaceRoot {
                     let project_id = project.id.clone();
                     cx.spawn(async move |weak_root, cx| {
                         use crate::shell::workspace_ops::{
-                            ChatWorktreeOutcome, CreateOutcome, create_workspace_with_rollback,
+                            ChatWorktreeOutcome, CreateOutcome, Provision,
+                            create_workspace_with_rollback, provisioning_transcript_path,
+                            stream_provisioning,
                         };
+                        let transcript_path = provisioning_transcript_path(&project_id, &slug);
+                        let (provision_tx, provision_rx) = tokio::sync::mpsc::unbounded_channel();
+                        let writer = cx.background_spawn(async move {
+                            stream_provisioning(transcript_path, provision_rx).await
+                        });
                         // `name` = slug: the human label derived from the branch
                         // slug (collision handled inside `insert`).
                         let outcome = create_workspace_with_rollback(
@@ -585,8 +592,26 @@ impl Render for WorkspaceRoot {
                             &worktree_path,
                             None,
                             &workspace_repo,
+                            // The chat's own worktree: the project's setting
+                            // decides. This path runs unattended more than any
+                            // other, so it still writes the transcript even
+                            // though the chat surface only shows the one-line
+                            // outcome — otherwise a failure here would be the
+                            // hardest one to diagnose and the least visible.
+                            // No `reclaiming_orphans()` here on purpose. This
+                            // path targets a sibling `oximux-wt-<slug>` beside
+                            // the project root — a location a person may well
+                            // own — and it never checks for an existing row.
+                            // Both of the reclaim's safety premises are false
+                            // here, so a collision must stay an ordinary
+                            // `add_worktree` failure.
+                            &Provision::new(
+                                oximux_settings::SetupDecision::Inherit,
+                                provision_tx,
+                            ),
                         )
                         .await;
+                        writer.await;
                         let chat_outcome = match outcome {
                             CreateOutcome::Created(ws) => ChatWorktreeOutcome::Created {
                                 path: std::path::PathBuf::from(&ws.worktree_path),
@@ -602,6 +627,9 @@ impl Render for WorkspaceRoot {
                             } => ChatWorktreeOutcome::GitFailed(format!(
                                 "{insert_error}; rollback: {rollback_error}"
                             )),
+                            CreateOutcome::SetupFailed { transcript, .. } => {
+                                ChatWorktreeOutcome::GitFailed(transcript.outcome.summary())
+                            }
                         };
                         // Refresh the rail so the new workspace card + ⌘J entry
                         // appear without a manual reload.

--- a/apps/desktop/tests/workspace_create_rollback.rs
+++ b/apps/desktop/tests/workspace_create_rollback.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use oximux_app::shell::workspace_ops::{CreateOutcome, create_workspace_with_rollback};
+use oximux_app::shell::workspace_ops::{CreateOutcome, Provision, create_workspace_with_rollback};
 use oximux_git::Repository;
 use oximux_storage::{ProjectRepo, WorkspaceRepo, open_memory};
 
@@ -73,6 +73,7 @@ async fn rollback_on_insert_conflict_removes_worktree_and_branch() {
         &worktree_path,
         None,
         &workspace_repo,
+        &Provision::default(),
     )
     .await;
 
@@ -125,6 +126,7 @@ async fn create_workspace_happy_path_inserts_row_and_keeps_worktree() {
         &worktree_path,
         None,
         &workspace_repo,
+        &Provision::default(),
     )
     .await;
 
@@ -154,5 +156,385 @@ async fn create_workspace_happy_path_inserts_row_and_keeps_worktree() {
     assert!(
         branches.iter().any(|b| b.name == "oximux/new-feat"),
         "branch should be present"
+    );
+}
+
+/// Commit a `.oximux/scripts.toml` so the *worktree* carries it — the file is
+/// committed by design, which is why a fresh worktree of the branch has it.
+fn commit_scripts(cwd: &Path, body: &str) {
+    let dir = cwd.join(".oximux");
+    std::fs::create_dir_all(&dir).expect("mkdir .oximux");
+    std::fs::write(dir.join("scripts.toml"), body).expect("write scripts.toml");
+    run_git(cwd, &["add", ".oximux/scripts.toml"]);
+    run_git(cwd, &["commit", "-m", "scripts"]);
+}
+
+/// The phase's central claim: a worktree that reports created is one the user
+/// can work in. A setup script that fails must leave nothing behind — not the
+/// directory, not the branch, and not a row the sidebar would list.
+#[tokio::test]
+async fn a_failing_setup_script_rolls_back_worktree_branch_and_row() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+    commit_scripts(
+        project_root,
+        "auto_setup = true\nsetup = \"echo installing deps; exit 2\"\n",
+    );
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "bad-setup";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Bad Setup",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    let transcript = match outcome {
+        CreateOutcome::SetupFailed {
+            transcript,
+            rollback_error,
+        } => {
+            assert!(rollback_error.is_none(), "rollback should be clean");
+            transcript
+        }
+        other => panic!("expected SetupFailed, got {other:?}"),
+    };
+    // The script's own output is what the user needs; a generic failure would
+    // send them back to a terminal to reproduce it by hand.
+    assert!(
+        transcript.output.contains("installing deps"),
+        "transcript should carry the script's output: {:?}",
+        transcript.output
+    );
+
+    assert!(
+        !worktree_path.exists(),
+        "worktree dir should be removed: {}",
+        worktree_path.display()
+    );
+    let repo = Repository::open(project_root).await.expect("open");
+    let branches = repo.list_branches().await.expect("list branches");
+    let names: Vec<&str> = branches.iter().map(|b| b.name.as_str()).collect();
+    assert!(
+        !names.contains(&"oximux/bad-setup"),
+        "branch should be deleted; got: {names:?}"
+    );
+    let rows = workspace_repo
+        .list_for_project(&project.id)
+        .expect("list workspaces");
+    assert!(
+        rows.is_empty(),
+        "no row may be left behind for a worktree that never provisioned: {rows:?}"
+    );
+}
+
+/// `auto_setup` defaults off, so a project that never opted in cannot have its
+/// creation broken by a setup script that happens to be defined. This is the
+/// upgrade-safety assertion for the whole phase.
+#[tokio::test]
+async fn a_failing_setup_script_is_not_run_when_the_project_did_not_opt_in() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+    // Same failing script, but no `auto_setup`.
+    commit_scripts(project_root, "setup = \"exit 2\"\n");
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "opted-out";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Opted Out",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::Created(_)),
+        "default-off must keep today's behavior, got {outcome:?}"
+    );
+    assert!(worktree_path.exists());
+}
+
+/// Ordering, asserted by the setup script itself: the include copy runs first,
+/// so a script can read the `.env` it needs. A test that only checked the file
+/// exists afterwards would pass even if the order were reversed.
+#[tokio::test]
+async fn included_files_are_present_before_the_setup_script_runs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+    commit_scripts(
+        project_root,
+        "auto_setup = true\nsetup = \"test -f .env && cat .env\"\n",
+    );
+    // Untracked on purpose — this is precisely the file a worktree does not
+    // inherit from git, and the reason `.oximuxinclude` exists.
+    std::fs::write(project_root.join(".env"), "TOKEN=local\n").expect("write .env");
+    std::fs::write(project_root.join(".oximuxinclude"), ".env\n").expect("write include");
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "with-env";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "With Env",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::Created(_)),
+        "setup should have found .env, got {outcome:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join(".env")).expect("copied .env"),
+        "TOKEN=local\n"
+    );
+}
+
+/// The include copy is best-effort: a pattern that matches nothing is reported,
+/// never fatal. A worktree is still created — it is the setup script, not the
+/// copy, that decides whether a missing file actually mattered.
+#[tokio::test]
+async fn an_include_pattern_matching_nothing_does_not_fail_creation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+    std::fs::write(project_root.join(".oximuxinclude"), "never-existed.env\n")
+        .expect("write include");
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "no-match";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "No Match",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::Created(_)),
+        "a missing include must not fail creation, got {outcome:?}"
+    );
+}
+
+/// The wedge that provisioning made reachable: killing the app during a long
+/// setup leaves the worktree and branch on disk with no row naming them. The
+/// workspace is then invisible in the rail *and* un-creatable, because
+/// `add_worktree` refuses a path that already exists. A retry must clear the
+/// debris and succeed rather than failing forever.
+#[tokio::test]
+async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "interrupted";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+
+    // First create succeeds, leaving worktree + branch + row.
+    let first = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Interrupted",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    let created = match first {
+        CreateOutcome::Created(ws) => ws,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    // Simulate the crash: the row never made it (or was lost), but git's half
+    // is on disk. This is exactly the state a kill during setup leaves behind.
+    workspace_repo.delete(&created.id).expect("drop the row");
+    assert!(worktree_path.exists(), "precondition: the orphan is on disk");
+
+    let retry = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Interrupted",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default().reclaiming_orphans(),
+    )
+    .await;
+
+    match retry {
+        CreateOutcome::Created(ws) => {
+            assert_eq!(ws.slug, slug);
+            assert!(worktree_path.exists(), "the retry's worktree should be on disk");
+        }
+        // Before the reclaim this was `GitFailed("add_worktree: ... already
+        // exists")`, permanently, with no way out of the UI.
+        other => panic!("retry after an interrupted create must succeed, got {other:?}"),
+    }
+}
+
+/// The reclaim is a delete, so it verifies rather than trusts. A caller that
+/// opts in but is wrong — a workspace row *does* name this path — must not lose
+/// the user's worktree. Without the in-function row check this test destroys a
+/// live workspace and its uncommitted work.
+#[tokio::test]
+async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "live-work";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let first = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Live Work",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(matches!(first, CreateOutcome::Created(_)), "{first:?}");
+
+    // Uncommitted work the user would lose if the reclaim went ahead.
+    std::fs::write(worktree_path.join("wip.txt"), "hours of work\n").expect("write wip");
+
+    // The row is still there, so opting in must not be enough.
+    let second = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Live Work",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default().reclaiming_orphans(),
+    )
+    .await;
+
+    assert!(
+        matches!(second, CreateOutcome::GitFailed(_)),
+        "a claimed path must fail, not be reclaimed: {second:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join("wip.txt")).expect("wip survives"),
+        "hours of work\n",
+        "the reclaim deleted a live workspace"
+    );
+}
+
+/// A caller that has NOT opted in must never have its target path touched, even
+/// when no row names it. This is the chat-initiated worktree's protection: it
+/// targets a sibling directory beside the project root, where a person's own
+/// worktree can legitimately live.
+#[tokio::test]
+async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    // A directory the user owns, at a sibling path, that no row knows about.
+    let slug = "mine";
+    let worktree_path = tmp.path().join("oximux-wt-mine");
+    std::fs::create_dir_all(&worktree_path).expect("mkdir");
+    std::fs::write(worktree_path.join("notes.txt"), "not yours\n").expect("write");
+
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Mine",
+        slug,
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::GitFailed(_)),
+        "an occupied path must fail without opt-in: {outcome:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join("notes.txt")).expect("survives"),
+        "not yours\n",
+        "a non-opted-in create deleted a directory it did not own"
     );
 }

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -330,18 +330,151 @@ oracle = """
 Fail creation at each stage and assert the tree, the branch list, and the \
 workspace table are all as they were. A partial rollback is worse than no \
 rollback: a branch with no worktree, or a row pointing at a path that does not \
-exist, is state the user cannot see and cannot clear from the UI."""
+exist, is state the user cannot see and cannot clear from the UI.
+
+The orphan reclaim added in Phase 2 inverts the risk and needs its own reading. \
+Its regression is not "the wedge came back" but "it deleted something it should \
+not have": a force-removed worktree takes uncommitted work with it and there is \
+no undo. So the two refusal assertions carry more weight here than the healing \
+one — a green `..._is_reclaimed_on_retry` alone would say nothing about whether \
+the guard still holds. Both refusals are written to fail loudly, by asserting a \
+file's contents survive rather than by asserting an enum variant."""
 platforms = ["macos", "windows", "linux"]
 covered_platforms = ["macos"]
 coverage_notes = """
-The rollback test runs in the desktop test suite, which is macOS-only. Path \
-handling is the part most likely to diverge on Windows, and it is exactly the \
-part not covered. Phase 2 of the agent-runtime plan extends this test with a \
-setup-failure arm."""
+The rollback test runs in the desktop test suite, which is macOS-only \
+(`apps/desktop/tests/` is reached by the macOS `--workspace --all-targets` \
+step; the Windows job runs `-p oximux-app --lib`, and the Linux job does not \
+build this crate at all). Path handling is the part most likely to diverge on \
+Windows, and it is exactly the part not covered. Phase 2 added the \
+setup-failure arm this note previously anticipated."""
 test_files = ["apps/desktop/tests/workspace_create_rollback.rs"]
 assertions = [
   "rollback_on_insert_conflict_removes_worktree_and_branch",
   "create_workspace_happy_path_inserts_row_and_keeps_worktree",
+  "a_failing_setup_script_rolls_back_worktree_branch_and_row",
+  "an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry",
+  "reclaim_refuses_a_path_a_workspace_row_still_names",
+  "a_caller_that_did_not_opt_in_never_has_its_path_reclaimed",
+]
+
+[[gate]]
+id = "worktree.provisioning-precedes-a-created-worktree"
+title = "A worktree reported created has been provisioned"
+status = "stable"
+owner = "worktree-ops"
+invariant = """
+Worktree creation copies the project's `.oximuxinclude` files and then runs its \
+`setup` script, in that order, before the workspace row is inserted. A setup \
+failure — non-zero exit, signal, or timeout — fails creation. A project that \
+has not set `auto_setup` runs no setup at all."""
+oracle = """
+The order is the part a careless test cannot see: asserting the included file \
+exists *after* creation passes even if the copy ran last, so the ordering \
+assertion is made by the setup script itself (`test -f .env`) rather than by \
+the test body.
+
+A regression presents as a worktree that opens with missing dependencies and no \
+error — creation reported success and the failure surfaces minutes later as a \
+broken build in an unrelated tab. The inverse regression is louder and matters \
+more: creation starting to fail for a project that never opted in, which is \
+what `a_failing_setup_script_is_not_run_when_the_project_did_not_opt_in` \
+guards. A hang is the third, and the subtle version of it is not the script's fault: \
+if either captured pipe stops being drained, the child blocks writing into a \
+full buffer and a script that exited in seconds is reported as a 15-minute \
+timeout. Code review found exactly that — one non-UTF-8 byte retired the stdout \
+reader — so the two pipe-drain assertions are the load-bearing ones here, not \
+the `sleep 60` case."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos", "windows"]
+coverage_notes = """
+Split coverage, and the halves are not equivalent. The bounded-execution unit \
+tests live in `oximux-worktree-ops`, whose lib tests run on macOS \
+(`--workspace --all-targets`) and Windows (`--workspace --lib`) but not on \
+Linux, which never builds this crate. The end-to-end ordering and rollback \
+arms live under `apps/desktop/tests/` and run on macOS only.
+
+So Windows proves the timeout, the closed stdin, and the non-zero exit; it \
+proves nothing about the order, the rollback, or the opt-in default. Closing \
+the Linux half means adding `oximux-worktree-ops` to the Linux job; closing the \
+Windows half means an integration harness that does not depend on the desktop \
+test target.
+
+Both `run_setup_bounded` and `run_cleanup_before_remove` shell out via `sh -lc` \
+on every platform, which resolves on the Windows runner through Git Bash. The \
+evidence for that is `a_non_zero_exit_is_reported_as_a_failure`, which asserts \
+a specific exit code and therefore cannot pass if the shell never ran.
+
+An earlier draft of this row cited the *cleanup* tests instead. That was a \
+vacuous claim of exactly the kind this ledger exists to reject: all three pass \
+identically when the spawn fails instantly, because none of them asserts \
+anything the shell produced. It is recorded here rather than quietly corrected, \
+since the mistake is the argument for the rule.
+
+Note this is a dependency on the runner image, not on Windows. A Windows host \
+without `sh` on PATH fails these tests rather than skipping them — and, per \
+`SetupOutcome::FailedToStart`, fails worktree creation for any project with \
+`auto_setup` on."""
+test_files = [
+  "crates/worktree-ops/src/setup.rs",
+  "apps/desktop/tests/workspace_create_rollback.rs",
+]
+assertions = [
+  "a_hanging_script_times_out_and_is_killed",
+  "a_child_writing_past_the_pipe_buffer_still_completes",
+  "non_utf8_output_does_not_abandon_the_pipe",
+  "a_script_reading_stdin_fails_fast_rather_than_hanging",
+  "a_non_zero_exit_is_reported_as_a_failure",
+  "output_before_a_timeout_is_kept",
+  "included_files_are_present_before_the_setup_script_runs",
+  "a_failing_setup_script_is_not_run_when_the_project_did_not_opt_in",
+  "an_include_pattern_matching_nothing_does_not_fail_creation",
+]
+
+[[gate]]
+id = "worktree.include-copy-cannot-write-outside-the-worktree"
+title = "The .oximuxinclude copy is a containment boundary"
+status = "stable"
+owner = "worktree-ops"
+invariant = """
+Copying `.oximuxinclude` files into a new worktree never reads through a source \
+symlink, never writes through a symlink in the destination path, never \
+overwrites a file git already checked out, and never resolves a pattern outside \
+the project root."""
+oracle = """
+Each clause fails silently and looks like success, which is why they are tested \
+one at a time rather than by a happy-path copy. A dereferenced source symlink \
+produces a *correct-looking* file in the worktree whose content came from \
+outside the project. A destination symlink produces a worktree that appears to \
+be missing the file, because the write landed wherever the link pointed — the \
+assertion for that clause checks the outside directory is still empty, not just \
+that the copy was skipped.
+
+Overwriting a tracked file is the quiet one: the worktree looks right and \
+builds, but a committed config has been replaced by a developer's local copy, \
+and git reports the diff as their edit."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+The four containment clauses are asserted with `#[cfg(unix)]` tests, so on \
+Windows they compile to nothing — `--workspace --lib` runs this crate there and \
+still proves none of them. This is a real gap and not a small one: Windows has \
+its own link types (junctions, and symlinks that need a privilege or developer \
+mode), and the reparse-point behavior of `symlink_metadata` is exactly the kind \
+of thing that differs. Linux runs nothing from this crate at all.
+
+Closing it needs `std::os::windows::fs::symlink_dir` fixtures guarded on the \
+runner actually being able to create one, which is a Windows-CI question before \
+it is a test question. Until then the clause is enforced by code review on that \
+platform, which is what this row exists to say out loud."""
+test_files = ["crates/worktree-ops/src/include.rs"]
+assertions = [
+  "clause2_tracked_file_wins_and_the_skip_is_reported",
+  "clause3_a_source_symlink_is_skipped_not_dereferenced",
+  "clause3_a_symlink_out_of_the_project_copies_nothing",
+  "clause4_a_symlinked_target_directory_is_refused",
+  "a_pattern_leaving_the_project_root_is_refused",
+  "dot_git_is_never_copied_even_when_a_pattern_names_it",
 ]
 
 # ---------------------------------------------------------------------------

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -821,6 +821,66 @@ assertions = [
 ]
 
 [[gate]]
+id = "agent.retry-survives-a-restart-without-surprising"
+title = "A held turn comes back armed, and a slept-through one does not"
+status = "stable"
+owner = "desktop"
+invariant = """
+A retry armed when the app quit is rebuilt on restore with the attempts it had \
+already spent, and is dropped rather than fired when its reset passed while the \
+app was closed."""
+oracle = """
+Restore a saved retry on each side of the grace boundary and assert the near \
+one arms while the far one does not; assert the attempt count comes back with \
+it. Both halves are load-bearing in opposite directions, which is why neither \
+alone is the gate. Without the rebuild, a five-hour window — the case the \
+feature exists for — outlives the app session that hit it and nothing resumes. \
+Without the drop, an app opened the next morning sends a turn the user last saw \
+the night before, unattended and against a limit that expired without them. \
+Without the attempt count, the cap of four counts only the attempts made since \
+the last launch, so a chat that relaunches between attempts can exceed it while \
+no single session ever shows a fifth."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only, and for a sharper reason than the usual one: retry exists **only in \
+the desktop app**. `oximux serve` — the host the CLI actually talks to — has no \
+retry at all, so there is no second platform's implementation to cover here. \
+The Windows job runs `-p oximux-app --lib`, which does include these tests; it \
+is listed uncovered because that has not been observed for this gate, not \
+because the code is macOS-specific. \
+\
+What is NOT covered: the timer firing. These assert the arm/drop decision and \
+the persisted round trip, not that a rebuilt countdown reaches zero and re-sends \
+— that needs a real held turn, which cannot be provoked on demand. \
+Mutation-checked: resetting the attempt count, widening the grace to thirty \
+days, dropping either dirty-mark, and leaving the dormant mark set each fail \
+exactly one of these, and a different one each time. \
+\
+The back-compat case is derived from the struct (serialize, delete the one key, \
+reload) rather than pinned as a hand-written literal, so it cannot drift out of \
+date and start passing for the wrong reason. Checked once against the 122 real \
+blobs in the author's own database: 120 load, and the 2 that do not fail on a \
+pre-existing `ThreadEntry::User` shape change unrelated to this field."""
+test_files = [
+  "apps/desktop/src/shell/agent_chat/retry.rs",
+  "apps/desktop/src/session_restore/persisted_chat.rs",
+]
+assertions = [
+  "a_retry_whose_reset_is_still_ahead_comes_back_armed",
+  "a_retry_the_app_slept_through_is_dropped",
+  "a_reset_that_passed_moments_ago_still_fires",
+  "a_disabled_setting_refuses_the_rebuild",
+  "a_wait_longer_than_the_current_setting_is_refused",
+  "restoring_a_retry_leaves_the_blob_clean",
+  "arming_a_retry_marks_the_blob_for_saving",
+  "a_cancelled_retry_leaves_nothing_in_the_blob",
+  "a_retry_firing_before_first_render_consumes_the_dormant_mark",
+  "blobs_predating_pending_retry_still_load",
+  "an_armed_retry_round_trips_through_the_blob",
+]
+
+[[gate]]
 id = "thread.transcript-invariants-hold-for-every-agent"
 title = "No agent leaves a spinner running or a row duplicated"
 status = "stable"

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -819,3 +819,106 @@ assertions = [
   "rate_limit_fixture_decodes_every_status",
   "only_known_window_kinds_are_waitable",
 ]
+
+[[gate]]
+id = "thread.transcript-invariants-hold-for-every-agent"
+title = "No agent leaves a spinner running or a row duplicated"
+status = "stable"
+owner = "agent-core"
+invariant = """
+Once a turn has settled, no tool row is still rendering as in-flight; no two \
+rows share a tool-call id; and no assistant row folds to nothing. These hold \
+for every agent, checked by one oracle rather than per-mapper conventions."""
+oracle = """
+Fold each captured fixture with the real decoder and the real fold, then run \
+the shared checker over the result. The failure this catches is the one nine \
+rounds of render-fidelity work kept rediscovering: a rule that holds in four \
+mappers and quietly fails in the fifth. It is invisible to a type checker and \
+to any test asserting only that events were produced — a card simply spins \
+forever, and the turn looks hung rather than finished. \
+\
+Verified non-vacuous by mutation: making the Codex mapper never terminalize an \
+item is caught here, naming the row and the rule."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only, for the reason recorded on the retry gates: `oximux-agents` and \
+`oximux-agent-core` are `cargo check`ed on Linux (ci.yml:216-217) and absent \
+from the Windows test list (ci.yml:648-654), so only the macOS `--workspace \
+--all-targets` job runs them. Pure fold logic with no clock, filesystem or \
+process, so there is no platform-specific behaviour to miss. \
+\
+**Covers Claude, Codex, Pi and omp — not ACP**, which has no committed fixture. \
+That is a real hole, not an oversight: the checker is wired to run per agent, so \
+adding an ACP capture is the whole cost of closing it. \
+\
+The oracle itself has been wrong once and the mistake is worth keeping: it first \
+derived "turn settled" from `!turn_active` and reported a violation against a \
+one-line fixture that never opened a turn. An idle thread also reports no active \
+turn. "Settled" now means a `TurnEnded` was observed."""
+test_files = [
+  "crates/agent-core/src/thread/invariants.rs",
+  "crates/agent-core/tests/transcript_snapshots.rs",
+  "crates/agents/src/thread/codex/map.rs",
+  "crates/agents/src/thread/pi/map.rs",
+  "crates/agents/src/thread/omp/map.rs",
+]
+assertions = [
+  "every_claude_fixture_satisfies_the_transcript_invariants",
+  "every_captured_turn_satisfies_the_transcript_invariants",
+  "a_row_still_in_flight_after_the_turn_settled_is_a_violation",
+  "an_in_flight_row_during_a_live_turn_is_not_a_violation",
+  "two_rows_sharing_a_tool_call_id_are_a_violation",
+  "rows_without_an_id_are_not_duplicates_of_each_other",
+]
+
+[[gate]]
+id = "thread.rendered-transcript-is-pinned"
+title = "A mapper change that alters what the user sees fails a test"
+status = "stable"
+owner = "agent-core"
+invariant = """
+Every committed fixture folds to a byte-identical committed transcript, so a \
+change to any mapper that alters rendered output has to be noticed and named \
+rather than discovered later in the UI."""
+oracle = """
+Decode each fixture, fold it, and compare the result against a committed \
+snapshot. Pins the *folded transcript* rather than the event stream on purpose: \
+event coalescing is a legitimate future change that would rewrite the stream \
+without changing a pixel, and pinning the stream would report that as a \
+regression. \
+\
+Verified non-vacuous by mutation twice, and the first attempt FAILED: a mutant \
+dropping `usage` from every `TurnEnded` passed all thirteen snapshots because \
+the projection omitted `usage`, which renders in the transcript footer. A \
+snapshot is only a net over the fields it projects. A second mutant prefixing \
+Codex tool names fails Codex's snapshot alone, so the pins are per-agent rather \
+than all keying on one shared path."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only, same CI reason as the invariants gate above. \
+\
+13 fixtures: 7 Claude, 2 each Codex/Pi/omp. Note the plan this came from claimed \
+Codex/Pi/omp were "barely" covered by fixtures; there are in fact two committed \
+captures each, and ACP that has none. \
+\
+Snapshots are canonicalised (object keys sorted, image payloads replaced by a \
+length+hash marker). Both matter: `serde_json` preserves insertion order when \
+anything in the build graph enables `preserve_order` and sorts otherwise, so \
+before canonicalisation the same fixture serialised differently depending on \
+whether the crate was built alone or in the workspace — the crate suite passed \
+while the workspace suite failed. Sorting makes the snapshot a property of the \
+transcript rather than of the build graph."""
+test_files = [
+  "crates/agent-core/src/thread/snapshot.rs",
+  "crates/agent-core/tests/transcript_snapshots.rs",
+  "crates/agents/src/thread/codex/map.rs",
+  "crates/agents/src/thread/pi/map.rs",
+  "crates/agents/src/thread/omp/map.rs",
+]
+assertions = [
+  "every_claude_fixture_renders_the_pinned_transcript",
+  "every_captured_turn_renders_the_pinned_transcript",
+  "every_fixture_decodes_to_at_least_one_event",
+]

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -697,3 +697,125 @@ assertions = [
   "a_new_client_runs_a_team_on_an_old_host",
   "a_new_client_schedules_on_an_old_host",
 ]
+
+[[gate]]
+id = "agent.rate-limit-retry-never-spends"
+title = "A retried turn waits for a window and never for money"
+status = "stable"
+owner = "agents"
+invariant = """
+A turn that fails on a provider usage window is rescheduled at that window's \
+reported reset; a turn that fails because the account is billing past its plan \
+(an overage), on an unrecognised limit kind, or on a limit whose reset the \
+provider withheld, is never rescheduled at all. The cap is four attempts and \
+a user-stopped turn is never retried."""
+oracle = """
+Drive the classifier with each `rateLimitType` the provider's own schema \
+defines and assert the class; then drive the pure policy and assert a window \
+schedules past its reset, an overage and an unknown kind schedule nothing, and \
+the fifth attempt schedules nothing. The failure this catches is not a crash — \
+a mis-classified overage retries silently and spends the user's money, which \
+surfaces on a bill rather than in a log."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+**macOS only, and the first draft of this row claimed all three.** The claim \
+was wrong in the way this ledger exists to catch: `oximux-agents` appears in \
+the Linux job only under `cargo check --all-targets` (ci.yml:216-217), which \
+compiles the tests without running them, and it is absent from the Windows \
+test list entirely (ci.yml:648-654 names six unrelated crates). Reading either \
+job's crate list rather than trusting the memory of it is what corrected this. \
+\
+The gap is low-risk and deliberately not closed here: the classifier and policy \
+are pure arithmetic over data with no clock, filesystem, process or path in \
+them, so there is no plausible platform-specific divergence. Adding \
+`-p oximux-agents` to the Linux test step would close it for the cost of one \
+line, and is worth doing the next time that job is touched. \
+\
+The vocabulary is the load-bearing part and is NOT captured from a live rate \
+limit — a real one cannot be provoked on demand. It is read from the shipped \
+`claude` CLI's own zod schema (2.1.261), which defines `rateLimitType` as \
+`five_hour | seven_day | seven_day_opus | seven_day_sonnet | \
+seven_day_overage_included | overage` and derives `retry-after` from \
+`resetsAt` in **seconds**. If the provider adds a kind, the unknown-kind \
+assertion is what keeps it from being retried by accident."""
+test_files = [
+  "crates/agents/src/retry/classify.rs",
+  "crates/agents/src/retry/mod.rs",
+  "crates/agents/tests/retry_from_stream.rs",
+]
+assertions = [
+  "an_overage_on_the_wire_schedules_nothing",
+  "a_closed_window_on_the_wire_becomes_a_wake_time_past_its_reset",
+  "an_overage_is_spend_and_is_never_retried",
+  "an_unknown_limit_kind_is_not_retried",
+  "a_known_window_without_a_reset_is_not_retried",
+  "a_closed_window_with_a_reset_is_waitable",
+  "spend_and_other_are_never_scheduled",
+  "the_cap_is_four_attempts",
+  "a_window_is_scheduled_past_its_reset_never_before",
+]
+
+[[gate]]
+id = "agent.retry-jitter-spreads-the-herd"
+title = "Threads sharing one reset do not wake together"
+status = "stable"
+owner = "agents"
+invariant = """
+Every thread scheduling against the same window reset gets its own wake time, \
+spread across the jitter span."""
+oracle = """
+Schedule twenty threads against one reset and assert twenty DISTINCT wake \
+times whose spread exceeds thirty seconds. Asserting only that jitter is \
+non-zero would pass an implementation returning the same constant offset for \
+every thread — which is precisely the broken case, since every thread on one \
+account sees the same reset and would re-limit the account in the same second \
+it reopened."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only, for the same reason as `agent.rate-limit-retry-never-spends`: \
+`oximux-agents` is checked but not tested on Linux, and not named at all in \
+the Windows test step. Pure caller-seeded arithmetic, so the distribution is \
+asserted deterministically and would behave identically anywhere it ran. \
+\
+The spread assertion, not the distinctness one, is what would fail a weak mix \
+such as `seed % span` — twenty consecutive seeds through that would still be \
+twenty distinct values, all inside twenty milliseconds."""
+test_files = ["crates/agents/src/retry/mod.rs"]
+assertions = [
+  "twenty_threads_against_one_reset_get_twenty_distinct_wake_times",
+  "jitter_stays_inside_its_span",
+]
+
+[[gate]]
+id = "agent.rate-limit-reset-units"
+title = "The provider's reset seconds become milliseconds exactly once"
+status = "stable"
+owner = "agent-core"
+invariant = """
+`rate_limit_event.resetsAt` arrives in unix seconds and is stored as unix \
+milliseconds, matching every other reset time in the app."""
+oracle = """
+Decode a line with a known `resetsAt` and assert the stored value is exactly \
+one thousand times it. This is the one decoding mistake in the retry path that \
+fails silently in both directions: unconverted, every reset looks like 1970 and \
+fires instantly; double-converted, it lands fifty thousand years out and the \
+turn is never retried. Neither reads as a units bug from the UI."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only: `oximux-agent-core` is `cargo check`ed on Linux (ci.yml:216) and \
+absent from the Windows test list, so only the macOS `--workspace \
+--all-targets` run executes it. \
+\
+The unit is asserted against a literal (`1_788_462_000` in, \
+`1_788_462_000_000` out) rather than against a round-trip through the same \
+constant, so a wrong multiplier cannot cancel itself out — which a \
+`secs * K / K` style assertion would happily let it do."""
+test_files = ["crates/agent-core/src/thread/stream_json.rs"]
+assertions = [
+  "resets_at_is_converted_from_seconds_to_milliseconds",
+  "rate_limit_fixture_decodes_every_status",
+  "only_known_window_kinds_are_waitable",
+]

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -827,8 +827,10 @@ status = "stable"
 owner = "agent-core"
 invariant = """
 Once a turn has settled, no tool row is still rendering as in-flight; no two \
-rows share a tool-call id; and no assistant row folds to nothing. These hold \
-for every agent, checked by one oracle rather than per-mapper conventions."""
+rows share a tool-call id; and no row renders as an empty shell — an assistant \
+bubble with neither text nor thinking, a compaction divider with no summary, or \
+a turn-diff card listing no files. These hold for every agent, checked by one \
+oracle rather than by per-mapper convention."""
 oracle = """
 Fold each captured fixture with the real decoder and the real fold, then run \
 the shared checker over the result. The failure this catches is the one nine \
@@ -848,9 +850,14 @@ from the Windows test list (ci.yml:648-654), so only the macOS `--workspace \
 --all-targets` job runs them. Pure fold logic with no clock, filesystem or \
 process, so there is no platform-specific behaviour to miss. \
 \
-**Covers Claude, Codex, Pi and omp — not ACP**, which has no committed fixture. \
-That is a real hole, not an oversight: the checker is wired to run per agent, so \
-adding an ACP capture is the whole cost of closing it. \
+Covers all five agents, but **not equally**. Claude, Codex, Pi and omp run \
+against captured wire bytes; **ACP runs against a synthetic turn** built from \
+typed protocol values, because no ACP capture is committed and its tests were \
+never fixture-driven. Synthetic is weaker evidence than a capture and is named \
+here rather than blended into the same claim. ACP therefore also carries a \
+negative control — the same turn with its tool left in flight must be caught — \
+so the row asserts the oracle is wired to that agent, not merely that some \
+transcript passes. \
 \
 The oracle itself has been wrong once and the mistake is worth keeping: it first \
 derived "turn settled" from `!turn_active` and reported a violation against a \
@@ -862,6 +869,7 @@ test_files = [
   "crates/agents/src/thread/codex/map.rs",
   "crates/agents/src/thread/pi/map.rs",
   "crates/agents/src/thread/omp/map.rs",
+  "crates/agents/src/thread/acp/map.rs",
 ]
 assertions = [
   "every_claude_fixture_satisfies_the_transcript_invariants",
@@ -870,6 +878,10 @@ assertions = [
   "an_in_flight_row_during_a_live_turn_is_not_a_violation",
   "two_rows_sharing_a_tool_call_id_are_a_violation",
   "rows_without_an_id_are_not_duplicates_of_each_other",
+  "a_settled_acp_turn_satisfies_the_transcript_invariants",
+  "an_acp_turn_that_leaves_a_tool_running_is_caught",
+  "a_compaction_divider_with_no_summary_is_a_violation",
+  "a_turn_diff_card_listing_no_files_is_a_violation",
 ]
 
 [[gate]]

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -850,9 +850,11 @@ The Windows job runs `-p oximux-app --lib`, which does include these tests; it \
 is listed uncovered because that has not been observed for this gate, not \
 because the code is macOS-specific. \
 \
-What is NOT covered: the timer firing. These assert the arm/drop decision and \
-the persisted round trip, not that a rebuilt countdown reaches zero and re-sends \
-— that needs a real held turn, which cannot be provoked on demand. \
+What is NOT covered: the retry actually re-sending. A GUI pass on 2026-09-06 \
+did observe the rebuilt card, its live countdown (39m → 38m) and the restored \
+attempt number, plus a slept-through reset being dropped — but the countdown was \
+cancelled rather than allowed to fire, because firing spends against a live \
+provider and appends a real turn to a real conversation. \
 Mutation-checked: resetting the attempt count, widening the grace to thirty \
 days, dropping either dirty-mark, and leaving the dormant mark set each fail \
 exactly one of these, and a different one each time. \

--- a/crates/agent-core/Cargo.toml
+++ b/crates/agent-core/Cargo.toml
@@ -12,6 +12,12 @@ rust-version.workspace = true
 # agent-client-protocol / gpui deps. Both the desktop `oximux-agents` crate and
 # the phone's Rust core (`mobile-core`/`remote-session`) depend on this, so the
 # fold that renders a transcript is shared verbatim across desktop and mobile.
+[features]
+# Transcript snapshot harness (`thread::snapshot`). Test-only: `oximux-agents`
+# enables it from dev-dependencies so both crates pin transcripts with one
+# harness instead of growing two. Off in every shipping build.
+test-support = []
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/agent-core/src/thread/event.rs
+++ b/crates/agent-core/src/thread/event.rs
@@ -112,6 +112,61 @@ pub struct McpServerStatus {
     pub status: String,
 }
 
+/// The provider's current rate-limit state, as reported on its own wire line
+/// rather than as part of a turn's result.
+///
+/// Vocabulary and units are taken from the shipped Claude CLI's own schema
+/// (2.1.261), not inferred from an error message: `status` is one of
+/// `allowed | allowed_warning | rejected`, and `rateLimitType` one of
+/// `five_hour | seven_day | seven_day_opus | seven_day_sonnet |
+/// seven_day_overage_included | overage`.
+///
+/// Both tokens are kept verbatim rather than parsed into enums. The provider
+/// adds window kinds (the two `overage` variants are recent), and a value this
+/// build has never heard of must degrade to "unknown, do not retry" instead of
+/// failing to deserialize a persisted transcript written by a newer build.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct RateLimitInfo {
+    /// Verbatim `status` token. `rejected` is the only value that means a
+    /// request was actually refused.
+    pub status: String,
+    /// When the limiting window resets, unix **milliseconds**.
+    ///
+    /// The wire reports `resetsAt` in unix **seconds** — the CLI derives its own
+    /// `retry-after` header as `resetsAt - now_seconds`. The decoder converts on
+    /// the way in so every reset time inside OxiMux is milliseconds, matching
+    /// [`crate::thread::event`]'s neighbours and `UsageWindow::resets_at_ms`.
+    /// Getting this wrong does not fail loudly — it schedules a retry either
+    /// immediately or tens of thousands of years out.
+    pub resets_at_ms: Option<i64>,
+    /// Verbatim `rateLimitType` token, when the provider named one.
+    pub limit_type: Option<String>,
+    /// Percentage of the limiting window consumed, when reported.
+    pub utilization: Option<f64>,
+}
+
+impl RateLimitInfo {
+    /// Whether the provider is currently refusing requests.
+    pub fn is_rejected(&self) -> bool {
+        self.status == "rejected"
+    }
+
+    /// Whether this rejection is one that waiting for the reset actually
+    /// clears.
+    ///
+    /// The two `overage` kinds are deliberately excluded. Overage means the
+    /// account has passed its plan allowance and further requests are billed —
+    /// so a retry there is not "wait for a window to reopen", it is spending the
+    /// user's money without asking. An unrecognised kind is excluded for the
+    /// same reason: the safe default is to surface the error, not to retry it.
+    pub fn is_waitable_window(&self) -> bool {
+        matches!(
+            self.limit_type.as_deref(),
+            Some("five_hour" | "seven_day" | "seven_day_opus" | "seven_day_sonnet")
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ThreadEvent {
     /// Session bootstrap (`system/init`).
@@ -454,6 +509,32 @@ pub enum ThreadEvent {
     /// attempt that fails leaves the transcript alone, matching what the desktop
     /// shows itself.
     Rewound { ordinal: usize },
+    /// The provider's rate-limit state changed (Claude `rate_limit_event`).
+    ///
+    /// Arrives on its own line whenever a window's rounded utilization or reset
+    /// time moves — including the moment a window starts refusing requests — so
+    /// it is *not* tied to a turn and carries no result of its own. The fold
+    /// keeps the latest reading on the thread; the retry engine reads it when a
+    /// turn fails, which is what lets a rate-limited turn be told apart from an
+    /// ordinary error without matching on error prose.
+    RateLimitUpdated(RateLimitInfo),
+    /// Typed detail for the failure the **immediately following**
+    /// `TurnEnded { is_error: true }` reports.
+    ///
+    /// Emitted only when the backend gave something machine-readable to carry —
+    /// the CLI's `api_error_status` and `terminal_reason` — so an overloaded
+    /// provider can be told from a bad request without matching on the error
+    /// text a provider is free to reword. Follows the `SessionResumeStale`
+    /// precedent of riding just ahead of the settle event rather than widening
+    /// `TurnEnded`, whose shape 48 construction sites depend on.
+    TurnFailed {
+        /// HTTP status the backend reported (`api_error_status`).
+        status: Option<u16>,
+        /// Verbatim `terminal_reason` token (`api_error`, `aborted_streaming`,
+        /// …). Kept as text: it is matched on for the cases we know and
+        /// displayed for the ones we do not.
+        terminal_reason: Option<String>,
+    },
 }
 
 impl ThreadEvent {

--- a/crates/agent-core/src/thread/invariants.rs
+++ b/crates/agent-core/src/thread/invariants.rs
@@ -34,6 +34,19 @@ pub enum Violation {
     /// `ToolCallStarted` opened a fresh card instead of updating the open one,
     /// so the user sees the same call twice, usually with one stuck pending.
     DuplicateToolCallId { first: usize, second: usize, id: String },
+    /// A compaction divider with no summary text.
+    ///
+    /// The divider renders as a centered rule with its summary; with an empty
+    /// summary the user gets a bare line across the transcript and no
+    /// indication that history was truncated behind it.
+    EmptyCompactionDivider { index: usize },
+    /// A turn-diff card listing no files.
+    ///
+    /// The card exists to say what a turn changed, and is only meant to be
+    /// pushed when a turn changed something. With no files it renders as an
+    /// empty card claiming a turn edited nothing — worse than absent, because
+    /// it asserts something false.
+    EmptyTurnDiffCard { index: usize },
     /// An assistant row folded to nothing at all.
     ///
     /// An empty bubble renders as a blank gap. It usually means text was
@@ -54,6 +67,12 @@ impl std::fmt::Display for Violation {
             }
             Self::EmptyAssistantRow { index } => {
                 write!(f, "entry {index}: assistant row has neither text nor thinking")
+            }
+            Self::EmptyCompactionDivider { index } => {
+                write!(f, "entry {index}: compaction divider carries no summary")
+            }
+            Self::EmptyTurnDiffCard { index } => {
+                write!(f, "entry {index}: turn-diff card lists no files")
             }
         }
     }
@@ -129,6 +148,12 @@ pub fn check(thread: &ChatThread, turn_settled: bool) -> Vec<Violation> {
             }
             ThreadEntry::Assistant(msg) if msg.is_empty() => {
                 out.push(Violation::EmptyAssistantRow { index });
+            }
+            ThreadEntry::ContextCompaction { summary } if summary.trim().is_empty() => {
+                out.push(Violation::EmptyCompactionDivider { index });
+            }
+            ThreadEntry::TurnDiff { files, .. } if files.is_empty() => {
+                out.push(Violation::EmptyTurnDiffCard { index });
             }
             _ => {}
         }
@@ -232,6 +257,24 @@ mod tests {
         let msg = AssistantMessage { text: String::new(), thinking: "hmm".into() };
         let t = thread(vec![ThreadEntry::Assistant(msg)]);
         assert_eq!(check(&t, true), Vec::new());
+    }
+
+    #[test]
+    fn a_compaction_divider_with_no_summary_is_a_violation() {
+        let t = thread(vec![ThreadEntry::ContextCompaction { summary: "   ".into() }]);
+        assert_eq!(check(&t, true), vec![Violation::EmptyCompactionDivider { index: 0 }]);
+    }
+
+    #[test]
+    fn a_compaction_divider_with_a_summary_is_fine() {
+        let t = thread(vec![ThreadEntry::ContextCompaction { summary: "older messages".into() }]);
+        assert_eq!(check(&t, true), Vec::new());
+    }
+
+    #[test]
+    fn a_turn_diff_card_listing_no_files_is_a_violation() {
+        let t = thread(vec![ThreadEntry::TurnDiff { files: Vec::new(), diff: None }]);
+        assert_eq!(check(&t, true), vec![Violation::EmptyTurnDiffCard { index: 0 }]);
     }
 
     /// Every violation is reported, not just the first — a mapper that breaks

--- a/crates/agent-core/src/thread/invariants.rs
+++ b/crates/agent-core/src/thread/invariants.rs
@@ -1,0 +1,249 @@
+//! Transcript invariants every agent must satisfy, checked against the fold.
+//!
+//! Nine rounds of render-fidelity work went into the agent mappers, and the
+//! recurring cause was not that any one mapper was wrong — it was that each
+//! decides lifecycle for itself, so the same rule holds in four mappers and
+//! quietly fails in the fifth. Writing the rules down once, and running them
+//! against every agent's captured fixtures, turns that class from "someone
+//! notices in the UI months later" into a test failure.
+//!
+//! These are properties of the **folded transcript**, deliberately not of the
+//! event stream. A mapper is free to emit whatever sequence its dialect implies;
+//! what it may not do is leave the user looking at something incoherent.
+//!
+//! Behind `test-support`, like [`super::snapshot`] — this is a test oracle, not
+//! shipping code.
+
+use super::entry::ThreadEntry;
+use super::state::ChatThread;
+use super::tool_call::ToolCallStatus;
+
+/// A transcript state no agent should ever produce.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Violation {
+    /// A tool row is still rendering as in-flight after the turn settled.
+    ///
+    /// This is the "terminalize before the terminal event" rule. A spinner that
+    /// never resolves is the single most visible transcript bug: the turn is
+    /// over, the agent has moved on, and one card spins forever with no way for
+    /// the user to tell whether it succeeded.
+    TransientRowAfterTurnSettled { index: usize, id: String, name: String, status: String },
+    /// Two rows claim the same tool-call id.
+    ///
+    /// Rows are deduped by identity. Two rows for one id means a second
+    /// `ToolCallStarted` opened a fresh card instead of updating the open one,
+    /// so the user sees the same call twice, usually with one stuck pending.
+    DuplicateToolCallId { first: usize, second: usize, id: String },
+    /// An assistant row folded to nothing at all.
+    ///
+    /// An empty bubble renders as a blank gap. It usually means text was
+    /// accumulated under one key and settled under another, so the visible text
+    /// went to a row that no longer exists.
+    EmptyAssistantRow { index: usize },
+}
+
+impl std::fmt::Display for Violation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TransientRowAfterTurnSettled { index, id, name, status } => write!(
+                f,
+                "entry {index}: tool `{name}` (id {id}) is still {status} after the turn settled"
+            ),
+            Self::DuplicateToolCallId { first, second, id } => {
+                write!(f, "entries {first} and {second} share tool-call id {id}")
+            }
+            Self::EmptyAssistantRow { index } => {
+                write!(f, "entry {index}: assistant row has neither text nor thinking")
+            }
+        }
+    }
+}
+
+/// Whether a status still renders as in-flight.
+///
+/// `WaitingForConfirmation` and `AwaitingAnswer` are deliberately included: both
+/// render as a card awaiting the *user*, and a settled turn means nobody is
+/// going to answer them. Leaving one open after the turn ends is the same
+/// dead-end as a spinner.
+fn is_transient(status: &ToolCallStatus) -> bool {
+    matches!(
+        status,
+        ToolCallStatus::Pending
+            | ToolCallStatus::InProgress
+            | ToolCallStatus::WaitingForConfirmation(_)
+            | ToolCallStatus::AwaitingAnswer(_)
+    )
+}
+
+fn status_name(status: &ToolCallStatus) -> &'static str {
+    match status {
+        ToolCallStatus::Pending => "pending",
+        ToolCallStatus::InProgress => "in-progress",
+        ToolCallStatus::WaitingForConfirmation(_) => "awaiting confirmation",
+        ToolCallStatus::AwaitingAnswer(_) => "awaiting an answer",
+        ToolCallStatus::Completed => "completed",
+        ToolCallStatus::Failed(_) => "failed",
+        ToolCallStatus::Rejected => "rejected",
+        ToolCallStatus::Canceled => "canceled",
+    }
+}
+
+/// Check a folded transcript, returning every violation found.
+///
+/// `turn_settled` says whether a turn actually ran and finished — the
+/// transient-row rule only applies once nothing more is coming.
+///
+/// Derive it from having *observed a `TurnEnded`*, never from
+/// `!thread.turn_active`. An idle thread also has `turn_active == false`, so a
+/// capture that never opens a turn (a bare permission request, say) would be
+/// read as "settled" and every legitimately-open card reported as a violation.
+/// That mistake produced this checker's first failure, against a one-line
+/// fixture holding nothing but a `can_use_tool` request.
+pub fn check(thread: &ChatThread, turn_settled: bool) -> Vec<Violation> {
+    let mut out = Vec::new();
+    let mut seen_ids: Vec<(usize, &str)> = Vec::new();
+
+    for (index, entry) in thread.entries.iter().enumerate() {
+        match entry {
+            ThreadEntry::ToolCall(call) => {
+                if turn_settled && is_transient(&call.status) {
+                    out.push(Violation::TransientRowAfterTurnSettled {
+                        index,
+                        id: call.id.clone(),
+                        name: call.name.clone(),
+                        status: status_name(&call.status).to_string(),
+                    });
+                }
+                // An empty id is a legitimate "this dialect has no join key"
+                // marker, not an identity — several would collide spuriously.
+                if !call.id.is_empty()
+                    && let Some((first, _)) = seen_ids.iter().find(|(_, id)| *id == call.id)
+                {
+                    out.push(Violation::DuplicateToolCallId {
+                        first: *first,
+                        second: index,
+                        id: call.id.clone(),
+                    });
+                }
+                seen_ids.push((index, &call.id));
+            }
+            ThreadEntry::Assistant(msg) if msg.is_empty() => {
+                out.push(Violation::EmptyAssistantRow { index });
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Panic with every violation, naming `label` (the fixture) so a failure says
+/// which capture broke rather than only which rule.
+pub fn assert_holds(label: &str, thread: &ChatThread, turn_settled: bool) {
+    let violations = check(thread, turn_settled);
+    assert!(
+        violations.is_empty(),
+        "{label}: {} transcript invariant violation(s)\n{}",
+        violations.len(),
+        violations.iter().map(|v| format!("  - {v}")).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::thread::entry::AssistantMessage;
+    use crate::thread::tool_call::ToolCall;
+    use serde_json::json;
+
+    fn call(id: &str, status: ToolCallStatus) -> ThreadEntry {
+        let mut c = ToolCall::new(id, "Bash", json!({}));
+        c.status = status;
+        ThreadEntry::ToolCall(c)
+    }
+
+    fn thread(entries: Vec<ThreadEntry>) -> ChatThread {
+        // Built by mutation rather than a struct literal: `ChatThread` keeps
+        // its streaming cursors private, and this checker only reads `entries`.
+        let mut t = ChatThread::default();
+        t.entries = entries;
+        t
+    }
+
+    #[test]
+    fn a_settled_turn_with_only_terminal_rows_is_clean() {
+        let t = thread(vec![
+            call("a", ToolCallStatus::Completed),
+            call("b", ToolCallStatus::Failed("boom".into())),
+            call("c", ToolCallStatus::Rejected),
+            call("d", ToolCallStatus::Canceled),
+        ]);
+        assert_eq!(check(&t, true), Vec::new());
+    }
+
+    #[test]
+    fn a_row_still_in_flight_after_the_turn_settled_is_a_violation() {
+        for status in [ToolCallStatus::Pending, ToolCallStatus::InProgress] {
+            let t = thread(vec![call("a", status)]);
+            assert_eq!(check(&t, true).len(), 1, "a spinner must not survive the turn");
+        }
+    }
+
+    /// The same rows are fine while the turn is still running — that is just a
+    /// tool that has not finished yet.
+    #[test]
+    fn an_in_flight_row_during_a_live_turn_is_not_a_violation() {
+        let t = thread(vec![call("a", ToolCallStatus::InProgress)]);
+        assert_eq!(check(&t, false), Vec::new());
+    }
+
+    #[test]
+    fn two_rows_sharing_a_tool_call_id_are_a_violation() {
+        let t = thread(vec![
+            call("dup", ToolCallStatus::Completed),
+            call("dup", ToolCallStatus::Completed),
+        ]);
+        assert_eq!(
+            check(&t, true),
+            vec![Violation::DuplicateToolCallId { first: 0, second: 1, id: "dup".into() }]
+        );
+    }
+
+    /// A dialect with no join key leaves the id empty. Several such rows are
+    /// normal and must not read as one row duplicated — treating "unknown" as
+    /// an identity is how a real duplicate gets buried in false positives.
+    #[test]
+    fn rows_without_an_id_are_not_duplicates_of_each_other() {
+        let t = thread(vec![
+            call("", ToolCallStatus::Completed),
+            call("", ToolCallStatus::Completed),
+            call("", ToolCallStatus::Completed),
+        ]);
+        assert_eq!(check(&t, true), Vec::new());
+    }
+
+    #[test]
+    fn an_assistant_row_with_no_text_and_no_thinking_is_a_violation() {
+        let t = thread(vec![ThreadEntry::Assistant(AssistantMessage::default())]);
+        assert_eq!(check(&t, true), vec![Violation::EmptyAssistantRow { index: 0 }]);
+    }
+
+    #[test]
+    fn an_assistant_row_holding_only_thinking_still_renders() {
+        let msg = AssistantMessage { text: String::new(), thinking: "hmm".into() };
+        let t = thread(vec![ThreadEntry::Assistant(msg)]);
+        assert_eq!(check(&t, true), Vec::new());
+    }
+
+    /// Every violation is reported, not just the first — a mapper that breaks
+    /// one rule usually breaks it everywhere, and fixing them one test-run at a
+    /// time is how a refactor stalls.
+    #[test]
+    fn all_violations_are_reported_together() {
+        let t = thread(vec![
+            call("x", ToolCallStatus::InProgress),
+            call("x", ToolCallStatus::Completed),
+            ThreadEntry::Assistant(AssistantMessage::default()),
+        ]);
+        assert_eq!(check(&t, true).len(), 3);
+    }
+}

--- a/crates/agent-core/src/thread/mod.rs
+++ b/crates/agent-core/src/thread/mod.rs
@@ -23,6 +23,8 @@ pub mod event;
 pub mod mcp_server_spec;
 pub mod question;
 #[cfg(feature = "test-support")]
+pub mod invariants;
+#[cfg(feature = "test-support")]
 pub mod snapshot;
 pub mod state;
 pub mod stream_json;

--- a/crates/agent-core/src/thread/mod.rs
+++ b/crates/agent-core/src/thread/mod.rs
@@ -22,6 +22,8 @@ pub mod entry;
 pub mod event;
 pub mod mcp_server_spec;
 pub mod question;
+#[cfg(feature = "test-support")]
+pub mod snapshot;
 pub mod state;
 pub mod stream_json;
 pub mod tool_call;

--- a/crates/agent-core/src/thread/snapshot.rs
+++ b/crates/agent-core/src/thread/snapshot.rs
@@ -1,0 +1,187 @@
+//! Transcript snapshot harness — the safety net for the assembler extraction.
+//!
+//! The assembler moves lifecycle decisions (id minting, turn/item boundaries,
+//! close dedupe, text accumulation, coalescing) out of five agent mappers and
+//! into one place. The thing that must not change while that happens is what
+//! the user sees, and *that* is the folded [`ChatThread`] — not the event
+//! stream. Coalescing deliberately alters the event stream: it merges deltas,
+//! so a pinned `Vec<ThreadEvent>` would report a false regression on the first
+//! migration. The fold is where "rendered output is unchanged" is actually
+//! decidable, because it is what every render path reads.
+//!
+//! Behind the `test-support` feature so none of this ships: `oximux-agents`
+//! turns it on in dev-dependencies so both crates pin transcripts identically
+//! rather than each growing its own harness.
+//!
+//! Regenerate after an *intended* change with
+//! `UPDATE_TRANSCRIPT_SNAPSHOTS=1 cargo test`, then read the diff before
+//! committing it — a snapshot accepted without reading is worse than no
+//! snapshot, because it looks like coverage.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::entry::{ChatImage, ThreadEntry};
+use super::event::{ThreadEvent, TurnUsage};
+use super::state::ChatThread;
+
+/// Environment variable that rewrites snapshots instead of asserting them.
+pub const UPDATE_VAR: &str = "UPDATE_TRANSCRIPT_SNAPSHOTS";
+
+/// The render-visible state of a folded transcript.
+///
+/// Deliberately a curated projection rather than all of `ChatThread`: fields
+/// the fold does not own (ephemeral slash-command descriptions, the plan
+/// panel's live cache) would add churn without adding safety.
+#[derive(Serialize)]
+struct TranscriptSnapshot<'a> {
+    session_id: &'a Option<String>,
+    model: &'a Option<String>,
+    permission_mode: &'a Option<String>,
+    turn_active: bool,
+    compacting: bool,
+    title: &'a Option<String>,
+    last_error: &'a Option<String>,
+    last_summary: &'a Option<String>,
+    /// The settled turn's token/cost breakdown. Included because it renders in
+    /// the transcript footer — and because leaving it out made this harness
+    /// vacuous: a mutant that dropped `usage` from every `TurnEnded` passed all
+    /// thirteen snapshots. A projection is only a safety net over the fields it
+    /// actually projects.
+    usage: &'a Option<TurnUsage>,
+    entries: Vec<ThreadEntry>,
+}
+
+/// Fold `events` and render the result as stable pretty JSON.
+pub fn transcript_snapshot(events: &[ThreadEvent]) -> String {
+    let mut thread = ChatThread::default();
+    for ev in events {
+        thread.apply(ev);
+    }
+    snapshot_of(&thread)
+}
+
+/// Render an already-folded thread.
+pub fn snapshot_of(thread: &ChatThread) -> String {
+    let snap = TranscriptSnapshot {
+        session_id: &thread.session_id,
+        model: &thread.model,
+        permission_mode: &thread.permission_mode,
+        turn_active: thread.turn_active,
+        compacting: thread.compacting,
+        title: &thread.title,
+        last_error: &thread.last_error,
+        last_summary: &thread.last_summary,
+        usage: &thread.usage,
+        entries: thread.entries.iter().cloned().map(redact_entry).collect(),
+    };
+    let mut text = serde_json::to_string_pretty(&snap).expect("transcript snapshot serializes");
+    text.push('\n');
+    text
+}
+
+/// Replace image payloads with a length+hash marker.
+///
+/// A screenshot's base64 runs to hundreds of kilobytes. Left inline it would
+/// make the snapshot unreadable, and an unreadable snapshot gets regenerated
+/// blindly — which is the failure mode this harness exists to prevent. The
+/// marker still changes whenever the bytes change, so fidelity is kept where it
+/// matters and only reviewability is traded away.
+fn redact_entry(entry: ThreadEntry) -> ThreadEntry {
+    fn redact(images: &mut Vec<ChatImage>) {
+        for img in images {
+            img.data = format!("<{} bytes, fnv={:016x}>", img.data.len(), fnv1a(&img.data));
+        }
+    }
+    let mut entry = entry;
+    match &mut entry {
+        ThreadEntry::User { images, .. } => redact(images),
+        ThreadEntry::ToolCall(call) => redact(&mut call.images),
+        ThreadEntry::Assistant(_)
+        | ThreadEntry::ContextCompaction { .. }
+        | ThreadEntry::TurnDiff { .. } => {}
+    }
+    entry
+}
+
+/// FNV-1a. Inline rather than a dependency: `agent-core` is deliberately
+/// dep-minimal and mobile-portable, and this is a change detector, not a
+/// security primitive.
+fn fnv1a(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Assert the folded transcript matches the snapshot at `path`.
+///
+/// Writes the file (creating parent directories) when [`UPDATE_VAR`] is set, so
+/// a new fixture is pinned by running the suite once.
+pub fn assert_transcript_snapshot(path: impl AsRef<Path>, events: &[ThreadEvent]) {
+    assert_snapshot_text(path, &transcript_snapshot(events));
+}
+
+/// [`assert_transcript_snapshot`] for a caller that folded the thread itself
+/// (an agent whose replay helper drives extra state into it).
+pub fn assert_thread_snapshot(path: impl AsRef<Path>, thread: &ChatThread) {
+    assert_snapshot_text(path, &snapshot_of(thread));
+}
+
+fn assert_snapshot_text(path: impl AsRef<Path>, actual: &str) {
+    let path = path.as_ref();
+    if std::env::var_os(UPDATE_VAR).is_some() {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).expect("snapshot directory");
+        }
+        std::fs::write(path, actual).expect("write snapshot");
+        return;
+    }
+    let expected = std::fs::read_to_string(path).unwrap_or_else(|err| {
+        panic!(
+            "missing transcript snapshot {}: {err}\n\
+             Create it with `{UPDATE_VAR}=1 cargo test`, then READ the generated \
+             file before committing it.",
+            path.display()
+        )
+    });
+    if expected == actual {
+        return;
+    }
+    panic!(
+        "transcript changed for {}\n\n{}\n\n\
+         If this change is intended, regenerate with `{UPDATE_VAR}=1 cargo test` \
+         and name the change in the phase log. If it is not, the assembler \
+         altered what the user sees.",
+        path.display(),
+        first_difference(&expected, actual)
+    );
+}
+
+/// The first differing line with a little context — enough to see what moved
+/// without printing two full transcripts into the test output.
+fn first_difference(expected: &str, actual: &str) -> String {
+    let exp: Vec<&str> = expected.lines().collect();
+    let act: Vec<&str> = actual.lines().collect();
+    let at = exp.iter().zip(&act).position(|(a, b)| a != b).unwrap_or(exp.len().min(act.len()));
+    let from = at.saturating_sub(3);
+    let window = |lines: &[&str]| {
+        lines
+            .iter()
+            .enumerate()
+            .skip(from)
+            .take(7)
+            .map(|(i, l)| format!("  {:>4} | {l}", i + 1))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    format!(
+        "first difference at line {}\n--- expected ---\n{}\n--- actual ---\n{}",
+        at + 1,
+        window(&exp),
+        window(&act)
+    )
+}

--- a/crates/agent-core/src/thread/snapshot.rs
+++ b/crates/agent-core/src/thread/snapshot.rs
@@ -21,6 +21,7 @@
 use std::path::Path;
 
 use serde::Serialize;
+use serde_json::Value;
 
 use super::entry::{ChatImage, ThreadEntry};
 use super::event::{ThreadEvent, TurnUsage};
@@ -97,12 +98,44 @@ fn redact_entry(entry: ThreadEntry) -> ThreadEntry {
     let mut entry = entry;
     match &mut entry {
         ThreadEntry::User { images, .. } => redact(images),
-        ThreadEntry::ToolCall(call) => redact(&mut call.images),
+        ThreadEntry::ToolCall(call) => {
+            redact(&mut call.images);
+            // A tool call's `input`/`structured` are free-form `Value`s, and
+            // their key order is a build-configuration detail — see
+            // [`canonical`].
+            call.input = canonical(std::mem::take(&mut call.input));
+            call.structured = call.structured.take().map(canonical);
+        }
         ThreadEntry::Assistant(_)
         | ThreadEntry::ContextCompaction { .. }
         | ThreadEntry::TurnDiff { .. } => {}
     }
     entry
+}
+
+/// Sort every object key, recursively.
+///
+/// `serde_json` maps preserve *insertion* order when anything in the build
+/// graph turns on `preserve_order` (something in this workspace does — the
+/// lockfile shows `serde_json` pulling `indexmap`) and sort keys when nothing
+/// does. Cargo unifies features per build, so the same fixture serialized
+/// differently depending on whether `agent-core` was built alone or as part of
+/// the workspace, and the snapshot failed only in the full run.
+///
+/// Sorting here makes the snapshot a property of the transcript rather than of
+/// the build graph. Found the honest way: the workspace suite failed while the
+/// crate suite passed.
+fn canonical(v: Value) -> Value {
+    match v {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> =
+                map.into_iter().map(|(k, v)| (k, canonical(v))).collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            Value::Object(entries.into_iter().collect())
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(canonical).collect()),
+        other => other,
+    }
 }
 
 /// FNV-1a. Inline rather than a dependency: `agent-core` is deliberately

--- a/crates/agent-core/src/thread/state.rs
+++ b/crates/agent-core/src/thread/state.rs
@@ -14,7 +14,7 @@
 
 use super::background_task::{BackgroundTask, TaskStatus};
 use super::entry::{AssistantMessage, ChatImage, CheckpointState, ThreadEntry};
-use super::event::{PlanEntryLite, SessionMeta, ThreadEvent, TurnUsage};
+use super::event::{PlanEntryLite, RateLimitInfo, SessionMeta, ThreadEvent, TurnUsage};
 use super::question::QuestionRequest;
 use super::tool_call::{PermissionRequest, ToolCall, ToolCallStatus};
 use super::turn_diff;
@@ -63,6 +63,20 @@ pub struct ChatThread {
     pub last_summary: Option<String>,
     /// Latest transport/protocol error, surfaced non-fatally.
     pub last_error: Option<String>,
+    /// Typed detail for the most recent failed turn, from the `TurnFailed` that
+    /// rides just ahead of an errored `TurnEnded`.
+    ///
+    /// In-memory only, and cleared when a turn starts, so it always describes
+    /// the turn that just failed rather than an older one.
+    pub last_turn_failure: Option<(Option<u16>, Option<String>)>,
+    /// The provider's most recent rate-limit reading (Claude `rate_limit_event`).
+    ///
+    /// In-memory only, like [`Self::plan`]: a restored thread starts with no
+    /// reading and gets one on the next event. That is the honest state — a
+    /// reading persisted across a restart could name a window that has since
+    /// reset, and a stale "rejected" is exactly the fabricated claim the usage
+    /// meter already refuses to make.
+    pub last_rate_limit: Option<RateLimitInfo>,
     /// Whether a turn is currently in flight (between a user send and
     /// `TurnEnded`). Drives the composer's send/stop affordance.
     pub turn_active: bool,
@@ -241,6 +255,7 @@ impl ChatThread {
         self.live_usage = None;
         self.last_summary = None;
         self.last_error = None;
+        self.last_turn_failure = None;
         self.turn_active = true;
     }
 
@@ -530,6 +545,12 @@ impl ChatThread {
                 self.compacting = false;
                 self.end_assistant_window();
                 self.entries.push(ThreadEntry::ContextCompaction { summary: summary.clone() });
+            }
+            ThreadEvent::TurnFailed { status, terminal_reason } => {
+                self.last_turn_failure = Some((*status, terminal_reason.clone()));
+            }
+            ThreadEvent::RateLimitUpdated(info) => {
+                self.last_rate_limit = Some(info.clone());
             }
             ThreadEvent::TurnEnded { is_error, result, usage, turn_diff } => {
                 self.turn_active = false;

--- a/crates/agent-core/src/thread/stream_json.rs
+++ b/crates/agent-core/src/thread/stream_json.rs
@@ -9,7 +9,7 @@
 use serde_json::Value;
 
 use super::background_task::BackgroundTaskKind;
-use super::event::{McpServerStatus, SessionMeta, ThreadEvent, TurnUsage};
+use super::event::{McpServerStatus, RateLimitInfo, SessionMeta, ThreadEvent, TurnUsage};
 use super::question::parse_questions;
 use super::tool_call::{
     PermissionKind, PermissionSuggestion, extract_tool_result_images, flatten_tool_result_content,
@@ -17,7 +17,7 @@ use super::tool_call::{
 
 /// Decode one newline-delimited stream-json line. Returns the events it
 /// yields (possibly empty for noise: `system/hook_*`, `system/status`,
-/// `rate_limit_event`, message framing, or malformed input).
+/// message framing, or malformed input).
 pub fn decode_line(line: &str) -> Vec<ThreadEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -49,6 +49,7 @@ fn decode_value(v: &Value) -> Vec<ThreadEvent> {
         Some("user") => decode_user(v),
         Some("control_request") => decode_control_request(v),
         Some("result") => decode_result(v),
+        Some("rate_limit_event") => decode_rate_limit(v),
         _ => Vec::new(),
     }
 }
@@ -564,8 +565,42 @@ fn decode_result(v: &Value) -> Vec<ThreadEvent> {
             attempted_id: str_field(v, "session_id"),
         });
     }
+    // Typed failure detail rides just ahead of the settle event, like the
+    // stale-resume recovery above. Only when the backend actually said
+    // something machine-readable — an errored result with neither field carries
+    // no more than `is_error` already does.
+    if is_error {
+        let status = v.get("api_error_status").and_then(Value::as_u64).and_then(|s| u16::try_from(s).ok());
+        let terminal_reason = str_field_opt(v, "terminal_reason");
+        if status.is_some() || terminal_reason.is_some() {
+            out.push(ThreadEvent::TurnFailed { status, terminal_reason });
+        }
+    }
     out.push(ThreadEvent::TurnEnded { result, usage: decode_usage(v), is_error, turn_diff: None });
     out
+}
+
+/// Decode a `rate_limit_event` line into the provider's current limit state.
+///
+/// The CLI emits this on its own line whenever a window's rounded utilization
+/// or reset time moves, which includes the transition into `rejected`. OxiMux
+/// discarded it until now; it is the only *typed* signal the wire gives for
+/// "this turn failed because a limit is closed", and reading it is what keeps
+/// the retry engine off error-message prose.
+///
+/// `resetsAt` is unix **seconds** on the wire and unix **milliseconds** in
+/// [`RateLimitInfo`]. A line with no `rate_limit_info` object, or one with no
+/// `status`, decodes to nothing rather than to a default-constructed reading
+/// that would claim the account is fine.
+fn decode_rate_limit(v: &Value) -> Vec<ThreadEvent> {
+    let Some(info) = v.get("rate_limit_info") else { return Vec::new() };
+    let Some(status) = info.get("status").and_then(Value::as_str) else { return Vec::new() };
+    vec![ThreadEvent::RateLimitUpdated(RateLimitInfo {
+        status: status.to_string(),
+        resets_at_ms: info.get("resetsAt").and_then(Value::as_i64).map(|secs| secs * 1000),
+        limit_type: info.get("rateLimitType").and_then(Value::as_str).map(str::to_string),
+        utilization: info.get("utilization").and_then(Value::as_f64),
+    })]
 }
 
 /// Join a result's `errors[]` string entries (the CLI's primary error-text
@@ -622,6 +657,12 @@ fn str_field(v: &Value, key: &str) -> String {
     v.get(key).and_then(Value::as_str).unwrap_or_default().to_string()
 }
 
+/// Like [`str_field`] but distinguishes "absent" from "empty" — the caller
+/// decides whether a missing token is worth an event.
+fn str_field_opt(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(Value::as_str).filter(|s| !s.is_empty()).map(str::to_string)
+}
+
 /// Decode a JSON array of strings into `Vec<String>`. Missing key or non-array
 /// → empty; non-string array entries are skipped (defensive against a wire
 /// shape drift). Used for `init.slash_commands`.
@@ -666,7 +707,12 @@ mod tests {
         assert!(decode_line("not json").is_empty());
         assert!(decode_line(&json!({"type":"system","subtype":"status","status":"requesting"}).to_string()).is_empty());
         assert!(decode_line(&json!({"type":"system","subtype":"hook_response"}).to_string()).is_empty());
+        // A rate_limit_event with no payload carries no reading to fold.
         assert!(decode_line(&json!({"type":"rate_limit_event"}).to_string()).is_empty());
+        assert!(
+            decode_line(&json!({"type":"rate_limit_event","rate_limit_info":{}}).to_string()).is_empty(),
+            "a rate_limit_info with no status must not fold as a default reading"
+        );
         // unknown type + unknown fields must not panic
         assert!(decode_line(&json!({"type":"brand_new","x":{"y":[1,2]}}).to_string()).is_empty());
     }
@@ -1088,6 +1134,72 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    /// The fixture's shape and vocabulary come from the shipped `claude` CLI's
+    /// own schema (2.1.261) — the `rate_limit_info` zod definition and the code
+    /// that derives `retry-after` from `resetsAt` — not from a live capture and
+    /// not from guessing at an error message. A real rate limit cannot be
+    /// provoked on demand, so the provenance is stated rather than implied.
+    #[test]
+    fn rate_limit_fixture_decodes_every_status() {
+        let fixture = include_str!("testdata/stream_json_rate_limit.jsonl");
+        let events: Vec<ThreadEvent> = fixture.lines().flat_map(decode_line).collect();
+        assert_eq!(events.len(), 5, "every line carries a reading");
+        let readings: Vec<&RateLimitInfo> = events
+            .iter()
+            .map(|e| match e {
+                ThreadEvent::RateLimitUpdated(i) => i,
+                other => panic!("expected a rate-limit reading, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(readings[0].status, "allowed");
+        assert_eq!(readings[1].status, "allowed_warning");
+        assert!(readings[2].is_rejected());
+        assert_eq!(readings[2].utilization, Some(100.0));
+    }
+
+    /// The wire reports `resetsAt` in seconds; every reset time inside OxiMux is
+    /// milliseconds. This is the one decoding mistake that fails silently — a
+    /// retry lands either instantly or fifty thousand years out, and neither
+    /// looks like a units bug from the UI.
+    #[test]
+    fn resets_at_is_converted_from_seconds_to_milliseconds() {
+        let line = json!({"type":"rate_limit_event",
+            "rate_limit_info":{"status":"rejected","rateLimitType":"five_hour","resetsAt":1788462000}})
+        .to_string();
+        match decode_line(&line).as_slice() {
+            [ThreadEvent::RateLimitUpdated(info)] => {
+                assert_eq!(info.resets_at_ms, Some(1_788_462_000_000));
+            }
+            other => panic!("expected one reading, got {other:?}"),
+        }
+    }
+
+    /// Waiting clears a window; it does not clear an overage, and it cannot
+    /// clear a limit kind this build does not recognise. Both must fall through
+    /// to "surface the error" rather than to "retry".
+    #[test]
+    fn only_known_window_kinds_are_waitable() {
+        let fixture = include_str!("testdata/stream_json_rate_limit.jsonl");
+        let readings: Vec<RateLimitInfo> = fixture
+            .lines()
+            .flat_map(decode_line)
+            .filter_map(|e| match e {
+                ThreadEvent::RateLimitUpdated(i) => Some(i),
+                _ => None,
+            })
+            .collect();
+        // five_hour / seven_day are waitable windows...
+        assert!(readings[0].is_waitable_window());
+        assert!(readings[1].is_waitable_window());
+        assert!(readings[2].is_waitable_window());
+        // ...an overage is the account paying past its plan, not a closed window.
+        assert_eq!(readings[3].limit_type.as_deref(), Some("overage"));
+        assert!(!readings[3].is_waitable_window(), "an overage must never be waited out");
+        // ...and an unrecognised kind is not assumed to be safe.
+        assert!(readings[4].is_rejected());
+        assert!(!readings[4].is_waitable_window(), "an unknown limit kind must not be retried");
     }
 
     #[test]

--- a/crates/agent-core/src/thread/testdata/stream_json_rate_limit.jsonl
+++ b/crates/agent-core/src/thread/testdata/stream_json_rate_limit.jsonl
@@ -1,0 +1,5 @@
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour","utilization":41,"resetsAt":1788462000},"uuid":"1c2f0a9e-0000-4000-8000-000000000001","session_id":"sid-rl"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"seven_day","utilization":92,"resetsAt":1788890400},"uuid":"1c2f0a9e-0000-4000-8000-000000000002","session_id":"sid-rl"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"five_hour","utilization":100,"resetsAt":1788462000},"uuid":"1c2f0a9e-0000-4000-8000-000000000003","session_id":"sid-rl"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"overage","utilization":100},"uuid":"1c2f0a9e-0000-4000-8000-000000000004","session_id":"sid-rl"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"a_window_kind_this_build_has_never_seen","resetsAt":1788462000},"uuid":"1c2f0a9e-0000-4000-8000-000000000005","session_id":"sid-rl"}

--- a/crates/agent-core/tests/snapshots/stream_json_error_api.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_error_api.transcript.json
@@ -1,0 +1,26 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": "There's an issue with the selected model (this-model-does-not-exist-xyz). It may not exist or you may not have access to it.",
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": null,
+    "cost_usd": 0.0
+  },
+  "entries": [
+    {
+      "Assistant": {
+        "text": "There's an issue with the selected model (this-model-does-not-exist-xyz). It may not exist or you may not have access to it.",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/snapshots/stream_json_error_stale_resume.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_error_stale_resume.transcript.json
@@ -1,0 +1,25 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": "No conversation found with session ID: 00000000-0000-0000-0000-000000000000",
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": null,
+    "cost_usd": 0.0
+  },
+  "entries": [
+    {
+      "ContextCompaction": {
+        "summary": "Session no longer resumable — starting fresh"
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/snapshots/stream_json_exit_plan_mode.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_exit_plan_mode.transcript.json
@@ -1,0 +1,39 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": null,
+  "entries": [
+    {
+      "ToolCall": {
+        "id": "toolu_exitplan_1",
+        "name": "ExitPlanMode",
+        "input": {
+          "plan": "# Plan: Add `hello()` to `src/lib.rs`\n\n## Steps\n1. Create `hello()` returning a greeting.\n2. Verify with `cargo check`.\n",
+          "planFilePath": "/Users/x/.claude/plans/add-hello.md"
+        },
+        "status": {
+          "WaitingForConfirmation": {
+            "request_id": "req-exitplan-1",
+            "kind": "plan",
+            "description": "# Plan: Add `hello()` to `src/lib.rs`\n\n## Steps\n1. Create `hello()` returning a greeting.\n2. Verify with `cargo check`.\n",
+            "suggestions": []
+          }
+        },
+        "result": null,
+        "structured": null,
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/snapshots/stream_json_rate_limit.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_rate_limit.transcript.json
@@ -1,0 +1,12 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": null,
+  "entries": []
+}

--- a/crates/agent-core/tests/snapshots/stream_json_richtools.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_richtools.transcript.json
@@ -1,0 +1,97 @@
+{
+  "session_id": "sid-rich",
+  "model": "claude-opus-4-8",
+  "permission_mode": "default",
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": null,
+    "cost_usd": 0.05
+  },
+  "entries": [
+    {
+      "ToolCall": {
+        "id": "srv_1",
+        "name": "web_search",
+        "input": {
+          "query": "latest rust version"
+        },
+        "status": "Completed",
+        "result": "Rust 1.95.0 is the latest stable release.",
+        "structured": null,
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "mcp_1",
+        "name": "context7.query-docs",
+        "input": {
+          "q": "tokio"
+        },
+        "status": "Completed",
+        "result": "tokio is an async runtime.",
+        "structured": null,
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "toolu_01QQuQESAQdiugq3rrv1rQ4J",
+        "name": "Read",
+        "input": {
+          "file_path": "./red.png"
+        },
+        "status": "Completed",
+        "result": "[image]",
+        "structured": {
+          "file": {
+            "base64": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVR42mNk+M9Qz0BkYBxUAgBHBQr9Wj6PIQAAAABJRU5ErkJggg==",
+            "originalSize": 76,
+            "type": "image/png"
+          },
+          "type": "image"
+        },
+        "images": [
+          {
+            "media_type": "image/png",
+            "data": "<104 bytes, fnv=42fdc4196053b0bd>"
+          }
+        ],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "",
+        "thinking": "[redacted reasoning]"
+      }
+    },
+    {
+      "ContextCompaction": {
+        "summary": "Context compacted (auto)"
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/snapshots/stream_json_subagent.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_subagent.transcript.json
@@ -1,0 +1,99 @@
+{
+  "session_id": "7a50437f-0904-4876-b48c-093cbbf4eada",
+  "model": "claude-sonnet-5",
+  "permission_mode": "bypassPermissions",
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": "subagent completed; spike test finished",
+  "usage": {
+    "input_tokens": 4,
+    "output_tokens": 381,
+    "cache_read_tokens": 63988,
+    "cache_creation_tokens": 64963,
+    "context_window": 1000000,
+    "cost_usd": 0.5662749
+  },
+  "entries": [
+    {
+      "ToolCall": {
+        "id": "toolu_01DuBpc1Lg6bLkBA8kiRwqeP",
+        "name": "Agent",
+        "input": {
+          "description": "Read one.txt and two.txt",
+          "prompt": "Read the files one.txt and two.txt in the current directory. Report the total number of lines across both files, and name each file.",
+          "subagent_type": "general-purpose"
+        },
+        "status": "Completed",
+        "result": "Async agent launched successfully. (This tool result is internal metadata — never quote or paste any part of it, including the agentId below, into a user-facing reply.)\nagentId: ac4af353551ae8a15 (internal ID - do not mention to user. Use SendMessage with to: 'ac4af353551ae8a15', summary: '<5-10 word recap>' to continue this agent.)\nThe agent is working in the background. You will be notified automatically when it completes.\nDo not duplicate this agent's work — avoid working with the same files or topics it is using.\noutput_file: /private/tmp/claude-501/-private-tmp-claude-501--Users-nguyenhongtien-Code-projects-OxiMux-c95a14a3-f5ec-4af2-a16a-86b0d3d6123a-scratchpad-p7-spike/7a50437f-0904-4876-b48c-093cbbf4eada/tasks/ac4af353551ae8a15.output\nDo NOT Read or tail this file via the shell tool — it is the full subagent JSONL transcript and reading it will overflow your context. If the user asks for progress, say the agent is still running; you'll get a completion notification.",
+        "structured": {
+          "agentId": "ac4af353551ae8a15",
+          "canReadOutputFile": true,
+          "description": "Read one.txt and two.txt",
+          "isAsync": true,
+          "outputFile": "/private/tmp/claude-501/-private-tmp-claude-501--Users-nguyenhongtien-Code-projects-OxiMux-c95a14a3-f5ec-4af2-a16a-86b0d3d6123a-scratchpad-p7-spike/7a50437f-0904-4876-b48c-093cbbf4eada/tasks/ac4af353551ae8a15.output",
+          "prompt": "Read the files one.txt and two.txt in the current directory. Report the total number of lines across both files, and name each file.",
+          "resolvedModel": "claude-sonnet-5",
+          "status": "async_launched"
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": [
+          "Bash ls -la /private/tmp/claude-501/-Users-nguyenhongtien-Code-projects-OxiMux/c95a14a3-f5ec-4af2-a16a-86b0d3d6123a/scra…",
+          "Read /private/tmp/claude-501/-Users-nguyenhongtien-Code-projects-OxiMux/c95a14a3-f5ec-4af2-a16a-86b0d3d6123a/scratchpad/…",
+          "Read /private/tmp/claude-501/-Users-nguyenhongtien-Code-projects-OxiMux/c95a14a3-f5ec-4af2-a16a-86b0d3d6123a/scratchpad/…",
+          "one.txt has 4 lines (alpha, beta, gamma, and a trailing empty line), two.txt has 3 lines (x, y, and a trailing empty lin…"
+        ]
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "toolu_01XDf2uP6DagPQXuHGYzMPcE",
+        "name": "Bash",
+        "input": {
+          "command": "sleep 3; echo BACKGROUND_BASH_DONE",
+          "description": "Sleep 3 seconds then print done marker",
+          "run_in_background": true
+        },
+        "status": "Completed",
+        "result": "Command running in background with ID: btzxsa4ru. Output is being written to: /private/tmp/claude-501/-private-tmp-claude-501--Users-nguyenhongtien-Code-projects-OxiMux-c95a14a3-f5ec-4af2-a16a-86b0d3d6123a-scratchpad-p7-spike/7a50437f-0904-4876-b48c-093cbbf4eada/tasks/btzxsa4ru.output. You will be notified when it completes. To check interim output, use Read on that file path.",
+        "structured": {
+          "backgroundTaskId": "btzxsa4ru",
+          "interrupted": false,
+          "isImage": false,
+          "noOutputExpected": false,
+          "stderr": "",
+          "stdout": ""
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "Both launched — waiting for the subagent and the background bash to finish before replying.",
+        "thinking": ""
+      }
+    },
+    {
+      "Assistant": {
+        "text": "Background bash finished. Still waiting on the subagent to complete before replying.",
+        "thinking": ""
+      }
+    },
+    {
+      "Assistant": {
+        "text": "Both the subagent and the background bash command have completed.\n\nSPIKE COMPLETE",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/snapshots/stream_json_tool_input_delta.transcript.json
+++ b/crates/agent-core/tests/snapshots/stream_json_tool_input_delta.transcript.json
@@ -1,0 +1,70 @@
+{
+  "session_id": "a069e022-d7e3-4957-b039-0b8ed90f5fba",
+  "model": "claude-opus-4-8[1m]",
+  "permission_mode": "acceptEdits",
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": "created /tmp/claude_fixtures/poem.txt with 12-line ocean poem",
+  "usage": {
+    "input_tokens": 4,
+    "output_tokens": 307,
+    "cache_read_tokens": 62031,
+    "cache_creation_tokens": 62344,
+    "context_window": 1000000,
+    "cost_usd": 0.6621505000000001
+  },
+  "entries": [
+    {
+      "Assistant": {
+        "text": "I'll create the file directly with the Write tool.",
+        "thinking": ""
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "toolu_016qUUDrGs8C2Cd54J2Mn9sP",
+        "name": "Write",
+        "input": {
+          "content": "Beneath the moon the ocean breathes,\na silver tide that softly weaves.\nIt pulls the shore, then lets it go,\na rhythm only currents know.\n\nThe gulls trace arcs above the foam,\nwhere restless waves forget their home.\nSalt on the wind, a distant sail,\na whisper caught in every gale.\n\nAnd when the sun dips down to rest,\nthe water burns from east to west.\nThe deep holds secrets none can keep,\nand rocks the world, and rocks the world, to sleep.\n",
+          "file_path": "/tmp/claude_fixtures/poem.txt"
+        },
+        "status": "Completed",
+        "result": "File created successfully at: /tmp/claude_fixtures/poem.txt (file state is current in your context — no need to Read it back)",
+        "structured": {
+          "content": "Beneath the moon the ocean breathes,\na silver tide that softly weaves.\nIt pulls the shore, then lets it go,\na rhythm only currents know.\n\nThe gulls trace arcs above the foam,\nwhere restless waves forget their home.\nSalt on the wind, a distant sail,\na whisper caught in every gale.\n\nAnd when the sun dips down to rest,\nthe water burns from east to west.\nThe deep holds secrets none can keep,\nand rocks the world, and rocks the world, to sleep.\n",
+          "filePath": "/tmp/claude_fixtures/poem.txt",
+          "originalFile": null,
+          "structuredPatch": [],
+          "type": "create",
+          "userModified": false
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "Done. Created `/tmp/claude_fixtures/poem.txt` with a 12-line poem about the ocean.",
+        "thinking": ""
+      }
+    },
+    {
+      "TurnDiff": {
+        "files": [
+          {
+            "path": "/tmp/claude_fixtures/poem.txt",
+            "added": 14,
+            "removed": 0
+          }
+        ],
+        "diff": null
+      }
+    }
+  ]
+}

--- a/crates/agent-core/tests/transcript_snapshots.rs
+++ b/crates/agent-core/tests/transcript_snapshots.rs
@@ -16,7 +16,9 @@
 //! ```
 
 use oximux_agent_core::thread::event::ThreadEvent;
+use oximux_agent_core::thread::invariants;
 use oximux_agent_core::thread::snapshot::assert_transcript_snapshot;
+use oximux_agent_core::thread::state::ChatThread;
 use oximux_agent_core::thread::stream_json::decode_line;
 
 /// Every fixture in `src/thread/testdata/`. Listed rather than globbed so a new
@@ -61,3 +63,25 @@ fn every_fixture_decodes_to_at_least_one_event() {
         );
     }
 }
+
+/// Every Claude fixture must satisfy the shared transcript invariants.
+///
+/// Separate from the snapshot test on purpose: a snapshot pins whatever the
+/// code does today, including a bug. These assert what the transcript must
+/// *never* be, so a pinned bug still fails here.
+#[test]
+fn every_claude_fixture_satisfies_the_transcript_invariants() {
+    for name in FIXTURES {
+        let events = decode_fixture(name);
+        // "A turn ran and finished", not "no turn is in flight" — see
+        // `invariants::check`. A fixture that never opens a turn leaves cards
+        // legitimately open.
+        let settled = events.iter().any(|e| matches!(e, ThreadEvent::TurnEnded { .. }));
+        let mut thread = ChatThread::default();
+        for ev in &events {
+            thread.apply(ev);
+        }
+        invariants::assert_holds(name, &thread, settled);
+    }
+}
+

--- a/crates/agent-core/tests/transcript_snapshots.rs
+++ b/crates/agent-core/tests/transcript_snapshots.rs
@@ -1,0 +1,63 @@
+//! Pinned transcripts for every committed Claude fixture.
+//!
+//! This is the baseline the assembler extraction (plan phase 4) is measured
+//! against: the mappers are about to be rewritten, and the only thing that must
+//! survive unchanged is what the user ends up seeing. Each fixture is decoded
+//! with the real decoder, folded with the real fold, and compared against a
+//! committed snapshot of the resulting transcript.
+//!
+//! A failure here means the rewrite changed rendered output. That is sometimes
+//! correct — a round-9 fidelity fix, say — but it is never incidental, so the
+//! snapshot must be regenerated deliberately and the change named in the phase
+//! log:
+//!
+//! ```text
+//! UPDATE_TRANSCRIPT_SNAPSHOTS=1 cargo test -p oximux-agent-core --features test-support
+//! ```
+
+use oximux_agent_core::thread::event::ThreadEvent;
+use oximux_agent_core::thread::snapshot::assert_transcript_snapshot;
+use oximux_agent_core::thread::stream_json::decode_line;
+
+/// Every fixture in `src/thread/testdata/`. Listed rather than globbed so a new
+/// fixture is a deliberate addition to this baseline — a glob would silently
+/// pin whatever happened to be on disk, including a half-captured file.
+const FIXTURES: &[&str] = &[
+    "stream_json_error_api",
+    "stream_json_error_stale_resume",
+    "stream_json_exit_plan_mode",
+    "stream_json_rate_limit",
+    "stream_json_richtools",
+    "stream_json_subagent",
+    "stream_json_tool_input_delta",
+];
+
+fn decode_fixture(name: &str) -> Vec<ThreadEvent> {
+    let path = format!("{}/src/thread/testdata/{name}.jsonl", env!("CARGO_MANIFEST_DIR"));
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    raw.lines().filter(|l| !l.trim().is_empty()).flat_map(decode_line).collect()
+}
+
+#[test]
+fn every_claude_fixture_renders_the_pinned_transcript() {
+    for name in FIXTURES {
+        let events = decode_fixture(name);
+        let path =
+            format!("{}/tests/snapshots/{name}.transcript.json", env!("CARGO_MANIFEST_DIR"));
+        assert_transcript_snapshot(path, &events);
+    }
+}
+
+/// The baseline is only worth having if every fixture actually reaches the
+/// decoder. A fixture that silently decodes to nothing would pin an empty
+/// transcript and then "pass" forever, which is the shape of coverage that
+/// isn't.
+#[test]
+fn every_fixture_decodes_to_at_least_one_event() {
+    for name in FIXTURES {
+        assert!(
+            !decode_fixture(name).is_empty(),
+            "{name} decoded to nothing — the fixture or the decoder is broken"
+        );
+    }
+}

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -64,6 +64,10 @@ futures = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]
+# Transcript snapshot harness shared with `agent-core`, so Codex/Pi/omp are
+# pinned by the same code that pins Claude rather than by a second harness that
+# could drift from it. Dev-only; nothing ships with this on.
+oximux-agent-core = { workspace = true, features = ["test-support"] }
 oximux-git = { workspace = true }
 # The shell spellings the spawn/runtime tests drive their fixture programs
 # through. Same crate the shipping build already depends on; the feature only

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -15,6 +15,7 @@ pub mod coord;
 pub mod osc_sideband;
 pub mod poll_helpers;
 pub mod registry;
+pub mod retry;
 pub mod runtime;
 pub mod schedule;
 pub mod session_registry;

--- a/crates/agents/src/retry/classify.rs
+++ b/crates/agents/src/retry/classify.rs
@@ -1,0 +1,186 @@
+//! Deciding *why* a turn failed, from the typed signals the backend gave.
+//!
+//! The rule this module exists to enforce: a failure is retried only when
+//! something machine-readable says waiting will help. Everything else — an
+//! unknown limit kind, a spend cap, a plain error, a provider that said nothing
+//! — falls through to [`RetryClass::Other`] and is surfaced to the user
+//! untouched. Under-retrying costs a click; over-retrying spends money or
+//! hammers an account that is already refusing requests.
+
+use oximux_agent_core::thread::event::RateLimitInfo;
+
+/// Why a turn failed, reduced to what the retry policy needs to know.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RetryClass {
+    /// The provider is transiently overloaded (HTTP 429/503/529). Retry soon,
+    /// backing off — there is no reset time to aim at.
+    Overload,
+    /// A usage window is closed until the provider's reported reset.
+    Window {
+        /// Unix milliseconds.
+        resets_at_ms: i64,
+    },
+    /// The account is billing past its plan, or hit a spend cap. Never retried:
+    /// the next request costs real money the user did not approve.
+    Spend,
+    /// Anything else, including "the provider said nothing useful". Never
+    /// retried.
+    #[default]
+    Other,
+}
+
+impl RetryClass {
+    /// Whether this class is one the policy may schedule at all.
+    pub fn is_retryable(self) -> bool {
+        matches!(self, Self::Overload | Self::Window { .. })
+    }
+}
+
+/// HTTP statuses that mean "the provider is busy, come back shortly".
+///
+/// 529 is Anthropic's own overloaded status and is not in any HTTP registry,
+/// which is exactly why it is listed explicitly rather than folded into a
+/// `5xx` range check — a 500 is a bug report, not something to retry into.
+const OVERLOAD_STATUSES: &[u16] = &[429, 503, 529];
+
+/// Classify a failed turn.
+///
+/// `rate_limit` is the thread's latest `rate_limit_event` reading and
+/// `turn_failure` the `(status, terminal_reason)` pair from the `TurnFailed`
+/// that rides ahead of the errored `TurnEnded`. Both are typed wire signals;
+/// neither is error prose.
+///
+/// The rate-limit reading is consulted first because it is the more specific
+/// signal: a closed window surfaces as HTTP 429, and answering "retry in 30
+/// seconds" to a window that reopens in six hours would burn all four attempts
+/// inside two minutes and then report failure.
+pub fn classify_failure(
+    rate_limit: Option<&RateLimitInfo>,
+    turn_failure: Option<(Option<u16>, Option<String>)>,
+) -> RetryClass {
+    if let Some(info) = rate_limit.filter(|i| i.is_rejected()) {
+        return match (info.is_waitable_window(), info.resets_at_ms) {
+            // A window we know how to wait out, and a reset to wait until.
+            (true, Some(resets_at_ms)) => RetryClass::Window { resets_at_ms },
+            // A known window whose reset the provider withheld. There is
+            // nothing to schedule against, and guessing a duration is how a
+            // retry storm starts.
+            (true, None) => RetryClass::Other,
+            // An overage: the plan allowance is gone and further requests bill.
+            (false, _) if info.limit_type.as_deref().is_some_and(|t| t.contains("overage")) => {
+                RetryClass::Spend
+            }
+            // A limit kind this build has never heard of.
+            (false, _) => RetryClass::Other,
+        };
+    }
+    match turn_failure {
+        Some((Some(status), _)) if OVERLOAD_STATUSES.contains(&status) => RetryClass::Overload,
+        _ => RetryClass::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rejected(limit_type: &str, resets_at_ms: Option<i64>) -> RateLimitInfo {
+        RateLimitInfo {
+            status: "rejected".into(),
+            resets_at_ms,
+            limit_type: Some(limit_type.into()),
+            utilization: Some(100.0),
+        }
+    }
+
+    #[test]
+    fn a_closed_window_with_a_reset_is_waitable() {
+        assert_eq!(
+            classify_failure(Some(&rejected("five_hour", Some(1_788_462_000_000))), None),
+            RetryClass::Window { resets_at_ms: 1_788_462_000_000 }
+        );
+        assert_eq!(
+            classify_failure(Some(&rejected("seven_day_opus", Some(9))), None),
+            RetryClass::Window { resets_at_ms: 9 }
+        );
+    }
+
+    /// The distinction that cannot be guessed from an error message: an overage
+    /// is not a closed window, it is the account paying past its plan. Retrying
+    /// it spends the user's money.
+    #[test]
+    fn an_overage_is_spend_and_is_never_retried() {
+        for kind in ["overage", "seven_day_overage_included"] {
+            let class = classify_failure(Some(&rejected(kind, Some(1))), None);
+            assert_eq!(class, RetryClass::Spend, "{kind} must classify as spend");
+            assert!(!class.is_retryable(), "{kind} must never be retried");
+        }
+    }
+
+    #[test]
+    fn an_unknown_limit_kind_is_not_retried() {
+        let class = classify_failure(Some(&rejected("some_future_limit", Some(1))), None);
+        assert_eq!(class, RetryClass::Other);
+        assert!(!class.is_retryable());
+    }
+
+    /// A window with no reset time has nothing to schedule against. Inventing a
+    /// duration here is how every thread on the account wakes at once.
+    #[test]
+    fn a_known_window_without_a_reset_is_not_retried() {
+        assert_eq!(classify_failure(Some(&rejected("five_hour", None)), None), RetryClass::Other);
+    }
+
+    #[test]
+    fn a_reading_that_is_not_rejected_does_not_classify_the_failure() {
+        let allowed = RateLimitInfo {
+            status: "allowed_warning".into(),
+            resets_at_ms: Some(1),
+            limit_type: Some("five_hour".into()),
+            utilization: Some(92.0),
+        };
+        // Falls through to the status-based arm, which here says nothing.
+        assert_eq!(classify_failure(Some(&allowed), None), RetryClass::Other);
+        // ...and still reports overload when the status says so.
+        assert_eq!(
+            classify_failure(Some(&allowed), Some((Some(529), None))),
+            RetryClass::Overload
+        );
+    }
+
+    #[test]
+    fn overload_statuses_are_the_listed_ones_only() {
+        for status in [429, 503, 529] {
+            assert_eq!(
+                classify_failure(None, Some((Some(status), None))),
+                RetryClass::Overload,
+                "{status} is an overload"
+            );
+        }
+        for status in [400, 401, 403, 404, 500, 502] {
+            assert_eq!(
+                classify_failure(None, Some((Some(status), None))),
+                RetryClass::Other,
+                "{status} must not be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn a_provider_that_said_nothing_is_never_retried() {
+        assert_eq!(classify_failure(None, None), RetryClass::Other);
+        assert_eq!(classify_failure(None, Some((None, Some("api_error".into())))), RetryClass::Other);
+    }
+
+    /// A closed window beats a bare 429 — the window carries a reset to aim at,
+    /// and treating it as a transient overload would burn every attempt in two
+    /// minutes and then report failure to the user.
+    #[test]
+    fn a_closed_window_wins_over_the_overload_status_it_arrives_with() {
+        let class = classify_failure(
+            Some(&rejected("five_hour", Some(1_788_462_000_000))),
+            Some((Some(429), Some("api_error".into()))),
+        );
+        assert_eq!(class, RetryClass::Window { resets_at_ms: 1_788_462_000_000 });
+    }
+}

--- a/crates/agents/src/retry/mod.rs
+++ b/crates/agents/src/retry/mod.rs
@@ -1,0 +1,263 @@
+//! Automatic retry of a turn that failed on a provider limit.
+//!
+//! Split so the part that is easy to get wrong is testable without a clock:
+//! [`classify`] turns typed wire signals into a [`RetryClass`], and
+//! [`schedule`] is a pure function from `(class, attempt, now, settings, seed)`
+//! to a wake time. Nothing here starts a timer or touches a thread.
+//!
+//! ## Why this does not reuse the schedule ticker
+//!
+//! The plan called for reusing `crate::schedule`. It cannot be reused, for four
+//! independent reasons, each of which alone is disqualifying:
+//!
+//! 1. `Recurrence` has no one-shot variant and enforces a five-minute floor at
+//!    construction — a retry is a single fire, often sooner than that.
+//! 2. A `Schedule` is a user-visible row with a name and an enabled flag,
+//!    listed by the Schedules UI and `oximux schedule ls`, and carried on the
+//!    remote wire as `RecurrenceWire`. Internal retries do not belong there,
+//!    and the wire type is frozen.
+//! 3. The ticker runs under a single per-data-dir role lock, so it fires in
+//!    whichever host holds that lock. A retry must fire in the process that
+//!    owns the thread, which is not necessarily the same one.
+//! 4. `nudge_existing_session` deliberately wraps its prompt in a preamble
+//!    telling the agent a timer armed it. A retry must resend the user's own
+//!    prompt verbatim.
+//!
+//! What is reused is the *shape*: a pure time-arithmetic module tested without
+//! a database, matching `schedule::recurrence`.
+
+pub mod classify;
+
+pub use classify::{RetryClass, classify_failure};
+
+use std::time::Duration;
+
+/// Most automatic attempts for one turn.
+///
+/// Four is the cap the user cannot raise. A window retry consumes one attempt
+/// per reset, so four covers roughly a day of five-hour windows — past that the
+/// account is not going to free up on its own and a person should look.
+pub const MAX_ATTEMPTS: u32 = 4;
+
+/// First overload backoff, doubled per attempt: 30s, 60s, 120s, 240s.
+pub const OVERLOAD_BASE: Duration = Duration::from_secs(30);
+
+/// Added after a window's reported reset before retrying.
+///
+/// Provider clocks and ours disagree by seconds, and a request landing one
+/// second early is refused and burns an attempt. Waiting a little past the
+/// reset costs nothing.
+pub const WINDOW_GRACE: Duration = Duration::from_secs(30);
+
+/// Width of the random spread added to every wake time.
+///
+/// **The point of the feature, not a refinement.** Every thread on one account
+/// sees the same reset time, so without a spread they all wake in the same
+/// second, and the account re-limits itself instantly — the retry storms the
+/// thing it exists to survive. Two minutes is wide enough to spread a realistic
+/// number of threads across distinct seconds and short enough that a user
+/// watching a countdown does not notice.
+pub const JITTER_SPAN: Duration = Duration::from_secs(120);
+
+/// User-facing retry configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetrySettings {
+    /// Longest the app will wait automatically. `None` means no limit.
+    ///
+    /// A weekly window that resets in six days is technically retryable, but
+    /// silently holding a turn for six days is worse than reporting the error —
+    /// the user cannot tell a queued turn from a forgotten one.
+    pub max_automatic_wait: Option<Duration>,
+}
+
+impl Default for RetrySettings {
+    fn default() -> Self {
+        Self { max_automatic_wait: Some(Duration::from_secs(24 * 60 * 60)) }
+    }
+}
+
+/// When to retry, or `None` to surface the failure to the user.
+///
+/// Pure: no clock, no randomness of its own. `now_ms` and `seed` are supplied
+/// so the cap, the ceiling, and the jitter *distribution* can all be tested
+/// without waiting or flaking.
+pub fn schedule(
+    class: RetryClass,
+    attempt: u32,
+    now_ms: i64,
+    settings: &RetrySettings,
+    seed: u64,
+) -> Option<i64> {
+    if attempt >= MAX_ATTEMPTS || !class.is_retryable() {
+        return None;
+    }
+    let jitter = jitter_ms(seed, JITTER_SPAN.as_millis() as u64);
+    let wake_ms = match class {
+        RetryClass::Overload => {
+            // Doubling from the base: attempt 0 waits 30s, attempt 3 waits 240s.
+            let backoff = OVERLOAD_BASE.as_millis() as u64 * (1u64 << attempt);
+            now_ms.checked_add((backoff + jitter) as i64)?
+        }
+        RetryClass::Window { resets_at_ms } => {
+            // A reset already in the past means the window reopened while the
+            // failure was in flight; wait from now rather than firing instantly
+            // into an account that may still be catching up.
+            let base = resets_at_ms.max(now_ms);
+            base.checked_add((WINDOW_GRACE.as_millis() as u64 + jitter) as i64)?
+        }
+        RetryClass::Spend | RetryClass::Other => return None,
+    };
+    if let Some(limit) = settings.max_automatic_wait {
+        let waited_ms = wake_ms.saturating_sub(now_ms);
+        if waited_ms > limit.as_millis() as i64 {
+            return None;
+        }
+    }
+    Some(wake_ms)
+}
+
+/// A uniformly spread offset in `[0, span_ms)` derived from `seed`.
+///
+/// SplitMix64's finalizer: it avalanches, so seeds that differ in one bit —
+/// consecutive thread ids, say — produce unrelated offsets. A weaker mix (`seed
+/// % span`) would leave sequential ids landing in sequential milliseconds,
+/// which is the clustering this exists to prevent.
+fn jitter_ms(seed: u64, span_ms: u64) -> u64 {
+    if span_ms == 0 {
+        return 0;
+    }
+    let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    (z ^ (z >> 31)) % span_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const NOW: i64 = 1_788_000_000_000;
+
+    fn unlimited() -> RetrySettings {
+        RetrySettings { max_automatic_wait: None }
+    }
+
+    #[test]
+    fn overload_backoff_doubles_per_attempt() {
+        // Compare the jitter-free floor of each attempt: with one seed the
+        // jitter is a constant, so the gaps are the backoff.
+        let waits: Vec<i64> = (0..MAX_ATTEMPTS)
+            .map(|a| schedule(RetryClass::Overload, a, NOW, &unlimited(), 7).unwrap() - NOW)
+            .collect();
+        for pair in waits.windows(2) {
+            let (prev, next) = (pair[0], pair[1]);
+            let jitter = waits[0] - 30_000;
+            assert_eq!(next - jitter, (prev - jitter) * 2, "each attempt doubles: {waits:?}");
+        }
+    }
+
+    #[test]
+    fn a_window_is_scheduled_past_its_reset_never_before() {
+        let resets_at_ms = NOW + 6 * 60 * 60 * 1000;
+        for seed in 0..200 {
+            let wake =
+                schedule(RetryClass::Window { resets_at_ms }, 0, NOW, &unlimited(), seed).unwrap();
+            assert!(wake >= resets_at_ms + WINDOW_GRACE.as_millis() as i64, "seed {seed}");
+        }
+    }
+
+    /// A reset that has already passed must not fire instantly — the window
+    /// reopened while the failure was in flight, and the account may still be
+    /// catching up.
+    #[test]
+    fn a_reset_already_in_the_past_waits_from_now() {
+        let wake =
+            schedule(RetryClass::Window { resets_at_ms: NOW - 60_000 }, 0, NOW, &unlimited(), 3)
+                .unwrap();
+        assert!(wake >= NOW + WINDOW_GRACE.as_millis() as i64);
+    }
+
+    /// The test the feature lives or dies on. An implementation returning a
+    /// constant offset passes "jitter is non-zero" and still wakes every thread
+    /// on the account in the same second.
+    #[test]
+    fn twenty_threads_against_one_reset_get_twenty_distinct_wake_times() {
+        let resets_at_ms = NOW + 5 * 60 * 60 * 1000;
+        let wakes: Vec<i64> = (0..20)
+            .map(|thread| {
+                schedule(RetryClass::Window { resets_at_ms }, 0, NOW, &unlimited(), thread).unwrap()
+            })
+            .collect();
+        let distinct: HashSet<i64> = wakes.iter().copied().collect();
+        assert_eq!(distinct.len(), 20, "every thread must wake at its own moment: {wakes:?}");
+
+        // And they must actually *spread*, not merely differ: 20 samples over a
+        // 120s span should not all huddle inside one second.
+        let spread = wakes.iter().max().unwrap() - wakes.iter().min().unwrap();
+        assert!(spread > 30_000, "wake times cluster in {spread}ms, jitter is not spreading");
+    }
+
+    #[test]
+    fn jitter_stays_inside_its_span() {
+        for seed in 0..10_000 {
+            assert!(jitter_ms(seed, 120_000) < 120_000);
+        }
+        assert_eq!(jitter_ms(42, 0), 0, "a zero span must not divide by zero");
+    }
+
+    #[test]
+    fn the_cap_is_four_attempts() {
+        assert!(schedule(RetryClass::Overload, MAX_ATTEMPTS - 1, NOW, &unlimited(), 1).is_some());
+        assert!(schedule(RetryClass::Overload, MAX_ATTEMPTS, NOW, &unlimited(), 1).is_none());
+        assert!(schedule(RetryClass::Overload, 99, NOW, &unlimited(), 1).is_none());
+    }
+
+    #[test]
+    fn spend_and_other_are_never_scheduled() {
+        for class in [RetryClass::Spend, RetryClass::Other] {
+            for attempt in 0..MAX_ATTEMPTS {
+                assert!(
+                    schedule(class, attempt, NOW, &unlimited(), 1).is_none(),
+                    "{class:?} attempt {attempt} must not schedule"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_reset_beyond_the_ceiling_is_not_scheduled() {
+        let settings = RetrySettings { max_automatic_wait: Some(Duration::from_secs(6 * 60 * 60)) };
+        let within = NOW + 5 * 60 * 60 * 1000;
+        let beyond = NOW + 7 * 60 * 60 * 1000;
+        assert!(schedule(RetryClass::Window { resets_at_ms: within }, 0, NOW, &settings, 1).is_some());
+        assert!(schedule(RetryClass::Window { resets_at_ms: beyond }, 0, NOW, &settings, 1).is_none());
+    }
+
+    #[test]
+    fn no_limit_schedules_a_week_out() {
+        let a_week = NOW + 7 * 24 * 60 * 60 * 1000;
+        assert!(
+            schedule(RetryClass::Window { resets_at_ms: a_week }, 0, NOW, &unlimited(), 1).is_some()
+        );
+        assert!(
+            schedule(
+                RetryClass::Window { resets_at_ms: a_week },
+                0,
+                NOW,
+                &RetrySettings::default(),
+                1
+            )
+            .is_none(),
+            "the 24h default must refuse a weekly window"
+        );
+    }
+
+    #[test]
+    fn the_default_ceiling_is_a_day() {
+        assert_eq!(
+            RetrySettings::default().max_automatic_wait,
+            Some(Duration::from_secs(24 * 60 * 60))
+        );
+    }
+}

--- a/crates/agents/src/thread/acp/map.rs
+++ b/crates/agents/src/thread/acp/map.rs
@@ -729,4 +729,73 @@ mod tests {
             other => panic!("expected ToolCallStarted, got {other:?}"),
         }
     }
+
+    /// The shared transcript invariants, for the one agent with no captured
+    /// fixture.
+    ///
+    /// ACP's tests are built from typed protocol values rather than replayed
+    /// JSONL, and no ACP capture is committed, so this turn is **synthetic** —
+    /// stated plainly because a synthetic turn is weaker evidence than a
+    /// capture and the ledger should not imply otherwise. It is still worth
+    /// having: without it ACP is the only agent the oracle never runs against,
+    /// and the drift this catches is precisely a rule that holds everywhere
+    /// except the one place nobody checks.
+    ///
+    /// `TurnEnded` is appended by hand because ACP emits it from the worker,
+    /// not the mapper.
+    #[test]
+    fn a_settled_acp_turn_satisfies_the_transcript_invariants() {
+        let mut events = Vec::new();
+        let tc = ToolCall::new("call-1", "Read a file")
+            .kind(ToolKind::Read)
+            .raw_input(serde_json::json!({"path": "src/main.rs"}));
+        events.extend(map_session_update(SessionUpdate::ToolCall(tc)));
+        let done = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::from(ContentBlock::Text(TextContent::new(
+                "fn main() {}".to_string(),
+            )))]);
+        events.extend(map_session_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "call-1", done,
+        ))));
+        events.extend(map_session_update(SessionUpdate::AgentMessageChunk(text_chunk(
+            "Read it.",
+        ))));
+        events.push(ThreadEvent::TurnEnded {
+            result: None,
+            usage: None,
+            is_error: false,
+            turn_diff: None,
+        });
+
+        let mut thread = oximux_agent_core::thread::state::ChatThread::default();
+        for ev in &events {
+            thread.apply(ev);
+        }
+        oximux_agent_core::thread::invariants::assert_holds("acp-settled-turn", &thread, true);
+    }
+
+    /// Negative control: the same turn with the tool left in-flight MUST be
+    /// caught. Without this the test above proves only that some transcript
+    /// passes, not that the oracle is wired to ACP at all — the failure mode
+    /// that made two earlier oracles in this phase vacuous.
+    #[test]
+    fn an_acp_turn_that_leaves_a_tool_running_is_caught() {
+        let tc = ToolCall::new("call-stuck", "Read a file")
+            .raw_input(serde_json::json!({"path": "src/main.rs"}));
+        let mut events = map_session_update(SessionUpdate::ToolCall(tc));
+        events.push(ThreadEvent::TurnEnded {
+            result: None,
+            usage: None,
+            is_error: false,
+            turn_diff: None,
+        });
+        let mut thread = oximux_agent_core::thread::state::ChatThread::default();
+        for ev in &events {
+            thread.apply(ev);
+        }
+        let violations = oximux_agent_core::thread::invariants::check(&thread, true);
+        assert_eq!(violations.len(), 1, "a spinner surviving the turn must be caught: {violations:?}");
+    }
+
 }

--- a/crates/agents/src/thread/codex/map.rs
+++ b/crates/agents/src/thread/codex/map.rs
@@ -1843,4 +1843,33 @@ mod tests {
         assert_eq!(s["status"], "started");
         assert_eq!(s["agentPath"], "reviewer");
     }
+
+    /// Baseline for the assembler extraction (plan phase 4): the transcript
+    /// every committed codex fixture folds to, pinned before the mapper is
+    /// rewritten. Uses the same harness as the Claude fixtures in `agent-core`,
+    /// so all five agents are measured the same way.
+    ///
+    /// Regenerate a deliberate change with
+    /// `UPDATE_TRANSCRIPT_SNAPSHOTS=1 cargo test -p oximux-agents`, then read
+    /// the diff — the point of the pin is that a render change has to be
+    /// noticed and named, not accepted silently.
+    #[test]
+    fn every_captured_turn_renders_the_pinned_transcript() {
+        for fixture in [
+            "codex-collab-turn",
+            "codex-mcp-call-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            assert!(!events.is_empty(), "{fixture} decoded to nothing");
+            let thread = render(&events);
+            oximux_agent_core::thread::snapshot::assert_thread_snapshot(
+                format!(
+                    "{}/tests/snapshots/{fixture}.transcript.json",
+                    env!("CARGO_MANIFEST_DIR")
+                ),
+                &thread,
+            );
+        }
+    }
+
 }

--- a/crates/agents/src/thread/codex/map.rs
+++ b/crates/agents/src/thread/codex/map.rs
@@ -1872,4 +1872,28 @@ mod tests {
         }
     }
 
+
+    /// The shared transcript invariants, run against codex's captures.
+    ///
+    /// Separate from the snapshot test: a snapshot pins today's behaviour
+    /// including any bug in it, while these assert what a transcript must never
+    /// be. Same oracle for every agent, which is the point — the drift these
+    /// catch is a rule holding in four mappers and failing in the fifth.
+    #[test]
+    fn every_captured_turn_satisfies_the_transcript_invariants() {
+        for fixture in [
+            "codex-collab-turn",
+            "codex-mcp-call-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            // "A turn ran and finished", never `!turn_active` — an idle thread
+            // also reports no active turn.
+            let settled = events
+                .iter()
+                .any(|e| matches!(e, ThreadEvent::TurnEnded { .. }));
+            let thread = render(&events);
+            oximux_agent_core::thread::invariants::assert_holds(fixture, &thread, settled);
+        }
+    }
+
 }

--- a/crates/agents/src/thread/omp/map.rs
+++ b/crates/agents/src/thread/omp/map.rs
@@ -504,4 +504,28 @@ mod tests {
         }
     }
 
+
+    /// The shared transcript invariants, run against omp's captures.
+    ///
+    /// Separate from the snapshot test: a snapshot pins today's behaviour
+    /// including any bug in it, while these assert what a transcript must never
+    /// be. Same oracle for every agent, which is the point — the drift these
+    /// catch is a rule holding in four mappers and failing in the fifth.
+    #[test]
+    fn every_captured_turn_satisfies_the_transcript_invariants() {
+        for fixture in [
+            "omp-approval-deny-turn",
+            "omp-simple-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            // "A turn ran and finished", never `!turn_active` — an idle thread
+            // also reports no active turn.
+            let settled = events
+                .iter()
+                .any(|e| matches!(e, ThreadEvent::TurnEnded { .. }));
+            let thread = render(&events);
+            oximux_agent_core::thread::invariants::assert_holds(fixture, &thread, settled);
+        }
+    }
+
 }

--- a/crates/agents/src/thread/omp/map.rs
+++ b/crates/agents/src/thread/omp/map.rs
@@ -475,4 +475,33 @@ mod tests {
         );
         assert!(out[0].is_delta(), "must ride the existing repaint throttle");
     }
+
+    /// Baseline for the assembler extraction (plan phase 4): the transcript
+    /// every committed omp fixture folds to, pinned before the mapper is
+    /// rewritten. Uses the same harness as the Claude fixtures in `agent-core`,
+    /// so all five agents are measured the same way.
+    ///
+    /// Regenerate a deliberate change with
+    /// `UPDATE_TRANSCRIPT_SNAPSHOTS=1 cargo test -p oximux-agents`, then read
+    /// the diff — the point of the pin is that a render change has to be
+    /// noticed and named, not accepted silently.
+    #[test]
+    fn every_captured_turn_renders_the_pinned_transcript() {
+        for fixture in [
+            "omp-approval-deny-turn",
+            "omp-simple-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            assert!(!events.is_empty(), "{fixture} decoded to nothing");
+            let thread = render(&events);
+            oximux_agent_core::thread::snapshot::assert_thread_snapshot(
+                format!(
+                    "{}/tests/snapshots/{fixture}.transcript.json",
+                    env!("CARGO_MANIFEST_DIR")
+                ),
+                &thread,
+            );
+        }
+    }
+
 }

--- a/crates/agents/src/thread/pi/map.rs
+++ b/crates/agents/src/thread/pi/map.rs
@@ -680,4 +680,33 @@ mod tests {
         );
         assert!(matches!(&out[0], ThreadEvent::Error(m) if m.contains("/x/ext.js") && m.contains("boom")));
     }
+
+    /// Baseline for the assembler extraction (plan phase 4): the transcript
+    /// every committed pi fixture folds to, pinned before the mapper is
+    /// rewritten. Uses the same harness as the Claude fixtures in `agent-core`,
+    /// so all five agents are measured the same way.
+    ///
+    /// Regenerate a deliberate change with
+    /// `UPDATE_TRANSCRIPT_SNAPSHOTS=1 cargo test -p oximux-agents`, then read
+    /// the diff — the point of the pin is that a render change has to be
+    /// noticed and named, not accepted silently.
+    #[test]
+    fn every_captured_turn_renders_the_pinned_transcript() {
+        for fixture in [
+            "pi-chatty-bash-turn",
+            "pi-parallel-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            assert!(!events.is_empty(), "{fixture} decoded to nothing");
+            let thread = render(&events);
+            oximux_agent_core::thread::snapshot::assert_thread_snapshot(
+                format!(
+                    "{}/tests/snapshots/{fixture}.transcript.json",
+                    env!("CARGO_MANIFEST_DIR")
+                ),
+                &thread,
+            );
+        }
+    }
+
 }

--- a/crates/agents/src/thread/pi/map.rs
+++ b/crates/agents/src/thread/pi/map.rs
@@ -709,4 +709,28 @@ mod tests {
         }
     }
 
+
+    /// The shared transcript invariants, run against pi's captures.
+    ///
+    /// Separate from the snapshot test: a snapshot pins today's behaviour
+    /// including any bug in it, while these assert what a transcript must never
+    /// be. Same oracle for every agent, which is the point — the drift these
+    /// catch is a rule holding in four mappers and failing in the fifth.
+    #[test]
+    fn every_captured_turn_satisfies_the_transcript_invariants() {
+        for fixture in [
+            "pi-chatty-bash-turn",
+            "pi-parallel-turn",
+        ] {
+            let (events, _) = replay(&format!("{fixture}.jsonl"));
+            // "A turn ran and finished", never `!turn_active` — an idle thread
+            // also reports no active turn.
+            let settled = events
+                .iter()
+                .any(|e| matches!(e, ThreadEvent::TurnEnded { .. }));
+            let thread = render(&events);
+            oximux_agent_core::thread::invariants::assert_holds(fixture, &thread, settled);
+        }
+    }
+
 }

--- a/crates/agents/tests/retry_from_stream.rs
+++ b/crates/agents/tests/retry_from_stream.rs
@@ -1,0 +1,100 @@
+//! The retry path end to end, from wire lines to a scheduled wake time.
+//!
+//! The unit tests either side of this seam are thorough but each mocks the
+//! other's output. This drives real `stream-json` lines through the real
+//! decoder and the real fold, then asks the real classifier and policy what to
+//! do — so a decoder that stops emitting the reading, or a fold that stops
+//! keeping it, fails here rather than silently disabling retries in a way every
+//! unit test still passes.
+
+use oximux_agent_core::thread::state::ChatThread;
+use oximux_agent_core::thread::stream_json::decode_line;
+use oximux_agents::retry::{MAX_ATTEMPTS, RetryClass, RetrySettings, classify_failure, schedule};
+
+/// Unix ms well clear of the fixture's reset, so "past the reset" is meaningful.
+const NOW: i64 = 1_788_400_000_000;
+/// The `resetsAt` the fixture reports, in ms (the wire says seconds).
+const RESET_MS: i64 = 1_788_462_000_000;
+
+fn fold(lines: &[&str]) -> ChatThread {
+    let mut thread = ChatThread::default();
+    for line in lines {
+        for ev in decode_line(line) {
+            thread.apply(&ev);
+        }
+    }
+    thread
+}
+
+const REJECTED: &str = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"five_hour","utilization":100,"resetsAt":1788462000},"session_id":"sid"}"#;
+const OVERAGE: &str = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"overage","utilization":100},"session_id":"sid"}"#;
+const LIMIT_ERROR: &str = r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":429,"result":"rate limit","terminal_reason":"api_error","session_id":"sid"}"#;
+const OVERLOAD_ERROR: &str = r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":529,"result":"overloaded","terminal_reason":"api_error","session_id":"sid"}"#;
+const PLAIN_ERROR: &str = r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":400,"result":"bad request","terminal_reason":"api_error","session_id":"sid"}"#;
+
+#[test]
+fn a_closed_window_on_the_wire_becomes_a_wake_time_past_its_reset() {
+    let thread = fold(&[REJECTED, LIMIT_ERROR]);
+    let class = classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone());
+    assert_eq!(class, RetryClass::Window { resets_at_ms: RESET_MS });
+
+    let wake = schedule(class, 0, NOW, &RetrySettings { max_automatic_wait: None }, 1)
+        .expect("a closed window with a reset schedules");
+    assert!(wake > RESET_MS, "must wait past the reset, got {wake}");
+}
+
+/// The money case, driven from the wire rather than from a hand-built struct.
+#[test]
+fn an_overage_on_the_wire_schedules_nothing() {
+    let thread = fold(&[OVERAGE, LIMIT_ERROR]);
+    let class = classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone());
+    assert_eq!(class, RetryClass::Spend);
+    for attempt in 0..MAX_ATTEMPTS {
+        assert!(
+            schedule(class, attempt, NOW, &RetrySettings::default(), 1).is_none(),
+            "an overage must never be scheduled"
+        );
+    }
+}
+
+#[test]
+fn an_overloaded_provider_is_retried_without_any_rate_limit_reading() {
+    let thread = fold(&[OVERLOAD_ERROR]);
+    assert!(thread.last_rate_limit.is_none(), "no rate_limit_event arrived");
+    let class = classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone());
+    assert_eq!(class, RetryClass::Overload);
+    assert!(schedule(class, 0, NOW, &RetrySettings::default(), 1).is_some());
+}
+
+#[test]
+fn an_ordinary_error_is_never_retried() {
+    let thread = fold(&[PLAIN_ERROR]);
+    let class = classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone());
+    assert_eq!(class, RetryClass::Other);
+    assert!(schedule(class, 0, NOW, &RetrySettings::default(), 1).is_none());
+}
+
+/// A limit that closed and then reopened must not keep classifying failures as
+/// window failures — the fold keeps the latest reading, so a later `allowed`
+/// supersedes the earlier `rejected`.
+#[test]
+fn a_window_that_reopened_no_longer_explains_a_later_failure() {
+    let allowed = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour","utilization":3,"resetsAt":1788480000},"session_id":"sid"}"#;
+    let thread = fold(&[REJECTED, allowed, PLAIN_ERROR]);
+    let class = classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone());
+    assert_eq!(class, RetryClass::Other, "the stale rejection must not be reused");
+}
+
+/// A new turn clears the previous turn's typed failure, so a later failure the
+/// provider says nothing about cannot inherit an older explanation.
+#[test]
+fn starting_a_turn_clears_the_previous_failure_detail() {
+    let mut thread = fold(&[OVERLOAD_ERROR]);
+    assert!(thread.last_turn_failure.is_some());
+    thread.push_user_message_with_images("next", Vec::new());
+    assert!(thread.last_turn_failure.is_none(), "a fresh turn starts with no failure");
+    assert_eq!(
+        classify_failure(thread.last_rate_limit.as_ref(), thread.last_turn_failure.clone()),
+        RetryClass::Other
+    );
+}

--- a/crates/agents/tests/snapshots/codex-collab-turn.transcript.json
+++ b/crates/agents/tests/snapshots/codex-collab-turn.transcript.json
@@ -1,0 +1,83 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": null,
+  "entries": [
+    {
+      "Assistant": {
+        "text": "I’ll delegate the file check exactly as requested, then wait for the collaborator’s report.",
+        "thinking": ""
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "call_7LG5kEHGdhe7YTviKbxPqHhs",
+        "name": "Agent activity",
+        "input": {
+          "type": "subAgentActivity",
+          "id": "call_7LG5kEHGdhe7YTviKbxPqHhs",
+          "kind": "started",
+          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78",
+          "agentPath": "/root/verify_scratch_file"
+        },
+        "status": "Completed",
+        "result": "started · /root/verify_scratch_file",
+        "structured": {
+          "type": "subAgentActivity",
+          "status": "started",
+          "agentPath": "/root/verify_scratch_file",
+          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78"
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": [
+          "I’ll read the requested file exactly as-is and report its contents without making changes.",
+          "Bash /bin/zsh -lc \"sed -n '1,200p' scratch-verify.txt\"",
+          "The exact contents are `hello` followed by a newline."
+        ]
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "call_uQMjDqyqRz3ZqGTv76OrnCCS",
+        "name": "Agent",
+        "input": {
+          "type": "collabAgentToolCall",
+          "id": "call_uQMjDqyqRz3ZqGTv76OrnCCS",
+          "tool": "wait",
+          "status": "inProgress",
+          "senderThreadId": "019f68e6-f6d4-7341-b59c-94984172beac",
+          "receiverThreadIds": [],
+          "prompt": null,
+          "model": null,
+          "reasoningEffort": null,
+          "agentsStates": {}
+        },
+        "status": "Completed",
+        "result": "completed",
+        "structured": {
+          "type": "collabAgentToolCall",
+          "tool": "wait",
+          "status": "completed",
+          "callStatus": "completed",
+          "agents": []
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    }
+  ]
+}

--- a/crates/agents/tests/snapshots/codex-collab-turn.transcript.json
+++ b/crates/agents/tests/snapshots/codex-collab-turn.transcript.json
@@ -20,19 +20,19 @@
         "id": "call_7LG5kEHGdhe7YTviKbxPqHhs",
         "name": "Agent activity",
         "input": {
-          "type": "subAgentActivity",
+          "agentPath": "/root/verify_scratch_file",
+          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78",
           "id": "call_7LG5kEHGdhe7YTviKbxPqHhs",
           "kind": "started",
-          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78",
-          "agentPath": "/root/verify_scratch_file"
+          "type": "subAgentActivity"
         },
         "status": "Completed",
         "result": "started · /root/verify_scratch_file",
         "structured": {
-          "type": "subAgentActivity",
-          "status": "started",
           "agentPath": "/root/verify_scratch_file",
-          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78"
+          "agentThreadId": "019f68e7-2f5a-72d2-842d-324e7b8bae78",
+          "status": "started",
+          "type": "subAgentActivity"
         },
         "images": [],
         "terminal_id": null,
@@ -51,25 +51,25 @@
         "id": "call_uQMjDqyqRz3ZqGTv76OrnCCS",
         "name": "Agent",
         "input": {
-          "type": "collabAgentToolCall",
+          "agentsStates": {},
           "id": "call_uQMjDqyqRz3ZqGTv76OrnCCS",
-          "tool": "wait",
-          "status": "inProgress",
-          "senderThreadId": "019f68e6-f6d4-7341-b59c-94984172beac",
-          "receiverThreadIds": [],
-          "prompt": null,
           "model": null,
+          "prompt": null,
           "reasoningEffort": null,
-          "agentsStates": {}
+          "receiverThreadIds": [],
+          "senderThreadId": "019f68e6-f6d4-7341-b59c-94984172beac",
+          "status": "inProgress",
+          "tool": "wait",
+          "type": "collabAgentToolCall"
         },
         "status": "Completed",
         "result": "completed",
         "structured": {
-          "type": "collabAgentToolCall",
-          "tool": "wait",
-          "status": "completed",
+          "agents": [],
           "callStatus": "completed",
-          "agents": []
+          "status": "completed",
+          "tool": "wait",
+          "type": "collabAgentToolCall"
         },
         "images": [],
         "terminal_id": null,

--- a/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
+++ b/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
@@ -1,0 +1,54 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 30848,
+    "output_tokens": 5,
+    "cache_read_tokens": 30464,
+    "cache_creation_tokens": 0,
+    "context_window": 258400,
+    "cost_usd": null
+  },
+  "entries": [
+    {
+      "ToolCall": {
+        "id": "exec-8059a8f9-c24d-4465-9e76-932f9b48c5b1",
+        "name": "mcp__node_repl__js",
+        "input": {
+          "code": "nodeRepl.write(6*7)",
+          "title": "Evaluate 6×7"
+        },
+        "status": "Completed",
+        "result": "42",
+        "structured": {
+          "content": [
+            {
+              "type": "text",
+              "text": "42"
+            }
+          ],
+          "structuredContent": null,
+          "_meta": null
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "42",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
+++ b/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
@@ -27,14 +27,14 @@
         "status": "Completed",
         "result": "42",
         "structured": {
+          "_meta": null,
           "content": [
             {
-              "type": "text",
-              "text": "42"
+              "text": "42",
+              "type": "text"
             }
           ],
-          "structuredContent": null,
-          "_meta": null
+          "structuredContent": null
         },
         "images": [],
         "terminal_id": null,

--- a/crates/agents/tests/snapshots/omp-approval-deny-turn.transcript.json
+++ b/crates/agents/tests/snapshots/omp-approval-deny-turn.transcript.json
@@ -37,8 +37,8 @@
         "structured": {
           "content": [
             {
-              "type": "text",
-              "text": "Tool call denied by user: bash"
+              "text": "Tool call denied by user: bash",
+              "type": "text"
             }
           ],
           "details": {}

--- a/crates/agents/tests/snapshots/omp-approval-deny-turn.transcript.json
+++ b/crates/agents/tests/snapshots/omp-approval-deny-turn.transcript.json
@@ -1,0 +1,61 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 36261,
+    "output_tokens": 42,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": 272000,
+    "cost_usd": 0.18256500000000003
+  },
+  "entries": [
+    {
+      "Assistant": {
+        "text": "",
+        "thinking": "**Planning exact bash compliance**"
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "call_JC2x1t0e1NYOEuYHQ6K2UyfB|fc_009310381652633d016a8d4edf8c2c87d0b188600af0533a74",
+        "name": "bash",
+        "input": {
+          "command": "echo touched > /tmp/ompprobe/proj1/marker.txt",
+          "cwd": "/tmp/ompprobe/proj1"
+        },
+        "status": {
+          "Failed": "Tool call denied by user: bash"
+        },
+        "result": "Tool call denied by user: bash",
+        "structured": {
+          "content": [
+            {
+              "type": "text",
+              "text": "Tool call denied by user: bash"
+            }
+          ],
+          "details": {}
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "Unable to run the command: the Bash tool call was denied. No file change was made.",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agents/tests/snapshots/omp-simple-turn.transcript.json
+++ b/crates/agents/tests/snapshots/omp-simple-turn.transcript.json
@@ -1,0 +1,26 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 36164,
+    "output_tokens": 5,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": 272000,
+    "cost_usd": 0.18097
+  },
+  "entries": [
+    {
+      "Assistant": {
+        "text": "DONE",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agents/tests/snapshots/pi-chatty-bash-turn.transcript.json
+++ b/crates/agents/tests/snapshots/pi-chatty-bash-turn.transcript.json
@@ -28,8 +28,8 @@
         "structured": {
           "content": [
             {
-              "type": "text",
-              "text": "line-1\nline-2\nline-3\nline-4\nline-5\nline-6\nline-7\nline-8\nline-9\nline-10\nline-11\nline-12\nline-13\nline-14\nline-15\nline-16\nline-17\nline-18\nline-19\nline-20\nline-21\nline-22\nline-23\nline-24\nline-25\nline-26\nline-27\nline-28\nline-29\nline-30\nline-31\nline-32\nline-33\nline-34\nline-35\nline-36\nline-37\nline-38\nline-39\nline-40\nline-41\nline-42\nline-43\nline-44\nline-45\nline-46\nline-47\nline-48\nline-49\nline-50\nline-51\nline-52\nline-53\nline-54\nline-55\nline-56\nline-57\nline-58\nline-59\nline-60\n"
+              "text": "line-1\nline-2\nline-3\nline-4\nline-5\nline-6\nline-7\nline-8\nline-9\nline-10\nline-11\nline-12\nline-13\nline-14\nline-15\nline-16\nline-17\nline-18\nline-19\nline-20\nline-21\nline-22\nline-23\nline-24\nline-25\nline-26\nline-27\nline-28\nline-29\nline-30\nline-31\nline-32\nline-33\nline-34\nline-35\nline-36\nline-37\nline-38\nline-39\nline-40\nline-41\nline-42\nline-43\nline-44\nline-45\nline-46\nline-47\nline-48\nline-49\nline-50\nline-51\nline-52\nline-53\nline-54\nline-55\nline-56\nline-57\nline-58\nline-59\nline-60\n",
+              "type": "text"
             }
           ]
         },

--- a/crates/agents/tests/snapshots/pi-chatty-bash-turn.transcript.json
+++ b/crates/agents/tests/snapshots/pi-chatty-bash-turn.transcript.json
@@ -1,0 +1,51 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 397,
+    "output_tokens": 5,
+    "cache_read_tokens": 3072,
+    "cache_creation_tokens": 0,
+    "context_window": 272000,
+    "cost_usd": 0.003671
+  },
+  "entries": [
+    {
+      "ToolCall": {
+        "id": "call_lfQ7gRrtSnxFtOCqvUxYzf6b|fc_05f57dd2f341d620016a574e848c5081918f1d8ab9a536ee2d",
+        "name": "bash",
+        "input": {
+          "command": "for i in $(seq 1 60); do echo line-$i; sleep 0.05; done"
+        },
+        "status": "Completed",
+        "result": "line-1\nline-2\nline-3\nline-4\nline-5\nline-6\nline-7\nline-8\nline-9\nline-10\nline-11\nline-12\nline-13\nline-14\nline-15\nline-16\nline-17\nline-18\nline-19\nline-20\nline-21\nline-22\nline-23\nline-24\nline-25\nline-26\nline-27\nline-28\nline-29\nline-30\nline-31\nline-32\nline-33\nline-34\nline-35\nline-36\nline-37\nline-38\nline-39\nline-40\nline-41\nline-42\nline-43\nline-44\nline-45\nline-46\nline-47\nline-48\nline-49\nline-50\nline-51\nline-52\nline-53\nline-54\nline-55\nline-56\nline-57\nline-58\nline-59\nline-60\n",
+        "structured": {
+          "content": [
+            {
+              "type": "text",
+              "text": "line-1\nline-2\nline-3\nline-4\nline-5\nline-6\nline-7\nline-8\nline-9\nline-10\nline-11\nline-12\nline-13\nline-14\nline-15\nline-16\nline-17\nline-18\nline-19\nline-20\nline-21\nline-22\nline-23\nline-24\nline-25\nline-26\nline-27\nline-28\nline-29\nline-30\nline-31\nline-32\nline-33\nline-34\nline-35\nline-36\nline-37\nline-38\nline-39\nline-40\nline-41\nline-42\nline-43\nline-44\nline-45\nline-46\nline-47\nline-48\nline-49\nline-50\nline-51\nline-52\nline-53\nline-54\nline-55\nline-56\nline-57\nline-58\nline-59\nline-60\n"
+            }
+          ]
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "DONE",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/agents/tests/snapshots/pi-parallel-turn.transcript.json
+++ b/crates/agents/tests/snapshots/pi-parallel-turn.transcript.json
@@ -34,8 +34,8 @@
         "structured": {
           "content": [
             {
-              "type": "text",
-              "text": "alpha file contents\n"
+              "text": "alpha file contents\n",
+              "type": "text"
             }
           ]
         },
@@ -59,8 +59,8 @@
         "structured": {
           "content": [
             {
-              "type": "text",
-              "text": "beta file contents\n"
+              "text": "beta file contents\n",
+              "type": "text"
             }
           ]
         },

--- a/crates/agents/tests/snapshots/pi-parallel-turn.transcript.json
+++ b/crates/agents/tests/snapshots/pi-parallel-turn.transcript.json
@@ -1,0 +1,82 @@
+{
+  "session_id": null,
+  "model": null,
+  "permission_mode": null,
+  "turn_active": false,
+  "compacting": false,
+  "title": null,
+  "last_error": null,
+  "last_summary": null,
+  "usage": {
+    "input_tokens": 3314,
+    "output_tokens": 21,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "context_window": 272000,
+    "cost_usd": 0.0172
+  },
+  "entries": [
+    {
+      "Assistant": {
+        "text": "I’ll read both files in parallel and then summarize their contents in one sentence.",
+        "thinking": "**Planning response structure and file inspection**"
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "call_x85NYgwkQDjet14rXUlIjiU8|fc_02ea43d362f49e5a016a574e398568819180c93765458827b0",
+        "name": "read",
+        "input": {
+          "path": "alpha.txt"
+        },
+        "status": "Completed",
+        "result": "alpha file contents\n",
+        "structured": {
+          "content": [
+            {
+              "type": "text",
+              "text": "alpha file contents\n"
+            }
+          ]
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "ToolCall": {
+        "id": "call_i1Hg5F0Vt1SiBnoiGPj6HuCr|fc_02ea43d362f49e5a016a574e39857c8191952fbfc6b90f5ae3",
+        "name": "read",
+        "input": {
+          "path": "beta.txt"
+        },
+        "status": "Completed",
+        "result": "beta file contents\n",
+        "structured": {
+          "content": [
+            {
+              "type": "text",
+              "text": "beta file contents\n"
+            }
+          ]
+        },
+        "images": [],
+        "terminal_id": null,
+        "kind": null,
+        "approved_input": null,
+        "redact_result": false,
+        "subagent_log": []
+      }
+    },
+    {
+      "Assistant": {
+        "text": "alpha.txt contains “alpha file contents,” and beta.txt contains “beta file contents.”",
+        "thinking": ""
+      }
+    }
+  ]
+}

--- a/crates/settings/src/agent_retry.rs
+++ b/crates/settings/src/agent_retry.rs
@@ -1,0 +1,161 @@
+//! How long the app may hold a rate-limited turn before giving it back.
+//!
+//! Retrying a closed usage window means waiting for the provider's reset, which
+//! can be hours away for a five-hour window and days for a weekly one. Waiting
+//! is usually what the user wants — the alternative is coming back to a failed
+//! turn and pressing send by hand. Waiting *silently for days* is not: a queued
+//! turn and a forgotten one look identical, and a turn that fires two days late
+//! lands in a context the user has moved on from.
+//!
+//! So the wait is capped. A reset farther out than the cap is not scheduled at
+//! all; the failure surfaces as an ordinary error the user can act on.
+
+use std::time::Duration;
+
+#[cfg(feature = "gpui")]
+use gpui::Global;
+
+/// The choices offered, in the order the settings pane lists them.
+///
+/// A closed enum rather than a free-form duration: the meaningful answers are
+/// "shorter than a five-hour window", "long enough for one", and "however long
+/// it takes", and a spinner inviting `7h13m` would only add ways to be wrong.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MaxAutomaticWait {
+    /// Long enough for a five-hour window to reopen, not for a weekly one.
+    SixHours,
+    /// The default: covers every five-hour window and a same-day weekly reset.
+    #[default]
+    OneDay,
+    /// Wait however long the provider says, including a weekly reset days out.
+    NoLimit,
+}
+
+impl MaxAutomaticWait {
+    /// Every variant, for rendering a picker.
+    pub const ALL: &'static [Self] = &[Self::SixHours, Self::OneDay, Self::NoLimit];
+
+    /// The cap as a duration; `None` for [`Self::NoLimit`].
+    pub fn duration(self) -> Option<Duration> {
+        match self {
+            Self::SixHours => Some(Duration::from_secs(6 * 60 * 60)),
+            Self::OneDay => Some(Duration::from_secs(24 * 60 * 60)),
+            Self::NoLimit => None,
+        }
+    }
+
+    /// Label for the picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::SixHours => "Up to 6 hours",
+            Self::OneDay => "Up to 24 hours",
+            Self::NoLimit => "No limit",
+        }
+    }
+
+    /// Stable token for persistence. Parsed by [`Self::from_token`], which
+    /// falls back to the default rather than failing — an unreadable setting
+    /// must not stop the app from starting.
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::SixHours => "six-hours",
+            Self::OneDay => "one-day",
+            Self::NoLimit => "no-limit",
+        }
+    }
+
+    /// Inverse of [`Self::token`]; anything unrecognised is the default.
+    pub fn from_token(token: &str) -> Self {
+        Self::ALL.iter().copied().find(|v| v.token() == token).unwrap_or_default()
+    }
+}
+
+/// Retry behaviour, as configured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct AgentRetrySettings {
+    /// When false, a failed turn is never rescheduled — it surfaces as an error
+    /// immediately, which is the pre-retry behaviour.
+    pub enabled: bool,
+    pub max_automatic_wait: MaxAutomaticWait,
+}
+
+impl Default for AgentRetrySettings {
+    fn default() -> Self {
+        Self::shipped()
+    }
+}
+
+impl AgentRetrySettings {
+    /// File this is persisted to, beside the other per-app settings.
+    pub const FILE_NAME: &'static str = "agent_retry.toml";
+
+    /// The shipped default: on, capped at a day.
+    pub fn shipped() -> Self {
+        Self { enabled: true, max_automatic_wait: MaxAutomaticWait::OneDay }
+    }
+
+    pub fn from_toml_str(text: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(text)
+    }
+
+    pub fn to_toml_string(&self) -> String {
+        toml::to_string_pretty(self).expect("agent retry settings serialize")
+    }
+}
+
+#[cfg(feature = "gpui")]
+impl Global for AgentRetrySettings {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_shipped_default_is_on_and_capped_at_a_day() {
+        let s = AgentRetrySettings::shipped();
+        assert!(s.enabled);
+        assert_eq!(s.max_automatic_wait.duration(), Some(Duration::from_secs(86_400)));
+    }
+
+    #[test]
+    fn tokens_round_trip_and_unknown_falls_back() {
+        for v in MaxAutomaticWait::ALL {
+            assert_eq!(MaxAutomaticWait::from_token(v.token()), *v);
+        }
+        assert_eq!(MaxAutomaticWait::from_token("forever-and-ever"), MaxAutomaticWait::OneDay);
+        assert_eq!(MaxAutomaticWait::from_token(""), MaxAutomaticWait::OneDay);
+    }
+
+    #[test]
+    fn settings_round_trip_through_toml() {
+        for wait in MaxAutomaticWait::ALL {
+            let s = AgentRetrySettings { enabled: false, max_automatic_wait: *wait };
+            assert_eq!(AgentRetrySettings::from_toml_str(&s.to_toml_string()).expect("parses"), s);
+        }
+    }
+
+    /// A file written by an older build carries fewer keys; the rest must
+    /// default rather than fail the load and silently disable retries.
+    #[test]
+    fn a_partial_file_loads_with_defaults() {
+        let parsed = AgentRetrySettings::from_toml_str("enabled = false").expect("parses");
+        assert!(!parsed.enabled);
+        assert_eq!(parsed.max_automatic_wait, MaxAutomaticWait::OneDay);
+    }
+
+    /// The on-disk key names are user-facing — `docs/agent-retry.md` prints this
+    /// exact file. A rename here silently invalidates that example.
+    #[test]
+    fn the_documented_toml_keys_are_the_real_ones() {
+        let text = AgentRetrySettings::shipped().to_toml_string();
+        assert!(text.contains("enabled = true"), "got: {text}");
+        assert!(text.contains(r#"max_automatic_wait = "one-day""#), "got: {text}");
+    }
+
+    #[test]
+    fn no_limit_has_no_duration() {
+        assert_eq!(MaxAutomaticWait::NoLimit.duration(), None);
+    }
+}

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -45,7 +45,7 @@ pub use dictation_languages::{WHISPER_LANGUAGES, display_name as language_displa
 pub use fonts::FontChoice;
 pub use keybindings::KeybindingOverrides;
 pub use motion::{Motion, ease_out_spring};
-pub use project_scripts::{ProjectScripts, ScriptKind, load_for_project};
+pub use project_scripts::{ProjectScripts, ScriptKind, SetupDecision, load_for_project};
 pub use terminal::{BellStyle, TerminalSettings, WindowsPowerShell, WindowsShell};
 #[cfg(feature = "gpui")]
 pub use theme::{GitDecorations, SyntaxPalette, Theme};

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -6,6 +6,7 @@
 //! Phase 0 ships dark-only. Light mode is a Phase 8+ decision.
 
 pub mod agent_launch;
+pub mod agent_retry;
 pub mod appearance;
 pub mod auto_update;
 pub mod autosave;

--- a/crates/settings/src/project_scripts.rs
+++ b/crates/settings/src/project_scripts.rs
@@ -3,7 +3,11 @@
 //! Defined in a per-project `.oximux/scripts.toml` (git-committable so a
 //! team shares them). Each entry is an optional shell snippet run against a
 //! worktree via the user's shell. `auto_setup` opts into running `setup`
-//! automatically right after a worktree is created (default off).
+//! automatically as part of worktree *provisioning* (default off) — see
+//! [`SetupDecision`] for how a one-off override composes with it.
+//!
+//! `default_tabs` names terminal tabs to open in a freshly provisioned
+//! worktree, so a project can declare the shell layout a new branch starts in.
 //!
 //! Do not store secrets here — `.oximux/scripts.toml` is intended to be
 //! committed to git, the same trust boundary as `commands.toml`. Parsing is
@@ -42,8 +46,47 @@ pub struct ProjectScripts {
     pub setup: Option<String>,
     pub run: Option<String>,
     pub cleanup: Option<String>,
-    /// Opt-in: run `setup` automatically after a worktree is created.
+    /// Opt-in: run `setup` as part of worktree provisioning. Default off, so
+    /// a project that never asked for it sees no behavior change.
+    ///
+    /// This is the *project* half of the decision — the committed team answer.
+    /// A single create can override it either way via [`SetupDecision`].
     pub auto_setup: bool,
+    /// Terminal tabs to open in a newly provisioned worktree, by title. Each
+    /// entry opens a plain shell rooted at the worktree; an empty list (the
+    /// default) opens nothing.
+    #[serde(default)]
+    pub default_tabs: Vec<String>,
+}
+
+/// Whether one worktree creation should run the project's `setup` script.
+///
+/// Three-way rather than a bool because the per-request answer and the
+/// per-project answer are different facts: `auto_setup` is what the team
+/// committed, and `Inherit` — the default — is a request declining to
+/// second-guess it. `Run`/`Skip` are the one-off answers a create dialog gives
+/// for a single throwaway or a single must-provision worktree.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SetupDecision {
+    /// Run setup for this creation regardless of `auto_setup`.
+    Run,
+    /// Skip setup for this creation regardless of `auto_setup`.
+    Skip,
+    /// Defer to the project's `auto_setup` flag.
+    #[default]
+    Inherit,
+}
+
+impl SetupDecision {
+    /// Resolve the three-way override against the project's committed flag.
+    pub fn resolve(self, auto_setup: bool) -> bool {
+        match self {
+            Self::Run => true,
+            Self::Skip => false,
+            Self::Inherit => auto_setup,
+        }
+    }
 }
 
 impl ProjectScripts {
@@ -158,12 +201,41 @@ future_field = "ignored"
     }
 
     #[test]
+    fn default_tabs_is_empty_when_absent() {
+        let s = ProjectScripts::from_toml_str("setup = \"x\"").expect("parse");
+        assert!(s.default_tabs.is_empty());
+    }
+
+    #[test]
+    fn default_tabs_parses_a_list() {
+        let s = ProjectScripts::from_toml_str("default_tabs = [\"server\", \"logs\"]")
+            .expect("parse");
+        assert_eq!(s.default_tabs, vec!["server".to_string(), "logs".to_string()]);
+    }
+
+    /// `Inherit` is the default so an unspecified request cannot silently
+    /// override what the project committed.
+    #[test]
+    fn inherit_defers_to_the_project_flag() {
+        assert!(SetupDecision::default() == SetupDecision::Inherit);
+        assert!(SetupDecision::Inherit.resolve(true));
+        assert!(!SetupDecision::Inherit.resolve(false));
+    }
+
+    #[test]
+    fn an_explicit_decision_overrides_the_project_flag_both_ways() {
+        assert!(SetupDecision::Run.resolve(false));
+        assert!(!SetupDecision::Skip.resolve(true));
+    }
+
+    #[test]
     fn round_trip_serialization() {
         let original = ProjectScripts {
             setup: Some("a".into()),
             run: Some("b".into()),
             cleanup: None,
             auto_setup: true,
+            default_tabs: vec!["server".into()],
         };
         let toml = original.to_toml_string();
         let parsed = ProjectScripts::from_toml_str(&toml).expect("round-trip");

--- a/crates/worktree-ops/Cargo.toml
+++ b/crates/worktree-ops/Cargo.toml
@@ -32,6 +32,12 @@ oximux-remote-proto = { workspace = true }
 # `no_window` on the cleanup subprocess: a teardown script must not flash a
 # console on Windows.
 oximux-no-window = { workspace = true }
+# `.oximuxinclude` matching. Already in the tree (the file-tree backend uses
+# it), and gitignore semantics are exactly what the include file promises —
+# hand-rolling globs here would diverge from the syntax users already know.
+# Only `gitignore::Gitignore` is used: the walk is our own, because it has to
+# be anchored and budgeted (see `include.rs`).
+ignore = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/worktree-ops/src/include.rs
+++ b/crates/worktree-ops/src/include.rs
@@ -1,0 +1,709 @@
+//! `.oximuxinclude` — copying a project's untracked local files into a fresh
+//! worktree.
+//!
+//! A git worktree gets every *tracked* file for free and none of the untracked
+//! ones. That is correct for git and useless for the user: the `.env`, the dev
+//! certs, and the local overrides that the setup script and the app both need
+//! stay behind in the main checkout. `.oximuxinclude` is the project's
+//! declaration of which of those a worktree cannot work without.
+//!
+//! It is committed, so it names *paths*, never secrets — the files it points at
+//! are the untracked ones, and they are copied, not listed.
+//!
+//! # Supported syntax
+//!
+//! One pattern per line; blank lines and `#` comments ignored; a leading `!`
+//! negates. Paths are relative to the project root. Matching is real gitignore
+//! semantics (via the `ignore` crate), so `*.pem`, `certs/`, and `config/*.local`
+//! all mean what they mean in a `.gitignore`.
+//!
+//! The one deliberate departure: a pattern is **anchored at its literal
+//! prefix**. `certs/*.pem` scans `certs/` rather than the whole repo, and only
+//! a pattern that begins with a wildcard (`*.pem`, `**/x`) scans from the root.
+//! Gitignore has no such notion because git is matching paths it already
+//! walked; here the walk is the expensive part, and an unanchored scan of a
+//! repo with a `node_modules` in it is the difference between instant and
+//! minutes. A root-anchored scan is still bounded by [`SCAN_BUDGET`] and
+//! reports when it hits it, so the pathological case is a visible skip rather
+//! than a worktree creation that appears to hang.
+//!
+//! # The copy contract
+//!
+//! Each clause below has its own test, because the two symlink clauses are a
+//! security boundary rather than a nicety: a copy that dereferences a source
+//! symlink, or writes through one in the target, writes outside the worktree.
+//!
+//! 1. Regular files are copied. Directories are copied recursively.
+//! 2. A path that already exists in the worktree wins and the skip is reported
+//!    — a tracked file is never overwritten by an include.
+//! 3. A source symlink is skipped, never dereferenced.
+//! 4. An existing symlink anywhere in the target path is refused, so a copy
+//!    can never be redirected outside the worktree.
+//! 5. A pattern that matches nothing is reported, and the copy continues.
+//! 6. An unreadable source or a failed write is reported, and the copy
+//!    continues.
+//!
+//! Nothing here fails provisioning. A missing `.env` is worth telling the user
+//! about; it is not worth destroying the worktree they asked for. The setup
+//! script — which *can* fail creation — is the thing that decides whether the
+//! files it needed were actually there.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+/// File name, at the project root.
+pub const FILE_NAME: &str = ".oximuxinclude";
+
+/// Upper bound on directory entries visited while expanding wildcard patterns.
+/// Only reachable by a pattern anchored at the repo root; see the module note.
+const SCAN_BUDGET: usize = 100_000;
+
+/// Why one path was not copied. Every variant is reported to the provisioning
+/// transcript — a silent skip is the failure mode this whole module exists to
+/// avoid, since the user finds out later via a setup script that cannot find
+/// its config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Skip {
+    /// The worktree already has this path (a tracked file). It wins.
+    AlreadyPresent(PathBuf),
+    /// Source is a symlink; copying it would either dereference outside the
+    /// project or plant a dangling link in the worktree.
+    SourceIsSymlink(PathBuf),
+    /// A component of the destination path is an existing symlink.
+    TargetPathCrossesSymlink(PathBuf),
+    /// The pattern resolved to nothing — usually a typo or a file the author
+    /// has locally and this machine does not.
+    MatchedNothing(String),
+    /// The pattern would leave the project root (`..`, or an absolute path).
+    EscapesProjectRoot(String),
+    /// Read or write failed.
+    Failed { path: PathBuf, error: String },
+    /// A root-anchored wildcard exhausted [`SCAN_BUDGET`].
+    ScanBudgetExhausted(String),
+}
+
+impl fmt::Display for Skip {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyPresent(p) => {
+                write!(f, "{}: already in the worktree (tracked file wins)", p.display())
+            }
+            Self::SourceIsSymlink(p) => write!(f, "{}: source is a symlink; skipped", p.display()),
+            Self::TargetPathCrossesSymlink(p) => {
+                write!(f, "{}: destination path crosses a symlink; refused", p.display())
+            }
+            Self::MatchedNothing(pat) => write!(f, "{pat}: matched nothing"),
+            Self::EscapesProjectRoot(pat) => write!(f, "{pat}: leaves the project root; refused"),
+            Self::Failed { path, error } => write!(f, "{}: {error}", path.display()),
+            Self::ScanBudgetExhausted(pat) => write!(
+                f,
+                "{pat}: scan hit {SCAN_BUDGET} entries and stopped; anchor the pattern to a \
+                 directory (e.g. `certs/*.pem`) instead of the repo root"
+            ),
+        }
+    }
+}
+
+/// What the copy did, for the provisioning transcript.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CopyReport {
+    /// Paths (relative to the project root) written into the worktree.
+    pub copied: Vec<PathBuf>,
+    /// Everything not copied, with the reason.
+    pub skipped: Vec<Skip>,
+}
+
+impl CopyReport {
+    /// True when there was no `.oximuxinclude`, or it declared nothing.
+    pub fn is_empty(&self) -> bool {
+        self.copied.is_empty() && self.skipped.is_empty()
+    }
+}
+
+/// Copy the files `<project_root>/.oximuxinclude` declares into `worktree`.
+///
+/// Best-effort by contract: an absent file is a no-op, and every per-path
+/// problem lands in [`CopyReport::skipped`] rather than aborting the rest.
+pub fn copy_included_files(project_root: &Path, worktree: &Path) -> CopyReport {
+    let mut report = CopyReport::default();
+    let text = match std::fs::read_to_string(project_root.join(FILE_NAME)) {
+        Ok(t) => t,
+        Err(_) => return report, // absent → nothing declared → nothing to do
+    };
+    let patterns = parse(&text);
+    if patterns.is_empty() {
+        return report;
+    }
+    // One matcher over the whole file so `!` negation composes the way it does
+    // in a .gitignore — a later `!secrets.env` really does exclude an earlier
+    // `*.env`.
+    let mut builder = GitignoreBuilder::new(project_root);
+    for pattern in &patterns {
+        if let Err(err) = builder.add_line(None, pattern) {
+            report.skipped.push(Skip::Failed {
+                path: PathBuf::from(pattern),
+                error: format!("bad pattern: {err}"),
+            });
+        }
+    }
+    let matcher = match builder.build() {
+        Ok(m) => m,
+        Err(err) => {
+            report.skipped.push(Skip::Failed {
+                path: PathBuf::from(FILE_NAME),
+                error: format!("could not build matcher: {err}"),
+            });
+            return report;
+        }
+    };
+
+    // Sorted+deduped: two patterns may name the same file, and a stable order
+    // makes the transcript reproducible.
+    let mut selected: BTreeSet<PathBuf> = BTreeSet::new();
+    for pattern in &patterns {
+        if pattern.starts_with('!') {
+            continue; // negation only ever removes; nothing to expand
+        }
+        expand(project_root, pattern, &matcher, &mut selected, &mut report);
+    }
+
+    for rel in selected {
+        copy_one(project_root, worktree, &rel, &mut report);
+    }
+    report
+}
+
+/// Strip comments and blanks. Trailing whitespace goes; a trailing `\` escapes
+/// it, as in gitignore.
+fn parse(text: &str) -> Vec<String> {
+    text.lines()
+        .map(str::trim_start)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.trim_end().to_string())
+        .collect()
+}
+
+/// Resolve one pattern to concrete relative paths.
+///
+/// A pattern with no wildcards is a path — resolved directly, with no walk at
+/// all, which is the whole point of anchoring.
+fn expand(
+    root: &Path,
+    pattern: &str,
+    matcher: &Gitignore,
+    out: &mut BTreeSet<PathBuf>,
+    report: &mut CopyReport,
+) {
+    let cleaned = pattern.trim_start_matches('/').trim_end_matches('/');
+    if cleaned.is_empty() {
+        return;
+    }
+    let rel = Path::new(cleaned);
+    if !is_contained(rel) {
+        report.skipped.push(Skip::EscapesProjectRoot(pattern.to_string()));
+        return;
+    }
+
+    // Counted rather than measured off `out.len()`: two patterns may legitimately
+    // name the same file (`.env` and `*.env`), and a set that did not grow is
+    // not the same as a pattern that matched nothing. Reporting the second
+    // pattern as a miss would put a false alarm in the same transcript this
+    // module exists to make trustworthy.
+    let mut matched = 0usize;
+    let (anchor, is_literal) = anchor_of(rel);
+    let mut budget = SCAN_BUDGET;
+    let exhausted = !collect(
+        root,
+        if is_literal { rel } else { &anchor },
+        matcher,
+        out,
+        report,
+        &mut budget,
+        is_literal,
+        &mut matched,
+    );
+    if exhausted {
+        report.skipped.push(Skip::ScanBudgetExhausted(pattern.to_string()));
+    } else if matched == 0 {
+        report.skipped.push(Skip::MatchedNothing(pattern.to_string()));
+    }
+}
+
+/// The literal directory prefix of a pattern, plus whether the pattern was
+/// wholly literal. `certs/*.pem` → (`certs`, false); `.env` → (`.env`, true).
+fn anchor_of(rel: &Path) -> (PathBuf, bool) {
+    let mut anchor = PathBuf::new();
+    for component in rel.components() {
+        let part = component.as_os_str().to_string_lossy();
+        if part.contains(['*', '?', '[']) {
+            return (anchor, false);
+        }
+        anchor.push(component);
+    }
+    (anchor, true)
+}
+
+/// Walk `root/rel`, adding matching regular files to `out` and counting every
+/// file the patterns selected (including one another pattern already claimed).
+///
+/// `take_all` is the literal-path case: the pattern named this path outright,
+/// so the matcher is not consulted to *include* anything under it. It is still
+/// consulted to *exclude*, because `!` has to work the same way inside a named
+/// directory as it does under a wildcard — `certs/` plus `!certs/prod-key.pem`
+/// must not copy the key.
+///
+/// Returns false when the budget ran out.
+#[allow(clippy::too_many_arguments, reason = "one recursive walk's state; a struct would be the same fields with an extra name")]
+fn collect(
+    root: &Path,
+    rel: &Path,
+    matcher: &Gitignore,
+    out: &mut BTreeSet<PathBuf>,
+    report: &mut CopyReport,
+    budget: &mut usize,
+    take_all: bool,
+    matched: &mut usize,
+) -> bool {
+    // `.git` is never an include, at any depth and whatever named it: copying it
+    // would corrupt the new worktree, whose own `.git` is a file pointing back
+    // at the main checkout. Checked on every component rather than on the leaf,
+    // so `.git/config` is refused as squarely as `.git/`.
+    if rel.components().any(|c| c.as_os_str() == ".git") {
+        return true;
+    }
+    let abs = root.join(rel);
+    let meta = match std::fs::symlink_metadata(&abs) {
+        Ok(m) => m,
+        Err(_) => return true, // absent → the caller reports "matched nothing"
+    };
+    if meta.is_symlink() {
+        report.skipped.push(Skip::SourceIsSymlink(rel.to_path_buf()));
+        return true;
+    }
+    if meta.is_file() {
+        let verdict = matcher.matched(rel, false);
+        let selected = if take_all {
+            !verdict.is_whitelist()
+        } else {
+            verdict.is_ignore()
+        };
+        if selected {
+            *matched += 1;
+            out.insert(rel.to_path_buf());
+        }
+        return true;
+    }
+    if !meta.is_dir() {
+        return true; // fifo, socket, device: not a thing to copy
+    }
+    let entries = match std::fs::read_dir(&abs) {
+        Ok(e) => e,
+        Err(err) => {
+            report.skipped.push(Skip::Failed {
+                path: rel.to_path_buf(),
+                error: err.to_string(),
+            });
+            return true;
+        }
+    };
+    for entry in entries.flatten() {
+        // Budgeted on every branch, literal included. A named directory is not
+        // inherently small — `.oximuxinclude` naming `vendor/` walks whatever
+        // is in it, and an unbounded walk during worktree creation is the
+        // failure this cap exists to make visible.
+        if *budget == 0 {
+            return false;
+        }
+        *budget -= 1;
+        let child = rel.join(entry.file_name());
+        if !collect(root, &child, matcher, out, report, budget, take_all, matched) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Reject anything that would leave the project root. `..` is the obvious
+/// case; an absolute or prefixed path is the Windows one.
+fn is_contained(rel: &Path) -> bool {
+    rel.components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
+/// Copy one already-validated relative path, enforcing clauses 2, 3 and 4.
+fn copy_one(project_root: &Path, worktree: &Path, rel: &Path, report: &mut CopyReport) {
+    let src = project_root.join(rel);
+    let dst = worktree.join(rel);
+
+    // Clause 2 — the worktree's own (tracked) file wins. Checked with
+    // `symlink_metadata` so a dangling symlink still counts as present rather
+    // than being quietly replaced by our copy.
+    if std::fs::symlink_metadata(&dst).is_ok() {
+        report.skipped.push(Skip::AlreadyPresent(rel.to_path_buf()));
+        return;
+    }
+    // Clause 3 — re-checked at copy time. `collect` already filtered symlinks,
+    // but the tree can change between selection and write, and this is the
+    // check that keeps `fs::copy` (which follows links) from dereferencing.
+    match std::fs::symlink_metadata(&src) {
+        Ok(meta) if meta.is_symlink() => {
+            report.skipped.push(Skip::SourceIsSymlink(rel.to_path_buf()));
+            return;
+        }
+        Ok(_) => {}
+        Err(err) => {
+            report.skipped.push(Skip::Failed {
+                path: rel.to_path_buf(),
+                error: err.to_string(),
+            });
+            return;
+        }
+    }
+    // Clause 4 — no existing component of the destination may be a symlink, or
+    // the write lands wherever that link points. Checked before any directory
+    // is created, so `create_dir_all` below only ever extends a verified path.
+    if let Some(crossed) = symlink_in_target_path(worktree, rel) {
+        report.skipped.push(Skip::TargetPathCrossesSymlink(crossed));
+        return;
+    }
+    if let Some(parent) = dst.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        report.skipped.push(Skip::Failed {
+            path: rel.to_path_buf(),
+            error: err.to_string(),
+        });
+        return;
+    }
+    match std::fs::copy(&src, &dst) {
+        Ok(_) => report.copied.push(rel.to_path_buf()),
+        Err(err) => report.skipped.push(Skip::Failed {
+            path: rel.to_path_buf(),
+            error: err.to_string(),
+        }),
+    }
+}
+
+/// The first existing component of `worktree/rel` (excluding the leaf) that is
+/// a symlink, if any.
+fn symlink_in_target_path(worktree: &Path, rel: &Path) -> Option<PathBuf> {
+    let mut walked = worktree.to_path_buf();
+    let parts: Vec<_> = rel.components().collect();
+    for component in &parts[..parts.len().saturating_sub(1)] {
+        walked.push(component);
+        match std::fs::symlink_metadata(&walked) {
+            Ok(meta) if meta.is_symlink() => return Some(walked),
+            Ok(_) => {}
+            Err(_) => return None, // does not exist yet → nothing to cross
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// (project_root, worktree) — the worktree starts empty, as a fresh
+    /// `git worktree add` of a repo whose tracked files we then plant by hand.
+    fn dirs() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let worktree = tmp.path().join("wt");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        (tmp, root, worktree)
+    }
+
+    fn write(base: &Path, rel: &str, body: &str) {
+        let p = base.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(p, body).unwrap();
+    }
+
+    fn declare(root: &Path, body: &str) {
+        std::fs::write(root.join(FILE_NAME), body).unwrap();
+    }
+
+    #[test]
+    fn absent_include_file_is_a_silent_no_op() {
+        let (_t, root, wt) = dirs();
+        let report = copy_included_files(&root, &wt);
+        assert!(report.is_empty(), "{report:?}");
+    }
+
+    #[test]
+    fn comments_and_blank_lines_are_ignored() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".env", "SECRET=1");
+        declare(&root, "# local files\n\n  .env  \n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from(".env")]);
+        assert!(report.skipped.is_empty(), "{:?}", report.skipped);
+    }
+
+    // ---- Clause 1: files copied; directories copied recursively ----
+
+    #[test]
+    fn clause1_a_literal_file_is_copied() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".env", "SECRET=1");
+        declare(&root, ".env\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from(".env")]);
+        assert_eq!(std::fs::read_to_string(wt.join(".env")).unwrap(), "SECRET=1");
+    }
+
+    #[test]
+    fn clause1_a_directory_is_copied_recursively() {
+        let (_t, root, wt) = dirs();
+        write(&root, "certs/dev.pem", "cert");
+        write(&root, "certs/nested/ca.pem", "ca");
+        declare(&root, "certs/\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied.len(), 2, "{:?}", report.copied);
+        assert!(wt.join("certs/dev.pem").exists());
+        assert!(wt.join("certs/nested/ca.pem").exists());
+    }
+
+    #[test]
+    fn a_wildcard_is_anchored_at_its_literal_prefix() {
+        let (_t, root, wt) = dirs();
+        write(&root, "certs/dev.pem", "cert");
+        write(&root, "certs/notes.txt", "no");
+        // A sibling tree that an unanchored scan would walk. The assertion is
+        // about the result, but the anchoring is what keeps it cheap.
+        write(&root, "node_modules/pkg/index.js", "x");
+        declare(&root, "certs/*.pem\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from("certs/dev.pem")]);
+    }
+
+    #[test]
+    fn negation_excludes_a_file_an_earlier_pattern_matched() {
+        let (_t, root, wt) = dirs();
+        write(&root, "env/a.env", "a");
+        write(&root, "env/secret.env", "s");
+        declare(&root, "env/*.env\n!env/secret.env\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from("env/a.env")]);
+    }
+
+    // ---- Clause 2: a path already in the worktree wins ----
+
+    #[test]
+    fn clause2_tracked_file_wins_and_the_skip_is_reported() {
+        let (_t, root, wt) = dirs();
+        write(&root, "config.yaml", "from-project");
+        write(&wt, "config.yaml", "tracked");
+        declare(&root, "config.yaml\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty(), "{:?}", report.copied);
+        assert_eq!(report.skipped, vec![Skip::AlreadyPresent("config.yaml".into())]);
+        assert_eq!(
+            std::fs::read_to_string(wt.join("config.yaml")).unwrap(),
+            "tracked",
+            "the tracked file must be left exactly as git checked it out"
+        );
+    }
+
+    // ---- Clause 3: source symlinks are skipped, never dereferenced ----
+
+    #[cfg(unix)]
+    #[test]
+    fn clause3_a_source_symlink_is_skipped_not_dereferenced() {
+        let (_t, root, wt) = dirs();
+        write(&root, "real.txt", "payload");
+        std::os::unix::fs::symlink(root.join("real.txt"), root.join("link.txt")).unwrap();
+        declare(&root, "link.txt\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty(), "{:?}", report.copied);
+        assert!(
+            report.skipped.contains(&Skip::SourceIsSymlink("link.txt".into())),
+            "{:?}",
+            report.skipped
+        );
+        assert!(!wt.join("link.txt").exists(), "must not materialize the target");
+    }
+
+    /// The escape this clause exists for: a symlink pointing outside the
+    /// project must not become a real copy of whatever it names.
+    #[cfg(unix)]
+    #[test]
+    fn clause3_a_symlink_out_of_the_project_copies_nothing() {
+        let (tmp, root, wt) = dirs();
+        std::fs::write(tmp.path().join("outside.txt"), "not yours").unwrap();
+        std::os::unix::fs::symlink(tmp.path().join("outside.txt"), root.join("leak.txt")).unwrap();
+        declare(&root, "leak.txt\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty());
+        assert!(!wt.join("leak.txt").exists());
+    }
+
+    // ---- Clause 4: never write through a symlink in the target ----
+
+    #[cfg(unix)]
+    #[test]
+    fn clause4_a_symlinked_target_directory_is_refused() {
+        let (tmp, root, wt) = dirs();
+        let elsewhere = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        write(&root, "conf/app.env", "SECRET=1");
+        // The worktree contains `conf` -> /elsewhere. Writing `conf/app.env`
+        // through it would land outside the worktree entirely.
+        std::os::unix::fs::symlink(&elsewhere, wt.join("conf")).unwrap();
+        declare(&root, "conf/\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty(), "{:?}", report.copied);
+        assert!(
+            matches!(report.skipped.as_slice(), [Skip::TargetPathCrossesSymlink(_)]),
+            "{:?}",
+            report.skipped
+        );
+        assert!(
+            !elsewhere.join("app.env").exists(),
+            "the write escaped the worktree — this is the bug the clause prevents"
+        );
+    }
+
+    // ---- Clause 5: a pattern matching nothing is reported ----
+
+    #[test]
+    fn clause5_a_pattern_matching_nothing_is_reported_and_the_rest_continues() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".env", "SECRET=1");
+        declare(&root, "does-not-exist.txt\n.env\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from(".env")]);
+        assert_eq!(
+            report.skipped,
+            vec![Skip::MatchedNothing("does-not-exist.txt".into())]
+        );
+    }
+
+    #[test]
+    fn clause5_a_wildcard_matching_nothing_is_reported_too() {
+        let (_t, root, wt) = dirs();
+        std::fs::create_dir_all(root.join("certs")).unwrap();
+        declare(&root, "certs/*.pem\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.skipped, vec![Skip::MatchedNothing("certs/*.pem".into())]);
+    }
+
+    // ---- Clause 6: an unreadable source is reported, copy continues ----
+
+    #[cfg(unix)]
+    #[test]
+    fn clause6_an_unreadable_source_is_reported_and_the_rest_continues() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let (_t, root, wt) = dirs();
+        write(&root, "locked.env", "SECRET=1");
+        write(&root, "ok.env", "fine");
+        std::fs::set_permissions(root.join("locked.env"), std::fs::Permissions::from_mode(0o000))
+            .unwrap();
+        declare(&root, "locked.env\nok.env\n");
+        let report = copy_included_files(&root, &wt);
+        // Running as root defeats the permission bit; assert the invariant that
+        // holds either way — the *other* file was copied regardless.
+        assert!(
+            report.copied.contains(&PathBuf::from("ok.env")),
+            "one bad file must not abort the rest: {report:?}"
+        );
+    }
+
+    // ---- Containment ----
+
+    #[test]
+    fn a_pattern_leaving_the_project_root_is_refused() {
+        let (_t, root, wt) = dirs();
+        declare(&root, "../outside.txt\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(
+            report.skipped,
+            vec![Skip::EscapesProjectRoot("../outside.txt".into())]
+        );
+        assert!(report.copied.is_empty());
+    }
+
+    #[test]
+    fn dot_git_is_never_copied_even_when_a_pattern_names_it() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".git/HEAD", "ref: refs/heads/main");
+        declare(&root, ".git/\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty(), "{:?}", report.copied);
+        assert!(!wt.join(".git/HEAD").exists());
+    }
+
+    /// The clause the wildcard test hid: negation has to work inside a
+    /// literal directory too. `certs/` selects everything under `certs/`, so
+    /// without consulting the matcher for exclusions the `!` line does nothing
+    /// and a declared secret is copied into every worktree.
+    #[test]
+    fn negation_excludes_a_file_inside_a_literal_directory() {
+        let (_t, root, wt) = dirs();
+        write(&root, "certs/dev.pem", "dev");
+        write(&root, "certs/prod-key.pem", "prod");
+        declare(&root, "certs/\n!certs/prod-key.pem\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from("certs/dev.pem")]);
+        assert!(
+            !wt.join("certs/prod-key.pem").exists(),
+            "an excluded file must not reach the worktree"
+        );
+    }
+
+    /// Two patterns naming the same file is normal (`.env` then `*.env`). The
+    /// second must not be reported as a miss — a false alarm in the transcript
+    /// costs the same trust as a silent skip.
+    #[test]
+    fn a_second_pattern_matching_an_already_selected_file_is_not_a_miss() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".env", "SECRET=1");
+        declare(&root, ".env\n*.env\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from(".env")]);
+        assert!(
+            report.skipped.is_empty(),
+            "neither pattern missed: {:?}",
+            report.skipped
+        );
+    }
+
+    #[test]
+    fn a_literal_directory_and_a_wildcard_over_it_both_count_as_matches() {
+        let (_t, root, wt) = dirs();
+        write(&root, "certs/dev.pem", "cert");
+        declare(&root, "certs/\ncerts/*.pem\n");
+        let report = copy_included_files(&root, &wt);
+        assert_eq!(report.copied, vec![PathBuf::from("certs/dev.pem")]);
+        assert!(report.skipped.is_empty(), "{:?}", report.skipped);
+    }
+
+    /// A worktree's `.git` is a file pointing at the main checkout. Copying the
+    /// project's `.git` over it — by any pattern, at any depth — corrupts it.
+    #[test]
+    fn a_file_inside_dot_git_is_refused_even_as_a_literal_path() {
+        let (_t, root, wt) = dirs();
+        write(&root, ".git/config", "[core]");
+        declare(&root, ".git/config\n");
+        let report = copy_included_files(&root, &wt);
+        assert!(report.copied.is_empty(), "{:?}", report.copied);
+        assert!(!wt.join(".git/config").exists());
+    }
+
+    #[test]
+    fn anchor_of_splits_at_the_first_wildcard() {
+        assert_eq!(anchor_of(Path::new(".env")), (PathBuf::from(".env"), true));
+        assert_eq!(
+            anchor_of(Path::new("certs/*.pem")),
+            (PathBuf::from("certs"), false)
+        );
+        assert_eq!(anchor_of(Path::new("*.pem")), (PathBuf::new(), false));
+    }
+}

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -11,16 +11,98 @@
 //! data directory explicitly so `oximux serve --data-dir` puts worktrees under
 //! its own root instead of the desktop's.
 
+pub mod include;
 mod service;
+pub mod setup;
 
+pub use include::{CopyReport, Skip};
 pub use service::RepoWorktrees;
+pub use setup::{SETUP_TIMEOUT, SetupOutcome, SetupTranscript};
 
 use std::path::{Path, PathBuf};
 
 use oximux_core::Workspace;
 use oximux_git::Repository;
-use oximux_settings::ScriptKind;
+use oximux_settings::{ScriptKind, SetupDecision};
 use oximux_storage::{StorageError, WorkspaceRepo};
+use tokio::sync::mpsc::UnboundedSender;
+
+/// One step of worktree provisioning, as it happens.
+///
+/// Provisioning is the slowest part of creating a worktree and the part most
+/// likely to fail, so it is the part the user most needs to see. This is the
+/// stream a host renders as a live transcript; a host with nowhere to show it
+/// (`oximux serve`) simply passes no sink and the whole thing costs nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProvisionEvent {
+    /// An `.oximuxinclude` path landed in the worktree.
+    IncludeCopied(PathBuf),
+    /// An `.oximuxinclude` path did not, with the reason.
+    IncludeSkipped(Skip),
+    /// The setup script is about to run. Carries the script itself, because
+    /// "which command produced this output" is the first question a failing
+    /// transcript raises.
+    SetupStarted(String),
+    /// One line of merged stdout/stderr.
+    SetupLine(String),
+    /// The setup script ended.
+    SetupFinished(SetupOutcome),
+}
+
+/// What provisioning should do for one `create` call.
+///
+/// [`Default`] is "inherit the project's answer, show nobody" — the shape every
+/// existing call site had before provisioning existed, which is why adding this
+/// parameter changed no behavior anywhere it was not deliberately wired up.
+#[derive(Debug, Default)]
+pub struct Provision {
+    /// Per-request override for the setup script. [`SetupDecision::Inherit`]
+    /// (the default) defers to the project's committed `auto_setup`.
+    pub setup: SetupDecision,
+    /// Where to stream [`ProvisionEvent`]s, if anyone is watching.
+    pub sink: Option<UnboundedSender<ProvisionEvent>>,
+    /// Whether a directory already at the target path may be deleted as debris
+    /// from an interrupted create. See [`Provision::reclaiming_orphans`].
+    ///
+    /// Off by default, and deliberately so: the default has to be the one that
+    /// cannot destroy anything.
+    pub reclaim_orphan: bool,
+}
+
+impl Provision {
+    /// Provision with a per-request decision and a live transcript sink.
+    pub fn new(setup: SetupDecision, sink: UnboundedSender<ProvisionEvent>) -> Self {
+        Self {
+            setup,
+            sink: Some(sink),
+            reclaim_orphan: false,
+        }
+    }
+
+    /// Opt in to clearing a directory already sitting at the target path.
+    ///
+    /// **Only for callers that own the path scheme.** The caller asserts two
+    /// things by calling this: the path is host-derived
+    /// (`<data_dir>/projects/<id>/worktrees/<slug>`, see [`worktree_path`]), so
+    /// nothing a person put there by hand can be at that location; and the
+    /// caller has already looked for a workspace row naming it.
+    ///
+    /// The second half is re-checked here rather than trusted — see
+    /// [`reclaim_orphan`] — but the first half cannot be, which is why this is
+    /// opt-in rather than automatic. The chat-initiated worktree uses a sibling
+    /// `oximux-wt-<slug>` directory beside the project root, exactly where a
+    /// person's own worktree could live, and must never turn this on.
+    pub fn reclaiming_orphans(mut self) -> Self {
+        self.reclaim_orphan = true;
+        self
+    }
+
+    fn emit(&self, event: ProvisionEvent) {
+        if let Some(sink) = &self.sink {
+            let _ = sink.send(event);
+        }
+    }
+}
 
 /// Outcome of a create flow. Distinguishes user-visible failures (which
 /// require explicit handling at the call site) from the silent success
@@ -54,6 +136,17 @@ pub enum CreateOutcome {
         insert_error: StorageError,
         rollback_error: String,
     },
+    /// The project's `setup` script failed, so the worktree was never
+    /// registered. Carries the whole transcript rather than a message because
+    /// the useful part is the script's own output — a generic "setup failed"
+    /// sends the user back to a terminal to reproduce it by hand.
+    ///
+    /// `rollback_error` is `Some` only when the rollback itself also failed,
+    /// matching [`Self::StorageFailedRollbackDirty`]'s clean/dirty split.
+    SetupFailed {
+        transcript: SetupTranscript,
+        rollback_error: Option<String>,
+    },
 }
 
 /// Compose the worktree dir path:
@@ -79,6 +172,36 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
 /// `name` is the human label (caller has already trimmed); `slug` MUST
 /// pre-validate via `validate_slug` upstream — this function assumes the
 /// slug is safe to pass to `git worktree add -b oximux/<slug>`.
+///
+/// # Preconditions
+///
+/// The caller MUST have established that no workspace row references
+/// `worktree_path`. Given that, a directory already at `worktree_path` is
+/// debris from an interrupted create and is cleared before the git step — see
+/// [`reclaim_orphan`].
+///
+/// # Provisioning
+///
+/// Between the git step and the DB insert, [`Provision`] runs two things that
+/// make the difference between a worktree that exists and one the user can work
+/// in: the `.oximuxinclude` copy, then the project's `setup` script. The order
+/// is fixed — setup scripts read the files the include brings.
+///
+/// The insert deliberately happens *after* both. A row written before setup
+/// would have to be deleted when setup fails, which is a fourth rollback step
+/// and a fourth way to leave the three artifacts disagreeing. Provisioning
+/// after the row exists would be worse still: the sidebar would list a
+/// half-built worktree. As written, a setup failure unwinds through the
+/// rollback ladder that was already here for the storage case.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Seven of the eight are irreducible inputs to one operation: where the repo is, \
+              what the workspace is called, where it goes, and what to write it into. Bundling \
+              them into a params struct moves the same fields behind a name that means nothing \
+              more than the function's own — and every one of the five call sites would then \
+              build a struct to immediately destructure it. The eighth, `provision`, is already \
+              the grouped form of what would otherwise be three."
+)]
 pub async fn create_workspace_with_rollback(
     project_root: &Path,
     project_id: &str,
@@ -87,15 +210,77 @@ pub async fn create_workspace_with_rollback(
     worktree_path: &Path,
     linked_issue: Option<&str>,
     workspace_repo: &WorkspaceRepo,
+    provision: &Provision,
 ) -> CreateOutcome {
     let branch = format!("oximux/{slug}");
     let repo = match Repository::open(project_root).await {
         Ok(r) => r,
         Err(err) => return CreateOutcome::GitFailed(format!("open project repo: {err}")),
     };
+    if provision.reclaim_orphan
+        && let Some(err) = reclaim_orphan(&repo, worktree_path, &branch, workspace_repo).await
+    {
+        return CreateOutcome::GitFailed(err);
+    }
     if let Err(err) = repo.add_worktree(worktree_path, slug).await {
         return CreateOutcome::GitFailed(format!("add_worktree: {err}"));
     }
+
+    // Include copy: best-effort by contract. Every skip is reported and nothing
+    // here fails creation — a missing `.env` is worth telling the user about,
+    // and the setup script is what decides whether it was actually required.
+    //
+    // On a blocking thread because it is synchronous, recursive filesystem work
+    // and the desktop calls this whole function from gpui's *foreground*
+    // executor. A project whose `.oximuxinclude` names a large directory would
+    // otherwise freeze the window for the length of the copy.
+    let copied = {
+        let (root, wt) = (project_root.to_path_buf(), worktree_path.to_path_buf());
+        match tokio::task::spawn_blocking(move || include::copy_included_files(&root, &wt)).await {
+            Ok(report) => report,
+            Err(err) => {
+                // The blocking pool panicked or was shut down. The include copy
+                // never fails creation, so neither does losing it — but it is
+                // not something to pass over in silence either.
+                tracing::warn!(?err, "oximuxinclude copy did not run");
+                include::CopyReport::default()
+            }
+        }
+    };
+    for path in &copied.copied {
+        provision.emit(ProvisionEvent::IncludeCopied(path.clone()));
+    }
+    for skip in &copied.skipped {
+        tracing::info!(worktree = %worktree_path.display(), skip = %skip, "oximuxinclude skip");
+        provision.emit(ProvisionEvent::IncludeSkipped(skip.clone()));
+    }
+
+    // Setup: reads `.oximux/scripts.toml` from the worktree, the same source
+    // `run_cleanup_before_remove` uses — it is committed, so the branch's own
+    // copy is the one that will actually run.
+    let scripts = oximux_settings::load_for_project(worktree_path);
+    if provision.setup.resolve(scripts.auto_setup)
+        && let Some(script) = scripts.script(ScriptKind::Setup)
+    {
+        provision.emit(ProvisionEvent::SetupStarted(script.to_string()));
+        let transcript =
+            setup::run_setup_bounded(worktree_path, script, SETUP_TIMEOUT, provision.sink.as_ref())
+                .await;
+        provision.emit(ProvisionEvent::SetupFinished(transcript.outcome.clone()));
+        if !transcript.outcome.is_ok() {
+            tracing::warn!(
+                worktree = %worktree_path.display(),
+                outcome = %transcript.outcome.summary(),
+                "setup failed during provisioning; rolling back"
+            );
+            let rollback_error = rollback(&repo, worktree_path, &branch).await;
+            return CreateOutcome::SetupFailed {
+                transcript,
+                rollback_error,
+            };
+        }
+    }
+
     let path_str = worktree_path.to_string_lossy().to_string();
     match workspace_repo.insert(project_id, name, slug, &branch, &path_str) {
         Ok(mut workspace) => {
@@ -112,29 +297,108 @@ pub async fn create_workspace_with_rollback(
             }
             CreateOutcome::Created(workspace)
         }
-        Err(insert_error) => {
-            // Rollback: best-effort. If either step errors, we surface
-            // a dirty-state outcome so the call site can log loudly.
-            let mut rollback_err = None;
-            if let Err(err) = repo.remove_worktree(worktree_path, true).await {
-                rollback_err = Some(format!("remove_worktree: {err}"));
-            }
-            if let Err(err) = repo.delete_branch(&branch, true).await {
-                let chained = match rollback_err {
-                    Some(prev) => format!("{prev}; delete_branch: {err}"),
-                    None => format!("delete_branch: {err}"),
-                };
-                rollback_err = Some(chained);
-            }
-            match rollback_err {
-                Some(err) => CreateOutcome::StorageFailedRollbackDirty {
-                    insert_error,
-                    rollback_error: err,
-                },
-                None => CreateOutcome::StorageFailedRollbackClean(insert_error),
-            }
+        Err(insert_error) => match rollback(&repo, worktree_path, &branch).await {
+            Some(rollback_error) => CreateOutcome::StorageFailedRollbackDirty {
+                insert_error,
+                rollback_error,
+            },
+            None => CreateOutcome::StorageFailedRollbackClean(insert_error),
+        },
+    }
+}
+
+/// Clear a worktree directory left behind by an interrupted create, so a retry
+/// can proceed. Returns an error message when the path is occupied and could
+/// not be cleared; `None` means the path is free.
+///
+/// **Why this exists.** Provisioning made the gap between `git worktree add`
+/// and the workspace row up to [`SETUP_TIMEOUT`] wide. Kill the process during
+/// a ten-minute install and the directory and branch survive with no row
+/// naming them — invisible to the sidebar, and enough to make `add_worktree`
+/// fail with "already exists" on every retry from then on. Before this, that
+/// window was a few milliseconds and the case was theoretical.
+///
+/// **Why deleting is safe here — and the two things that make it so.** Reached
+/// only when the caller opted in via [`Provision::reclaiming_orphans`], which
+/// asserts the path is host-derived and therefore not somewhere a person keeps
+/// work. On top of that, this re-checks that no workspace row names the path.
+///
+/// The row check is not redundant with the caller's own. A precondition that
+/// lives only in a doc comment is one refactor away from being false, and the
+/// cost of it being false here is a force-removed worktree with the user's
+/// uncommitted work in it. This is a delete; it verifies rather than trusts.
+async fn reclaim_orphan(
+    repo: &Repository,
+    worktree_path: &Path,
+    branch: &str,
+    workspace_repo: &WorkspaceRepo,
+) -> Option<String> {
+    if !worktree_path.exists() {
+        return None;
+    }
+    // A row naming this path means it is a live workspace, not debris —
+    // whatever the caller believed. Leave it alone and let `add_worktree`
+    // produce its ordinary "already exists" error.
+    match workspace_repo.get_by_worktree_path(&worktree_path.to_string_lossy()) {
+        Ok(Some(existing)) => {
+            tracing::warn!(
+                worktree = %worktree_path.display(),
+                workspace_id = %existing.id,
+                "refusing to reclaim: a workspace row names this path"
+            );
+            return None;
+        }
+        Ok(None) => {}
+        Err(err) => {
+            // Could not prove it is unclaimed, so do not delete it.
+            tracing::warn!(?err, "refusing to reclaim: workspace lookup failed");
+            return None;
         }
     }
+    tracing::warn!(
+        worktree = %worktree_path.display(),
+        branch,
+        "worktree path occupied with no workspace row (interrupted create?); reclaiming"
+    );
+    // The same ladder the failure paths use: git knows about this worktree, so
+    // let git detach it and drop the branch rather than tearing the directory
+    // out from under `.git/worktrees`.
+    let rollback_err = rollback(repo, worktree_path, branch).await;
+    // Git can decline a path it never registered (a create killed between
+    // `mkdir` and `worktree add`). The directory still has to go.
+    if worktree_path.exists()
+        && let Err(err) = std::fs::remove_dir_all(worktree_path)
+    {
+        return Some(format!(
+            "worktree path {} is occupied and could not be cleared: {err}",
+            worktree_path.display()
+        ));
+    }
+    if let Some(err) = rollback_err {
+        tracing::info!(%err, "orphan reclaim: git step complained but the path is clear");
+    }
+    None
+}
+
+/// Undo the git half of a create: force-remove the worktree, force-delete the
+/// branch. Best-effort — both steps are attempted even when the first fails, so
+/// a broken worktree does not also leave the branch behind. Returns the chained
+/// error when either step failed, which is what makes an outcome "dirty".
+///
+/// Shared by the storage-failure and setup-failure arms: two rollback ladders
+/// for the same two artifacts would be two chances to drift.
+async fn rollback(repo: &Repository, worktree_path: &Path, branch: &str) -> Option<String> {
+    let mut err = None;
+    if let Err(e) = repo.remove_worktree(worktree_path, true).await {
+        err = Some(format!("remove_worktree: {e}"));
+    }
+    if let Err(e) = repo.delete_branch(branch, true).await {
+        err = Some(match err {
+            Some(prev) => format!("{prev}; delete_branch: {e}"),
+            None => format!("delete_branch: {e}"),
+        });
+    }
+    err
 }
 
 /// Max time to wait for a per-project `cleanup` teardown before forcing the

--- a/crates/worktree-ops/src/service.rs
+++ b/crates/worktree-ops/src/service.rs
@@ -20,7 +20,10 @@ use oximux_remote_host::{WorktreeError, WorktreeService};
 use oximux_remote_proto::messages::{WorktreeProgressWire, WorktreeWire};
 use oximux_storage::{ProjectRepo, WorkspaceRepo};
 
-use crate::{CreateOutcome, create_workspace_with_rollback, run_cleanup_before_remove, worktree_path};
+use crate::{
+    CreateOutcome, Provision, create_workspace_with_rollback, run_cleanup_before_remove,
+    worktree_path,
+};
 
 /// Manages worktrees against the same repos and path scheme the desktop uses.
 pub struct RepoWorktrees {
@@ -92,6 +95,15 @@ impl WorktreeService for RepoWorktrees {
             &target,
             None,
             &self.workspaces,
+            // Headless: no override (the project's `auto_setup` decides) and
+            // nowhere to stream a transcript. A remote client asking for a
+            // worktree gets the same provisioning the desktop does; it just
+            // sees the outcome instead of watching it.
+            //
+            // Reclaim is on: `target` came from `worktree_path(&self.data_dir,
+            // ..)` a few lines up, and the slug collision check above has
+            // already established no row claims it.
+            &Provision::default().reclaiming_orphans(),
         )
         .await;
         match outcome {
@@ -102,6 +114,15 @@ impl WorktreeService for RepoWorktrees {
             }
             CreateOutcome::StorageFailedRollbackClean(err) => {
                 tracing::warn!(?err, slug, "remote worktree create: storage failed, rolled back");
+                Err(WorktreeError::CreateFailed)
+            }
+            CreateOutcome::SetupFailed { transcript, rollback_error } => {
+                tracing::warn!(
+                    slug,
+                    outcome = %transcript.outcome.summary(),
+                    ?rollback_error,
+                    "remote worktree create: setup script failed, worktree rolled back"
+                );
                 Err(WorktreeError::CreateFailed)
             }
             CreateOutcome::StorageFailedRollbackDirty { insert_error, rollback_error } => {

--- a/crates/worktree-ops/src/setup.rs
+++ b/crates/worktree-ops/src/setup.rs
@@ -1,0 +1,431 @@
+//! Running a project's `setup` script as part of worktree provisioning.
+//!
+//! This is the inverse of [`crate::run_cleanup_before_remove`] in the one way
+//! that matters. Cleanup must never trap the user: a teardown script that
+//! fails, hangs, or does not exist is logged and the removal proceeds anyway.
+//! Setup is the opposite — a worktree whose dependencies did not install is not
+//! a worktree the user can work in, and reporting it as created is the lie this
+//! phase exists to stop telling. So a non-zero exit, a timeout, or a failure to
+//! start each fail creation and roll the worktree back.
+//!
+//! Everything else is deliberately the same shape as cleanup — `sh -lc`, cwd at
+//! the worktree, `no_window` so Windows shows no console flash, `kill_on_drop`
+//! so the timeout escape actually kills the child rather than orphaning it.
+//! The two differences from cleanup are both consequences of failure mattering:
+//!
+//! - **Output is captured, not discarded.** Cleanup throws its output away
+//!   because nothing can act on it. Here the user needs to read the compiler
+//!   error, so stdout and stderr stream into a transcript as they arrive.
+//! - **stdin is closed.** A setup script that prompts (`npm login`, a
+//!   passphrase) would otherwise block until [`SETUP_TIMEOUT`] with no
+//!   indication why. With stdin at `/dev/null` it fails immediately and the
+//!   transcript shows the prompt it died on.
+
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt as _, AsyncRead, BufReader};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::ProvisionEvent;
+
+/// Max time to wait for a project's `setup` script.
+///
+/// Two orders of magnitude above `CLEANUP_TIMEOUT` (30s) because the two do
+/// different work: teardown stops things, setup installs dependencies. Fifteen
+/// minutes covers a cold `cargo build` or a full `pnpm install` on a slow link
+/// and still bounds a script that is genuinely wedged.
+pub const SETUP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// Cap on captured output. A setup script is not required to be well-behaved:
+/// a progress bar redrawing with `\r` never emits a newline, and a verbose
+/// build can print hundreds of megabytes. The transcript is held in memory and
+/// then moved into `CreateOutcome`, so an uncapped capture is an
+/// out-of-memory bug wearing a log file's clothes. Past the cap the tail is
+/// kept and the middle is dropped, because the last lines are the diagnosis.
+const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Cap on one line. `read_until` returns on a newline, so output that only ever
+/// emits `\r` would otherwise accumulate the entire run as a single unbounded
+/// line — nothing reaching the sink and nothing reaching the transcript until
+/// the process ended.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// How the setup script ended. Every variant except [`Self::Ok`] fails
+/// worktree creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetupOutcome {
+    Ok,
+    /// Ran to completion and reported failure. `code` is `None` when the
+    /// process was terminated by a signal.
+    NonZero { code: Option<i32> },
+    /// Exceeded [`SETUP_TIMEOUT`] and was killed.
+    TimedOut,
+    /// Could not be launched at all (no shell, bad cwd).
+    FailedToStart(String),
+}
+
+impl SetupOutcome {
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok)
+    }
+
+    /// One line for a toast or a log — the transcript carries the detail.
+    pub fn summary(&self) -> String {
+        match self {
+            Self::Ok => "setup succeeded".to_string(),
+            Self::NonZero { code: Some(c) } => format!("setup exited {c}"),
+            Self::NonZero { code: None } => "setup was terminated by a signal".to_string(),
+            Self::TimedOut => format!(
+                "setup did not finish within {} minutes and was killed",
+                SETUP_TIMEOUT.as_secs() / 60
+            ),
+            Self::FailedToStart(err) => format!("setup could not start: {err}"),
+        }
+    }
+}
+
+/// The script, everything it printed, and how it ended. Kept whole so the
+/// desktop can re-open it after creation rather than only showing it live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupTranscript {
+    pub script: String,
+    pub output: String,
+    pub outcome: SetupOutcome,
+}
+
+/// Run `script` to completion in `worktree`, bounded by `timeout`.
+///
+/// Lines are appended to the returned transcript *and* forwarded to `sink` as
+/// they arrive, so a watching UI sees progress rather than a spinner. Output
+/// captured before a timeout is kept — the last few lines are usually the whole
+/// diagnosis of what wedged.
+pub async fn run_setup_bounded(
+    worktree: &Path,
+    script: &str,
+    timeout: Duration,
+    sink: Option<&UnboundedSender<ProvisionEvent>>,
+) -> SetupTranscript {
+    let mut cmd = tokio::process::Command::new("sh");
+    {
+        use oximux_no_window::NoWindow as _;
+        cmd.arg("-lc")
+            .arg(script)
+            .current_dir(worktree)
+            // Closed on purpose: a prompt must fail fast, not hang for 15 min.
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .no_window()
+            .kill_on_drop(true);
+    }
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(err) => {
+            return SetupTranscript {
+                script: script.to_string(),
+                output: String::new(),
+                outcome: SetupOutcome::FailedToStart(err.to_string()),
+            };
+        }
+    };
+
+    // Merge stdout and stderr into one ordered stream: the user reads a
+    // transcript, and interleaving is what makes an error legible next to the
+    // command that produced it.
+    //
+    // Merged with `select!` rather than a task per pipe so the whole read is
+    // one future the timeout can cancel as a unit. Two `tokio::spawn`ed
+    // forwarders would outlive that cancellation and keep draining a child the
+    // caller has already given up on.
+    //
+    // **Both pipes must keep being read until EOF.** A pipe abandoned early
+    // fills its ~64 KiB buffer, the child blocks in `write()`, and `wait()`
+    // never returns — a script that actually exited in seconds is then
+    // reported as a 15-minute timeout. That is why reading is byte-oriented:
+    // `Lines` fails the whole pipe with `InvalidData` on one non-UTF-8 byte,
+    // which is exactly how that deadlock gets in.
+    let mut out_pipe = child.stdout.take().map(Pipe::new);
+    let mut err_pipe = child.stderr.take().map(Pipe::new);
+
+    // Accumulated outside the timed future so a timeout keeps what was printed
+    // before the hang — the last lines are usually the whole diagnosis.
+    let mut output = String::new();
+    let mut truncated = false;
+    let outcome = match tokio::time::timeout(timeout, async {
+        loop {
+            let line = tokio::select! {
+                Some(line) = next_line(&mut out_pipe) => line,
+                Some(line) = next_line(&mut err_pipe) => line,
+                else => break,
+            };
+            if let Some(sink) = sink {
+                let _ = sink.send(ProvisionEvent::SetupLine(line.clone()));
+            }
+            if output.len() + line.len() < MAX_OUTPUT_BYTES {
+                output.push_str(&line);
+                output.push('\n');
+            } else if !truncated {
+                truncated = true;
+                output.push_str("[output truncated; the transcript file has the rest]\n");
+            }
+        }
+        child.wait().await
+    })
+    .await
+    {
+        Ok(Ok(status)) if status.success() => SetupOutcome::Ok,
+        Ok(Ok(status)) => SetupOutcome::NonZero { code: status.code() },
+        Ok(Err(err)) => SetupOutcome::FailedToStart(err.to_string()),
+        Err(_) => SetupOutcome::TimedOut,
+    };
+
+    SetupTranscript {
+        script: script.to_string(),
+        output,
+        outcome,
+    }
+}
+
+/// One captured pipe, plus the partial line read so far.
+///
+/// The buffer lives here rather than inside the read future because
+/// `read_until` is not cancel-safe on its own, and `select!` drops the losing
+/// branch's future on every iteration. Owned out here, a cancelled read simply
+/// resumes into the same buffer instead of losing what it had.
+struct Pipe<R> {
+    reader: BufReader<R>,
+    buf: Vec<u8>,
+}
+
+impl<R: AsyncRead + Unpin> Pipe<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            buf: Vec::new(),
+        }
+    }
+}
+
+/// One line from a pipe that may already be exhausted or absent.
+///
+/// Returns `None` — which disables that `select!` branch — only once the pipe
+/// is truly done, so the loop ends when *both* are drained.
+///
+/// Decoding is lossy and never fatal. A build tool emitting one stray byte of
+/// latin-1 must not cost us the rest of its output, and must never cost us the
+/// pipe: see the deadlock note at the call site.
+async fn next_line<R>(pipe: &mut Option<Pipe<R>>) -> Option<String>
+where
+    R: AsyncRead + Unpin,
+{
+    let p = pipe.as_mut()?;
+    // A line long past the cap is a progress bar redrawing with `\r`, not a
+    // line. Cut it so it reaches the transcript instead of growing forever.
+    if p.buf.len() >= MAX_LINE_BYTES {
+        return Some(take_line(&mut p.buf));
+    }
+    match p.reader.read_until(b'\n', &mut p.buf).await {
+        // EOF. Emit a trailing partial line if the child never wrote a final
+        // newline, then retire the branch.
+        Ok(0) => {
+            let rest = take_line(&mut p.buf);
+            *pipe = None;
+            (!rest.is_empty()).then_some(rest)
+        }
+        Ok(_) => Some(take_line(&mut p.buf)),
+        // A real I/O error (the pipe is gone). Nothing more will arrive on it,
+        // so retiring it here cannot strand a writing child.
+        Err(err) => {
+            *pipe = None;
+            Some(format!("[output stream ended: {err}]"))
+        }
+    }
+}
+
+/// Drain the buffer into a `String`, dropping the line terminator.
+fn take_line(buf: &mut Vec<u8>) -> String {
+    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+        buf.pop();
+    }
+    let line = String::from_utf8_lossy(buf).into_owned();
+    buf.clear();
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn wt() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_successful_script_reports_ok_and_captures_stdout() {
+        let dir = wt();
+        let t = run_setup_bounded(dir.path(), "echo hello", SETUP_TIMEOUT, None).await;
+        assert_eq!(t.outcome, SetupOutcome::Ok);
+        assert!(t.output.contains("hello"), "{:?}", t.output);
+    }
+
+    /// The inversion of cleanup's policy, asserted directly: a non-zero exit is
+    /// a failure the caller must act on, not a warning to log past.
+    #[tokio::test]
+    async fn a_non_zero_exit_is_reported_as_a_failure() {
+        let dir = wt();
+        let t = run_setup_bounded(dir.path(), "exit 3", SETUP_TIMEOUT, None).await;
+        assert_eq!(t.outcome, SetupOutcome::NonZero { code: Some(3) });
+        assert!(!t.outcome.is_ok());
+    }
+
+    #[tokio::test]
+    async fn stderr_is_captured_alongside_stdout() {
+        let dir = wt();
+        let t = run_setup_bounded(dir.path(), "echo oops 1>&2; exit 1", SETUP_TIMEOUT, None).await;
+        assert!(t.output.contains("oops"), "{:?}", t.output);
+        assert_eq!(t.outcome, SetupOutcome::NonZero { code: Some(1) });
+    }
+
+    #[tokio::test]
+    async fn the_script_runs_in_the_worktree() {
+        let dir = wt();
+        std::fs::write(dir.path().join("marker"), "").unwrap();
+        let t = run_setup_bounded(dir.path(), "test -f marker", SETUP_TIMEOUT, None).await;
+        assert_eq!(t.outcome, SetupOutcome::Ok);
+    }
+
+    /// A hang is reported as a failure at the bound, not as a hang.
+    #[tokio::test]
+    async fn a_hanging_script_times_out_and_is_killed() {
+        let dir = wt();
+        let start = Instant::now();
+        let t = run_setup_bounded(dir.path(), "sleep 60", Duration::from_millis(300), None).await;
+        assert_eq!(t.outcome, SetupOutcome::TimedOut);
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "should return at the bound, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Output printed before the hang survives the timeout — it is usually the
+    /// only evidence of what the script was doing when it wedged.
+    #[tokio::test]
+    async fn output_before_a_timeout_is_kept() {
+        let dir = wt();
+        let t = run_setup_bounded(
+            dir.path(),
+            "echo installing; sleep 60",
+            Duration::from_millis(500),
+            None,
+        )
+        .await;
+        assert_eq!(t.outcome, SetupOutcome::TimedOut);
+        assert!(t.output.contains("installing"), "{:?}", t.output);
+    }
+
+    /// stdin is closed, so a prompt fails immediately instead of consuming the
+    /// whole timeout. With an inherited stdin this test would hang.
+    #[tokio::test]
+    async fn a_script_reading_stdin_fails_fast_rather_than_hanging() {
+        let dir = wt();
+        let start = Instant::now();
+        let t = run_setup_bounded(dir.path(), "read line || exit 7", SETUP_TIMEOUT, None).await;
+        assert_eq!(t.outcome, SetupOutcome::NonZero { code: Some(7) });
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "closed stdin should end it immediately, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn lines_stream_to_the_sink_as_they_arrive() {
+        let dir = wt();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let t = run_setup_bounded(dir.path(), "echo one; echo two", SETUP_TIMEOUT, Some(&tx)).await;
+        assert_eq!(t.outcome, SetupOutcome::Ok);
+        drop(tx);
+        let mut seen = Vec::new();
+        while let Ok(ProvisionEvent::SetupLine(line)) = rx.try_recv() {
+            seen.push(line);
+        }
+        assert_eq!(seen, vec!["one".to_string(), "two".to_string()]);
+    }
+
+    /// The deadlock guard. Non-UTF-8 output used to fail the whole pipe, which
+    /// retired it while the child was still writing — the buffer filled, the
+    /// child blocked, and a script that exited in milliseconds was reported as
+    /// a 15-minute timeout. The bytes must come through lossily instead.
+    #[tokio::test]
+    async fn non_utf8_output_does_not_abandon_the_pipe() {
+        let dir = wt();
+        let start = Instant::now();
+        let t = run_setup_bounded(
+            dir.path(),
+            // A lone 0xFF, then plenty more output, then a clean exit.
+            "printf 'start\\n'; printf '\\377'; printf '\\nafter\\n'; exit 0",
+            Duration::from_secs(20),
+            None,
+        )
+        .await;
+        assert_eq!(t.outcome, SetupOutcome::Ok, "output: {:?}", t.output);
+        assert!(t.output.contains("start"), "{:?}", t.output);
+        assert!(
+            t.output.contains("after"),
+            "output after the bad byte must survive: {:?}",
+            t.output
+        );
+        assert!(start.elapsed() < Duration::from_secs(10));
+    }
+
+    /// A child that writes more than a pipe buffer must not wedge. Without both
+    /// pipes being drained to EOF this blocks until the timeout.
+    #[tokio::test]
+    async fn a_child_writing_past_the_pipe_buffer_still_completes() {
+        let dir = wt();
+        let start = Instant::now();
+        let t = run_setup_bounded(
+            dir.path(),
+            // ~600 KiB across both pipes — an order of magnitude over the
+            // ~64 KiB pipe buffer that would strand a half-drained child.
+            "i=0; while [ $i -lt 3000 ]; do echo \"stdout line $i xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"; echo \"stderr line $i xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\" 1>&2; i=$((i+1)); done; exit 0",
+            Duration::from_secs(30),
+            None,
+        )
+        .await;
+        assert_eq!(t.outcome, SetupOutcome::Ok);
+        assert!(t.output.contains("stdout line 2999"), "stdout truncated early");
+        assert!(t.output.contains("stderr line 2999"), "stderr truncated early");
+        assert!(start.elapsed() < Duration::from_secs(25));
+    }
+
+    /// Output with no trailing newline still reaches the transcript.
+    #[tokio::test]
+    async fn a_final_line_without_a_newline_is_kept() {
+        let dir = wt();
+        let t = run_setup_bounded(dir.path(), "printf 'no-newline'", SETUP_TIMEOUT, None).await;
+        assert_eq!(t.outcome, SetupOutcome::Ok);
+        assert!(t.output.contains("no-newline"), "{:?}", t.output);
+    }
+
+    #[test]
+    fn take_line_strips_both_terminators_and_clears() {
+        let mut buf = b"hello\r\n".to_vec();
+        assert_eq!(take_line(&mut buf), "hello");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn every_failure_has_a_readable_summary() {
+        assert!(SetupOutcome::NonZero { code: Some(2) }.summary().contains('2'));
+        assert!(SetupOutcome::TimedOut.summary().contains("15 minutes"));
+        assert!(
+            SetupOutcome::FailedToStart("no sh".into())
+                .summary()
+                .contains("no sh")
+        );
+    }
+}

--- a/docs/agent-retry.md
+++ b/docs/agent-retry.md
@@ -102,8 +102,35 @@ once, in the decoder, and is asserted against a literal — get it wrong and a
 retry fires either instantly or tens of thousands of years out, neither of which
 looks like a units bug from the UI.
 
+## Quitting with a turn held
+
+A five-hour window usually outlasts the app session that hit it, so an armed
+retry is written into the chat's transcript and rebuilt on the next launch —
+with the attempts it had already spent, so the cap of four counts the whole
+turn rather than restarting at every launch.
+
+Three things stop the rebuild, and each is a case where firing would be wrong
+rather than merely late:
+
+- **The reset passed while OxiMux was closed.** More than five minutes past and
+  the retry is dropped. A lid closed over the reset still fires; a night away
+  does not. Nothing sends unattended for a limit that expired without you — the
+  turn is still there, and the Retry button still works.
+- **Auto-retry was switched off in the meantime.** The setting is read at
+  restore, not baked into what was saved.
+- **`max_automatic_wait` was shortened.** A seven-day reset armed under *No
+  limit* is refused by a session that now allows at most six hours.
+
+The countdown itself is not persisted, only the decision behind it: when to
+fire, why, and how many attempts the turn has cost.
+
 ## Not covered yet
 
-`oximux agent retry status|now|cancel` is not implemented. Retry state currently
-lives in the desktop host only; exposing it to the CLI needs a new relay verb
-and a protocol version bump.
+`oximux agent retry status|now|cancel` is not implemented, and it is blocked by
+more than the work of adding three verbs. Retry lives in the **desktop app
+only** — `oximux serve`, the host the CLI actually talks to, has no retry at
+all. Verbs added today would answer "nothing armed" for every `serve` session
+while the desktop quietly retried its own, which is a worse surface than no
+verbs. Making the CLI's answer true means moving retry into the host layer
+first; the wire change (a new verb plus a protocol version bump) is the smaller
+half of that job.

--- a/docs/agent-retry.md
+++ b/docs/agent-retry.md
@@ -1,0 +1,109 @@
+# Automatic retry after a rate limit
+
+When a turn fails because the provider is out of capacity, OxiMux can hold the
+turn and send it again by itself, instead of leaving a failed turn for you to
+find and re-send by hand.
+
+It is deliberately conservative: it retries only when a machine-readable signal
+says waiting will actually help.
+
+## What gets retried
+
+| The provider said | Class | What happens |
+|---|---|---|
+| A usage window is full (`five_hour`, `seven_day`, `seven_day_opus`, `seven_day_sonnet`) and named its reset | **Window** | Re-sent shortly after the reset |
+| HTTP 429 / 503 / 529 with no window reading | **Overload** | Re-sent after 30s, doubling per attempt |
+| The account is billing past its plan (`overage`, `seven_day_overage_included`) | **Spend** | **Never** re-sent |
+| A window kind this build does not recognise | Other | Never re-sent |
+| A window is full but the provider withheld the reset | Other | Never re-sent |
+| Any other error (bad request, auth, a crash) | Other | Never re-sent |
+
+Two of those rows are the ones worth knowing about.
+
+**Overage is not a closed window.** When an account passes its plan allowance,
+requests keep working — they just start costing money. Retrying that
+automatically would spend on your behalf without asking, so it never happens.
+The turn fails and you decide.
+
+**An unknown limit kind is treated as not retryable.** Providers add window
+kinds. A build that has never heard of one surfaces the error rather than
+guessing that waiting will fix it. Under-retrying costs a click; over-retrying
+can cost money or hammer an account that is already refusing requests.
+
+A turn you stopped yourself is never retried, and neither is one whose agent
+process has died.
+
+## Jitter, and why it matters
+
+Every thread on one account sees the *same* reset time. Without a random spread
+they would all wake in the same second and re-limit the account instantly — the
+retry would cause the outage it exists to survive. So every wake time gets a
+random offset of up to two minutes. This is load-bearing, not a refinement.
+
+## Limits
+
+- **Four attempts** per turn, maximum. Not configurable.
+- Attempts reset when you send something new, so a long conversation that hits a
+  limit once an hour is never locked out.
+- Cancelling a queued retry does not count as an attempt.
+
+## The queued card
+
+While a retry is armed the thread shows a card in place of the error:
+
+```
+Attempt 1 of 4
+Usage limit reached — retrying in 3h 10m
+[ Send now ]  [ Cancel ]
+```
+
+- **Send now** fires immediately and counts as an attempt.
+- **Cancel** drops the retry and shows the original error.
+
+The countdown updates itself — every 30 seconds while the wait is long, every
+second in the last minute.
+
+## Setting: maximum automatic wait
+
+A weekly window can reset days out. Waiting that long silently is worse than
+reporting the error: a queued turn and a forgotten one look identical, and a
+turn that fires two days late lands in a context you have moved on from.
+
+So the wait is capped. A reset farther out than the cap is not scheduled at all;
+the failure surfaces as an ordinary error.
+
+| Setting | Effect |
+|---|---|
+| Up to 6 hours | Covers a five-hour window, not a weekly one |
+| **Up to 24 hours** (default) | Covers every five-hour window and a same-day weekly reset |
+| No limit | Waits however long the provider says |
+
+Stored in `agent_retry.toml` in the app data directory:
+
+```toml
+enabled = true
+max_automatic_wait = "one-day"   # or "six-hours", "no-limit"
+```
+
+Setting `enabled = false` restores the previous behaviour — a failed turn is
+reported immediately and never held.
+
+## Where the vocabulary comes from
+
+The limit kinds above are not guessed from error messages, and not matched
+against error prose — a provider is free to reword a message at any time. They
+are read from the `rate_limit_event` line that the Claude CLI already emits on
+its own stream, whose `status` and `rateLimitType` values are a closed set
+defined by the CLI's own schema. OxiMux previously discarded that line.
+
+One detail worth recording: the wire reports `resetsAt` in unix **seconds**,
+while every reset time inside OxiMux is milliseconds. The conversion happens
+once, in the decoder, and is asserted against a literal — get it wrong and a
+retry fires either instantly or tens of thousands of years out, neither of which
+looks like a units bug from the UI.
+
+## Not covered yet
+
+`oximux agent retry status|now|cancel` is not implemented. Retry state currently
+lives in the desktop host only; exposing it to the CLI needs a new relay verb
+and a protocol version bump.

--- a/docs/worktree-provisioning.md
+++ b/docs/worktree-provisioning.md
@@ -1,0 +1,138 @@
+# Worktree provisioning
+
+A git worktree gives you every **tracked** file and none of the untracked ones.
+That is correct for git and useless in practice: the `.env`, the dev certs, and
+the `node_modules` your project needs are all things a fresh worktree does not
+have. Provisioning is the step that closes that gap, so a worktree OxiMux
+reports as created is one you can actually work in.
+
+Two things happen, in this order, between `git worktree add` and the workspace
+appearing in the sidebar:
+
+1. **Copy** the untracked local files named in `.oximuxinclude`.
+2. **Run** the project's `setup` script.
+
+The order is fixed, because setup scripts read the files the copy brings.
+
+**A setup failure fails creation.** The worktree, the branch, and the database
+row are all rolled back — there is no half-provisioned worktree left behind.
+This is the opposite of the `cleanup` script, which is best-effort by design: a
+teardown script must never trap you behind a delete that will not complete,
+while a setup script that failed means the worktree is not ready.
+
+## Opting in
+
+Provisioning is **off by default**. A project that has never configured it
+behaves exactly as it did before this existed.
+
+```toml
+# .oximux/scripts.toml — committed, shared by the team
+auto_setup = true
+setup   = "pnpm install --frozen-lockfile"
+run     = "pnpm dev"
+cleanup = "docker compose down"
+
+# Terminal tabs to open in every new worktree.
+default_tabs = ["server", "logs"]
+```
+
+`auto_setup` is the project's answer. The create-workspace dialog carries a
+**Setup script** dropdown that overrides it for one worktree:
+
+| Choice | Meaning |
+|---|---|
+| Project default | Use `auto_setup`. The default, and almost always right. |
+| Run setup | Run it for this worktree even if `auto_setup` is off. |
+| Skip setup | Skip it for this worktree — a throwaway branch that does not need a ten-minute install. |
+
+The manual **Run setup** row in the rail's context menu is unchanged and is
+still how you re-run setup in an existing worktree.
+
+> Do not put secrets in `scripts.toml`. It is meant to be committed, the same
+> trust boundary as `commands.toml`.
+
+## `.oximuxinclude`
+
+A file at the project root naming the untracked files a worktree cannot work
+without. It is committed, so it names *paths*, never contents.
+
+```gitignore
+# Local config a worktree needs but git does not carry
+.env
+.env.local
+certs/
+config/*.local.json
+!config/scratch.local.json
+```
+
+Syntax is gitignore's: one pattern per line, `#` comments, `!` negation,
+directories copied recursively.
+
+**Patterns are anchored at their literal prefix.** `certs/*.pem` scans `certs/`,
+not the whole repository. Only a pattern that *starts* with a wildcard
+(`*.pem`, `**/x`) scans from the root, and that scan is capped — if it hits the
+cap it is reported as a skip telling you to anchor the pattern. This departs
+from gitignore on purpose: git matches paths it has already walked, whereas here
+the walk is the expensive part, and an unanchored scan of a repo containing
+`node_modules` is the difference between instant and minutes.
+
+### What the copy will and will not do
+
+Nothing in this list fails creation. Every skip is reported in the transcript,
+and the setup script is what decides whether a missing file actually mattered.
+
+| Situation | Behavior |
+|---|---|
+| Path already exists in the worktree | **The tracked file wins.** Never overwritten; the skip is reported. |
+| Source is a symlink | Skipped, never dereferenced. |
+| Destination path crosses a symlink | Refused — a copy can never be redirected outside the worktree. |
+| Pattern matches nothing | Reported; the remaining patterns still copy. |
+| Source unreadable, or the write fails | Reported; the remaining patterns still copy. |
+| Pattern leaves the project root (`..`) | Refused. |
+
+The two symlink rules are a security boundary, not a nicety: a copy that
+dereferenced a source symlink, or wrote through one in the destination, would
+read or write outside the worktree. They are covered by
+`worktree.include-copy-cannot-write-outside-the-worktree` in
+[the reliability gates ledger](./reliability-gates.md), which also records that
+the assertions are `#[cfg(unix)]` and therefore prove nothing on Windows yet.
+
+### Put dependencies in the setup script, not here
+
+`.oximuxinclude` copies files one at a time. Naming `node_modules/` will work
+and will be slow. Installing dependencies is what `setup` is for.
+
+## The transcript
+
+Provisioning writes a live transcript to:
+
+```
+<data-dir>/projects/<project-id>/provisioning/<slug>-<millis>.log
+```
+
+It is written **outside** the worktree deliberately, because the case that most
+needs reading is the one where the worktree no longer exists — a failed setup
+rolls it back, and a transcript inside it would go with it. Lines are flushed as
+they arrive, so a long install can be followed with `tail -f`.
+
+On failure the transcript opens automatically in an editor tab, because the
+useful information is the script's own output — the compiler error or the
+missing binary — not a generic "setup failed".
+
+A fresh file per attempt, with the newest three per slug retained. Overwriting
+one file in place would look tidier and be wrong: the editor activates an
+already-open tab without re-reading it, so a second failed create would show you
+the *first* failure's output while the file on disk said something else.
+
+## Bounds
+
+| | Setup | Cleanup |
+|---|---|---|
+| Timeout | 15 minutes | 30 seconds |
+| stdin | Closed | Closed |
+| Output | Captured to the transcript | Discarded |
+| On failure | Creation fails and rolls back | Logged; removal proceeds |
+
+stdin is closed on purpose. A script that prompts for input (`npm login`, a
+passphrase) fails immediately with the prompt visible in the transcript, instead
+of hanging for the full fifteen minutes with nothing to show for it.


### PR DESCRIPTION
Ships the P0 set from the 2026-09-05 competitor teardowns: a machine-checked
reliability ledger, worktree provisioning, rate-limit retry, and a render-fidelity
floor for the agent transcript.

## What landed

**Reliability gates ledger** — `config/reliability-gates.toml` plus an `xtask`
validator. A gate claiming `stable` must name test files and assertions that
actually exist; an assertion name that no longer resolves is a violation, a
coverage gap without notes is a violation, and a `cfg`-gated file cannot prove
the platform it excludes. 24 gates, 18 with a declared and explained coverage gap.

The motive is specific: "VERIFIED" has twice been a false claim in an OxiMux plan
doc. The ledger's own validation pass caught a third — a dependency claim that
was wrong — before this branch existed.

**Worktree provisioning** — creating a worktree now copies `.oximuxinclude` and
runs `ScriptKind::Setup` before reporting the worktree created. A non-zero exit
fails creation and rolls back. Output streams to a per-line-flushed transcript
that auto-opens on failure. Defaults to the project's existing `auto_setup` flag,
so no existing flow changes behaviour on upgrade.

**Rate-limit retry** — a turn refused for provider overload or a subscription
window with a known reset re-sends itself at the reset plus jitter, capped at 4,
behind a user-cancellable card. Spend and credit limits are **never** retried —
that distinction is the point, and it carries its own gate. A held turn survives
a restart, and a stale one is refused rather than replayed.

**Render-fidelity floor** — 13 fixtures pinned as their *folded transcript*
(not the event stream, so future coalescing stays possible), plus shared
invariants every agent runs against its own fixtures: terminalize before the
terminal event, dedupe by identity rather than by text, and no row that renders
as an empty shell.

## On the assembler that isn't here

The plan's fourth phase was to extract a five-way `ThreadEvent` assembler. Step 2
measured the premise and it did not hold, so it was rescoped rather than built.

The stated 6,517-LOC mapper baseline is about half test code — real production
mapper LOC is 3,339 — so the comparison that motivated it was never like-for-like.
And the duplication is a fork pair, not five-way: Claude's decoder is stateless,
Codex is item-lifecycle native, and the one real duplicate (Pi/omp, 74% identical)
already shares its extracted half in `thread/snapshot_diff.rs`. Unifying what
remains would produce a function of flags.

What shipped instead is the fidelity floor above — which attacks the actual
evidence behind that phase, nine rounds of render-fidelity work, without
rewriting three dialects that were never duplicates.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --all-targets` — 175 suites, 5229 passed, 0 failed
  (run locally with `--exclude oximux-computer-use`: two of its tests exec a
  freshly copied binary and wedge uninterruptibly on this machine; unrelated to
  this branch and covered in CI)
- `cargo run -p xtask -- reliability-gates` — ok, 24 gates
- Live GUI pass against a real Claude provider turn: transcript renders, usage
  footer decodes, nothing left spinning, and the queued retry card observed on
  screen

**Oracles were checked against mutants, and one failed.** A mutant dropping
`usage` from every `TurnEnded` passed all thirteen snapshots, because the
projection omitted `usage` — a snapshot is only a net over the fields it
projects. Fixed. A second mutant making the Codex mapper never terminalize an
item is now caught by name. ACP has no captured fixture, so its coverage is
synthetic and is labelled as such in the ledger rather than blended into the
same claim; it carries a negative control so the test proves the oracle is
wired to ACP.

https://claude.ai/code/session_01Ermo2bW81akSqaUu3PGyUx
