### PR TITLE
fix(ci): run the two xtask lints that have been gating nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,25 @@ jobs:
       - name: xtask file-size-lint
         run: cargo run -p xtask -- file-size-lint
 
+      # Where OxiMux keeps its data is one decision owned by `app_paths`. A
+      # direct `dirs::data_dir()` elsewhere reads correctly on the machine that
+      # wrote it and silently splits the data directory on the platform whose
+      # convention differs — which is why this is a lint and not a review note.
+      - name: xtask data-dir-lint
+        run: cargo run -p xtask -- data-dir-lint
+
       # Radius and type sizes belong to `Density` / `Typography`. A raw
       # `px(N)` cannot scale, which is what would break UI zoom — so the
       # allowlist is a ratchet and this step is what keeps it going down.
       - name: xtask literal-lint
         run: cargo run -p xtask -- literal-lint
+
+      # A view that caches appearance tokens but never re-pulls them keeps
+      # rendering the old theme after a change, and a type scale resolved
+      # without the chosen faces silently ignores the font setting. Both look
+      # correct in the code and wrong only on screen, after a setting changes.
+      - name: xtask appearance-lint
+        run: cargo run -p xtask -- appearance-lint
 
       # The reliability ledger records what OxiMux claims to be true and where
       # that claim is actually proven. It is checked here rather than left to

--- a/config/reliability-gates.toml
+++ b/config/reliability-gates.toml
@@ -996,3 +996,46 @@ assertions = [
   "every_captured_turn_renders_the_pinned_transcript",
   "every_fixture_decodes_to_at_least_one_event",
 ]
+
+[[gate]]
+id = "ci.every-xtask-check-actually-runs"
+title = "A lint in the ci-check chain cannot silently gate nothing"
+status = "stable"
+owner = "xtask"
+invariant = """
+Every check listed in `CI_CHECKS` — the chain `xtask ci-check` runs — is \
+invoked by `.github/workflows/ci.yml` as its own step. Adding a lint to the \
+chain is therefore enough to make CI enforce it."""
+oracle = """
+Read the workflow and assert each check's argv appears in it. Asserts the \
+command rather than the step name, because a step is free to be renamed and \
+the command is what actually runs. \
+\
+This is a checker for the checkers, and it is registered because the failure \
+already happened and lasted months: `data-dir-lint` and `appearance-lint` were \
+written, unit-tested (19 tests between them) and added to the chain, while CI \
+ran neither — `ci-check` is invoked nowhere in the workflow, which lists its \
+lints individually so a failure names itself. The dispatch even carried a \
+comment arguing the data-dir lint 'has to run on every platform's CI'. That was \
+the intent, it was never true, and nothing said so. \
+\
+Verified non-vacuous by mutation: deleting the `appearance-lint` step from \
+`ci.yml` fails the test and names the missing check. A negative control also \
+pins that the probe string is genuinely absent, since a `contains` against a \
+workflow full of cargo invocations could otherwise match by accident."""
+platforms = ["macos", "windows", "linux"]
+covered_platforms = ["macos"]
+coverage_notes = """
+macOS only, and that is sufficient here rather than a gap worth closing: the \
+assertion reads two files in the repo and has no platform behaviour at all. \
+`xtask` is built and tested in the macOS `--workspace --all-targets` job; the \
+Linux jobs scope to the CLI crates and the Windows job runs a named crate list \
+that does not include it. \
+\
+What this gate does NOT prove is that the lints it counts are themselves \
+meaningful, only that they run. It is a wiring check."""
+test_files = ["xtask/src/main.rs"]
+assertions = [
+  "every_ci_check_runs_in_ci",
+  "a_check_absent_from_the_workflow_would_be_caught",
+]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,6 +39,46 @@ use std::process::ExitCode;
 const WARN_LOC: usize = 1500;
 const FAIL_LOC: usize = 3000;
 const ALLOW_FILE: &str = "xtask/file-size-allow.txt";
+/// The workflow [`CI_CHECKS`] is asserted against. Test-only: nothing in a
+/// normal `xtask` run reads the workflow, it only has to agree with it.
+#[cfg(test)]
+const CI_WORKFLOW: &str = ".github/workflows/ci.yml";
+
+type Check = fn() -> Result<(), Box<dyn std::error::Error>>;
+
+/// Every check `ci-check` runs, paired with the argv CI must invoke it by.
+///
+/// A table rather than a chain of `and_then`s because the names are asserted
+/// against the workflow file: `ci.yml` calls each lint as its own step so a
+/// failure names itself in the job list, and nothing then kept the two lists in
+/// agreement. They had already drifted — `data-dir-lint` and `appearance-lint`
+/// sat in the chain, fully implemented and unit-tested, while CI ran neither for
+/// months. The dispatch comment even argued that the data-dir lint "has to run
+/// on every platform's CI", which was true and had never happened, because
+/// `ci-check` itself is invoked nowhere in the workflow.
+///
+/// So this is the source of truth, and [`tests::every_ci_check_runs_in_ci`] is
+/// what makes adding a row here enough.
+///
+/// `icon --check` is in the list rather than in a Windows-only job because the
+/// icon is derived from a file in the repo, not from the host: it goes stale on
+/// whichever platform edits the source, and that is usually not Windows. The
+/// data-dir lint is here for the inverted reason — the mistake it catches is
+/// invisible on macOS, so it must run everywhere rather than on Windows alone.
+const CI_CHECKS: &[(&str, Check)] = &[
+    ("file-size-lint", file_size_lint),
+    ("data-dir-lint", data_dir_lint),
+    ("literal-lint", literal_lint),
+    ("appearance-lint", appearance_lint),
+    ("reliability-gates", reliability_gates),
+    ("icon --check", icon_check),
+];
+
+/// `icon::run` takes the flag the others do not, so it is adapted rather than
+/// widening every signature in [`CI_CHECKS`].
+fn icon_check() -> Result<(), Box<dyn std::error::Error>> {
+    icon::run(true)
+}
 
 /// Repo-relative directories the lint walks, enumerated rather than globbed.
 ///
