### PR TITLE
fix: name a line-ending difference instead of drawing two identical halves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7735,6 +7735,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 name = "oximux-agent-core"
 version = "0.1.19"
 dependencies = [
+ "oximux-agent-core",
  "serde",
  "serde_json",
  "tracing",

--- a/crates/agent-core/Cargo.toml
+++ b/crates/agent-core/Cargo.toml
@@ -25,3 +25,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+# This crate's own integration test (`tests/transcript_snapshots.rs`) uses
+# `thread::snapshot`, which is behind `test-support`. Without this line the
+# feature reached it only by Cargo unifying features across a `--workspace`
+# build, borrowed from `oximux-agents`'s dev-dependency — so `cargo test -p
+# oximux-agent-core` failed to compile while CI stayed green. A crate's tests
+# must not depend on which *other* crate happens to be in the same build.
+oximux-agent-core = { path = ".", features = ["test-support"] }

--- a/crates/agent-core/src/thread/snapshot.rs
+++ b/crates/agent-core/src/thread/snapshot.rs
@@ -1,13 +1,20 @@
-//! Transcript snapshot harness — the safety net for the assembler extraction.
+//! Transcript snapshot harness — the fidelity floor under the agent mappers.
 //!
-//! The assembler moves lifecycle decisions (id minting, turn/item boundaries,
-//! close dedupe, text accumulation, coalescing) out of five agent mappers and
-//! into one place. The thing that must not change while that happens is what
-//! the user sees, and *that* is the folded [`ChatThread`] — not the event
-//! stream. Coalescing deliberately alters the event stream: it merges deltas,
-//! so a pinned `Vec<ThreadEvent>` would report a false regression on the first
-//! migration. The fold is where "rendered output is unchanged" is actually
-//! decidable, because it is what every render path reads.
+//! Written as the safety net for a five-way `Assembler` extraction, which was
+//! then declined on measurement: the mappers turned out not to be five copies
+//! of one lifecycle (Claude's decoder is stateless, Codex is item-lifecycle
+//! native, and the one real duplicate already shares `snapshot_diff`). The
+//! harness outlived the plan that motivated it, because the evidence behind
+//! that plan — nine rounds of render-fidelity work — was never about the
+//! assembler. It was about mapper changes altering what the user sees without
+//! failing anything.
+//!
+//! What is pinned is the folded [`ChatThread`], not the event stream. That is
+//! deliberate and still load-bearing: event coalescing remains a legitimate
+//! future change that would rewrite the stream without moving a pixel, and a
+//! pinned `Vec<ThreadEvent>` would report it as a regression. The fold is where
+//! "rendered output is unchanged" is actually decidable, because it is what
+//! every render path reads.
 //!
 //! Behind the `test-support` feature so none of this ships: `oximux-agents`
 //! turns it on in dev-dependencies so both crates pin transcripts identically
@@ -187,7 +194,7 @@ fn assert_snapshot_text(path: impl AsRef<Path>, actual: &str) {
     panic!(
         "transcript changed for {}\n\n{}\n\n\
          If this change is intended, regenerate with `{UPDATE_VAR}=1 cargo test` \
-         and name the change in the phase log. If it is not, the assembler \
+         and name the change in the commit. If it is not, a mapper change \
          altered what the user sees.",
         path.display(),
         first_difference(&expected, actual)
@@ -196,10 +203,68 @@ fn assert_snapshot_text(path: impl AsRef<Path>, actual: &str) {
 
 /// The first differing line with a little context — enough to see what moved
 /// without printing two full transcripts into the test output.
+///
+/// Reports a difference `str::lines()` cannot see *as such*, rather than
+/// rendering a window for it. `lines()` discards `\r` and the trailing newline,
+/// so two strings that differ only in those compare equal line by line: the
+/// scan finds nothing, and a naive fallback prints the tail of each side —
+/// two halves that are character-identical, under a message saying the
+/// transcript changed. That reads like a bug in the fold, and the natural
+/// response is to regenerate the snapshot, which "fixes" it by committing the
+/// wrong bytes and silently destroys the byte-exactness this harness exists to
+/// provide. It has happened once already (CRLF on the Windows runner), so the
+/// invisible cases are named here instead of being drawn.
 fn first_difference(expected: &str, actual: &str) -> String {
     let exp: Vec<&str> = expected.lines().collect();
     let act: Vec<&str> = actual.lines().collect();
-    let at = exp.iter().zip(&act).position(|(a, b)| a != b).unwrap_or(exp.len().min(act.len()));
+
+    if let Some(at) = exp.iter().zip(&act).position(|(a, b)| a != b) {
+        return window_around(at, &exp, &act);
+    }
+
+    // Every line the two share is equal, so the difference is either past the
+    // end of the shorter side or in bytes `lines()` threw away.
+    if exp.len() != act.len() {
+        return format!(
+            "{}\n\n(expected has {} lines, actual has {} — they agree up to line {})",
+            window_around(exp.len().min(act.len()), &exp, &act),
+            exp.len(),
+            act.len(),
+            exp.len().min(act.len())
+        );
+    }
+
+    format!(
+        "every line is equal, so the difference is in bytes `lines()` discards:\n\
+         {}\n\
+         This is a line-ending or trailing-newline difference, NOT a change to \
+         the transcript. Do NOT regenerate with `{UPDATE_VAR}=1` — that would \
+         commit the wrong bytes. Fix it where it comes from: a checkout that \
+         rewrote the file (see the `text eol=lf` rules in `.gitattributes`) or \
+         an editor that added a final newline.",
+        invisible_differences(expected, actual)
+    )
+}
+
+/// The concrete evidence for a difference no rendered line can show.
+fn invisible_differences(expected: &str, actual: &str) -> String {
+    let describe = |s: &str| {
+        let endings = match (s.contains("\r\n"), s.contains('\n')) {
+            (true, _) => "CRLF",
+            (false, true) => "LF",
+            (false, false) => "no line breaks",
+        };
+        let trailing = if s.ends_with('\n') { "yes" } else { "no" };
+        format!("{endings}, trailing newline: {trailing}, {} bytes", s.len())
+    };
+    format!(
+        "  expected: {}\n  actual:   {}",
+        describe(expected),
+        describe(actual)
+    )
+}
+
+fn window_around(at: usize, exp: &[&str], act: &[&str]) -> String {
     let from = at.saturating_sub(3);
     let window = |lines: &[&str]| {
         lines
@@ -214,7 +279,60 @@ fn first_difference(expected: &str, actual: &str) -> String {
     format!(
         "first difference at line {}\n--- expected ---\n{}\n--- actual ---\n{}",
         at + 1,
-        window(&exp),
-        window(&act)
+        window(exp),
+        window(act)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_difference;
+
+    /// The failure that actually shipped: a CRLF checkout of an LF snapshot.
+    ///
+    /// The old reporter answered this with "first difference at line 4" and two
+    /// windows that printed identically, because `lines()` strips `\r`.
+    #[test]
+    fn a_crlf_checkout_is_named_rather_than_drawn() {
+        let report = first_difference("a\r\nb\r\nc\r\n", "a\nb\nc\n");
+
+        assert!(report.contains("every line is equal"), "{report}");
+        assert!(report.contains("expected: CRLF"), "{report}");
+        assert!(report.contains("actual:   LF"), "{report}");
+        // The whole point: do not send the reader to the regenerate command.
+        assert!(report.contains("Do NOT regenerate"), "{report}");
+        assert!(!report.contains("first difference at line"), "{report}");
+    }
+
+    #[test]
+    fn a_trailing_newline_difference_is_named_too() {
+        let report = first_difference("a\nb\n", "a\nb");
+
+        assert!(report.contains("every line is equal"), "{report}");
+        assert!(report.contains("trailing newline: yes"), "{report}");
+        assert!(report.contains("trailing newline: no"), "{report}");
+    }
+
+    /// Negative control. A reporter that called everything invisible would pass
+    /// both tests above, so a real content change must still be drawn.
+    #[test]
+    fn a_real_content_change_is_still_drawn_with_a_window() {
+        let report = first_difference("a\nb\nc\n", "a\nB\nc\n");
+
+        assert!(report.contains("first difference at line 2"), "{report}");
+        assert!(report.contains("     2 | b"), "{report}");
+        assert!(report.contains("     2 | B"), "{report}");
+        assert!(!report.contains("every line is equal"), "{report}");
+    }
+
+    /// A truncated side shares every line it has, so it reaches the same branch
+    /// as the invisible cases — but it is a genuine content difference and must
+    /// not be reported as line endings.
+    #[test]
+    fn a_shorter_actual_reports_the_line_counts_not_line_endings() {
+        let report = first_difference("a\nb\nc\n", "a\nb\n");
+
+        assert!(report.contains("expected has 3 lines, actual has 2"), "{report}");
+        assert!(!report.contains("every line is equal"), "{report}");
+    }
 }

--- a/docs/agent-retry.md
+++ b/docs/agent-retry.md
@@ -134,3 +134,14 @@ while the desktop quietly retried its own, which is a worse surface than no
 verbs. Making the CLI's answer true means moving retry into the host layer
 first; the wire change (a new verb plus a protocol version bump) is the smaller
 half of that job.
+
+What is *not* missing is the policy. `oximux_agents::retry::schedule()` and
+`classify_failure` are already pure and host-agnostic — no clock, no randomness,
+no view — so what has to move is the driver that arms a timer and re-sends, not
+the rules about when a retry is allowed. Two shipped things give that driver its
+shape: `schedule::ScheduleFirer` is the same host-agnostic-trait-plus-per-host-
+implementation pattern, and `serve`'s pump already holds the folded thread, the
+`SessionHandle` that can re-send, and a Tokio loop to time it from. The open
+design question is what a headless host should do in place of the desktop's
+`dormant` check — in particular whether it should re-send into a session whose
+agent process has exited.


### PR DESCRIPTION
Two fixes and a doc, all from digging into loose ends left by the reliability-enhancements plan.

## The snapshot reporter's worst output was for the failure it had just been used on

`first_difference` scans with `str::lines()`, which discards `\r` and the trailing newline. Two strings differing only in those compare equal line by line, so the scan found nothing, `unwrap_or(min_len)` put the cursor one past the end, and the window printed the tail of each side — two halves that are character-identical, under a message saying the transcript changed.

That is worse than an unhelpful diff. It reads like a bug in the fold, and the message's own advice is to regenerate the snapshot — which would "fix" it by committing CRLF into the pins and destroying the byte-exactness the harness exists to provide. This is exactly what the Windows runner produced last week.

The invisible cases are now named rather than drawn: which side is CRLF, which has a trailing newline, byte counts, an explicit instruction *not* to regenerate, and a pointer to the `.gitattributes` rule that fixes it at source. A shorter side is separated out and reports line counts, since that one is a real content difference arriving at the same branch.

Four tests, including a negative control — a reporter that called everything invisible would satisfy both line-ending tests, so a genuine content change must still be drawn.

## `cargo test -p oximux-agent-core` did not compile

Found while writing those tests. The integration test uses `thread::snapshot`, behind `test-support`, which reached it only through Cargo unifying features across a `--workspace` build — borrowed from `oximux-agents`'s dev-dependency. CI stayed green because CI runs the workspace. A crate's own tests must not depend on which other crate happens to share the build.

## Stale prose

The module doc and panic text described this harness as the safety net for an `Assembler` extraction that was measured, declined, and will not be built. `docs/agent-retry.md` said the missing CLI verbs were "blocked on a precondition" without saying where to start — the policy half is already host-agnostic, `ScheduleFirer` is a working template for the driver, and the genuinely open question is what a headless host does in place of the desktop's `dormant` check.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --all-targets --exclude oximux-computer-use` — exit 0
- `cargo test -p oximux-agent-core` — now compiles and passes standalone (183 tests); previously a build error
- `cargo run -p xtask -- reliability-gates` — ok, 24 gates

https://claude.ai/code/session_01Ermo2bW81akSqaUu3PGyUx