@@ -58,19 +98,7 @@ fn main() -> ExitCode {
         "appearance-lint" => appearance_lint(),
         "reliability-gates" => reliability_gates(),
         "icon" => icon::run(check),
-        // Every check CI should run, in one command. `icon --check` is here
-        // rather than in a Windows-only job because the icon is derived from a
-        // file in the repo, not from the host — it goes stale on whichever
-        // platform edits the source, and that is usually not Windows. The
-        // data-dir lint is here for the same reason inverted: the mistake it
-        // catches is invisible on macOS, so it has to run on every platform's
-        // CI rather than Windows'.
-        "ci-check" => file_size_lint()
-            .and_then(|()| data_dir_lint())
-            .and_then(|()| literal_lint())
-            .and_then(|()| appearance_lint())
-            .and_then(|()| reliability_gates())
-            .and_then(|()| icon::run(true)),
+        "ci-check" => CI_CHECKS.iter().try_for_each(|(_, run)| run()),
         "help" | "--help" | "-h" => {
             print_help();
             Ok(())
@@ -317,4 +345,55 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Box<dyn std::error::Er
 fn count_loc(path: &Path) -> Result<usize, Box<dyn std::error::Error>> {
     let text = std::fs::read_to_string(path)?;
     Ok(text.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CI_CHECKS, CI_WORKFLOW, workspace_root};
+
+    /// Every check in [`CI_CHECKS`] is actually invoked by the workflow.
+    ///
+    /// The failure this exists to catch has already happened twice and cost
+    /// months: a lint is written, unit-tested, added to the `ci-check` chain,
+    /// and gates nothing — because `ci-check` is not what CI runs. It reads as
+    /// covered from inside the xtask crate and is invisible from the workflow,
+    /// which is the same "looks like coverage" shape the reliability ledger
+    /// exists to reject.
+    ///
+    /// Asserting the argv rather than the step name on purpose: a step can be
+    /// renamed freely, but the command is what runs.
+    #[test]
+    fn every_ci_check_runs_in_ci() {
+        let root = workspace_root().expect("workspace root");
+        let workflow = std::fs::read_to_string(root.join(CI_WORKFLOW))
+            .expect("ci.yml is readable from the workspace root");
+
+        let missing: Vec<&str> = CI_CHECKS
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| !workflow.contains(&format!("cargo run -p xtask -- {name}")))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "these checks are in the ci-check chain but never run in CI: {missing:?}\n\
+             Add `cargo run -p xtask -- <name>` as a step in {CI_WORKFLOW}, or drop \
+             the row from CI_CHECKS. A lint that gates nothing is worse than no lint."
+        );
+    }
+
+    /// Negative control: the assertion above must be able to fail. A `contains`
+    /// against a workflow that mentions almost every cargo invocation somewhere
+    /// could easily match by accident.
+    #[test]
+    fn a_check_absent_from_the_workflow_would_be_caught() {
+        let root = workspace_root().expect("workspace root");
+        let workflow = std::fs::read_to_string(root.join(CI_WORKFLOW))
+            .expect("ci.yml is readable from the workspace root");
+
+        assert!(
+            !workflow.contains("cargo run -p xtask -- a-lint-that-does-not-exist"),
+            "the probe name was expected to be absent from the workflow"
+        );
+    }
 }


### PR DESCRIPTION
`data-dir-lint` and `appearance-lint` are implemented, unit-tested (19 tests between them), listed in the `xtask ci-check` chain — and have never run in CI. The workflow invokes its lints individually (deliberately, so a failure names itself in the job list) and `ci-check` itself is invoked nowhere.

Both lints pass today, so this is enforcement that was missing, not a backlog to work through.

## Why this is a defect, not a choice

The dispatch carried this comment:

> The data-dir lint is here for the same reason inverted: the mistake it catches is invisible on macOS, so it has to run on every platform's CI rather than Windows'.

That was the intent. It had never been true, and nothing said so. The lint catches a component picking its own data directory instead of going through `app_paths` — which reads correctly on the machine that wrote it and silently splits the data directory on the platform whose convention differs. Invisible on macOS, which is where it was written.

## Two steps fix today; `CI_CHECKS` fixes tomorrow

The chain is now a table of `(argv, fn)` that `ci-check` iterates, and a test asserts each argv appears in `ci.yml`. It asserts the **command**, not the step name — a step is free to be renamed, the command is what runs. Adding a lint to the table is now sufficient: the test fails until CI invokes it.

## Verification

- Mutation: deleting the `appearance-lint` step from `ci.yml` fails the test and names the missing check. Reverted, green again.
- Negative control pins that the probe string is genuinely absent, since a `contains` against a workflow full of cargo invocations could match by accident.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --all-targets --exclude oximux-computer-use` — exit 0
- `cargo run -p xtask -- ci-check` — exit 0 (the whole chain, including the two newly-wired lints)
- `cargo run -p xtask -- reliability-gates` — ok, 25 gates

Registered as `ci.every-xtask-check-actually-runs`. That is the ledger's 25th gate, which is its documented cap — it earns the slot by mapping to a real incident, which is the kind the cap says to keep rather than grow past.

https://claude.ai/code/session_01Ermo2bW81akSqaUu3PGyUx