### PR TITLE
fix(codex): one writer per thread — handoff, honest refusal, recoverable failure

### DIFF
--- a/apps/desktop/src/shell/agent_chat/assemble.rs
+++ b/apps/desktop/src/shell/agent_chat/assemble.rs
@@ -346,6 +346,7 @@ impl AgentChatView {
             terminal: None,
             companion_session: None,
             chat_advanced_since_companion: false,
+            companion_spawn_pending: false,
             _terminal_observer: None,
             expanded_thinking: HashSet::new(),
             collapsed_thinking: HashSet::new(),

--- a/apps/desktop/src/shell/agent_chat/assemble.rs
+++ b/apps/desktop/src/shell/agent_chat/assemble.rs
@@ -449,17 +449,16 @@ impl AgentChatView {
         // constructed with the generic "Agent" placeholder).
         let provider_label = self.provider_label().to_string();
         // Live context-meter inputs: prefer the mid-turn `live_usage`, fall back
-        // to the settled `usage`; total token occupancy = input + cache + output
-        // (ACP folds its whole "used" count into `input_tokens`). The window is
-        // the cross-turn cached denominator; cost is the session accumulator.
+        // to the settled `usage`. Occupancy comes from `context_used()` and must
+        // not be recomputed here — the cache counts mean different things per
+        // backend. The window is the cross-turn cached denominator; cost is the
+        // session accumulator.
         let meter_used = self
             .thread
             .live_usage
             .as_ref()
             .or(self.thread.usage.as_ref())
-            .map(|u| {
-                u.input_tokens + u.cache_read_tokens + u.cache_creation_tokens + u.output_tokens
-            });
+            .map(TurnUsage::context_used);
         let meter_window = self.thread.last_known_context_window;
         let meter_cost = self.thread.session_cost_usd;
         // An unbound draft has no `connection`, so `caps`/`vocab` above are the

--- a/apps/desktop/src/shell/agent_chat/companion_sync.rs
+++ b/apps/desktop/src/shell/agent_chat/companion_sync.rs
@@ -48,6 +48,7 @@ impl AgentChatView {
         self.terminal = Some(terminal);
         self.companion_session = Some(session);
         self.chat_advanced_since_companion = false;
+        self.companion_spawn_pending = false;
         self.view_mode = ChatViewMode::Terminal;
         self.focus_active_surface(window, cx);
         cx.notify();
@@ -106,6 +107,19 @@ impl AgentChatView {
         self.sync_composer(cx);
     }
 
+    /// Whether a companion spawn is already in flight, so the host can refuse a
+    /// second toggle rather than schedule a duplicate.
+    pub fn companion_spawn_pending(&self) -> bool {
+        self.companion_spawn_pending
+    }
+
+    /// Mark (or clear) an in-flight companion spawn. The host sets it
+    /// synchronously before scheduling, and clears it on every path that ends
+    /// the attempt without an attach.
+    pub fn set_companion_spawn_pending(&mut self, pending: bool) {
+        self.companion_spawn_pending = pending;
+    }
+
     /// Record that the chat sent a prompt while a companion terminal exists.
     /// The running interactive CLI loaded the session at spawn time and never
     /// re-reads the log, so from this moment its context is missing turns —
@@ -130,6 +144,7 @@ impl AgentChatView {
         self.companion_session = None;
         self._terminal_observer = None;
         self.chat_advanced_since_companion = false;
+        self.companion_spawn_pending = false;
         cx.notify();
     }
 

--- a/apps/desktop/src/shell/agent_chat/companion_sync.rs
+++ b/apps/desktop/src/shell/agent_chat/companion_sync.rs
@@ -9,10 +9,11 @@
 //! the log off the UI thread and append the suffix the thread hasn't seen.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use gpui::{AppContext as _, Context, Window};
 
-use oximux_agents::thread::{ThreadEntry, Transport};
+use oximux_agents::thread::{AgentConnection, ThreadEntry, Transport};
 use oximux_agents::SharedBackend;
 use oximux_core::AgentSessionId;
 use oximux_pty::TerminalSessionId;
@@ -50,6 +51,59 @@ impl AgentChatView {
         self.view_mode = ChatViewMode::Terminal;
         self.focus_active_surface(window, cx);
         cx.notify();
+    }
+
+    /// Whether this chat's backend lets only ONE process write the session at a
+    /// time, so the chat and its companion terminal must take turns owning it
+    /// rather than both running.
+    ///
+    /// Codex does: since 0.153.4 it holds a per-thread writer lock, and the
+    /// second `thread/resume` is refused (see `is_thread_writer_conflict` in
+    /// the codex protocol module).
+    /// Every other backend tolerates two readers of one session log — Claude,
+    /// Pi, omp and OpenCode all keep their instant re-toggle, with the
+    /// companion CLI alive underneath the chat.
+    pub fn needs_session_handoff(&self) -> bool {
+        self.backend.transport == Transport::AppServer
+    }
+
+    /// Whether a turn is streaming right now. The host reads it to refuse a
+    /// session handoff mid-answer.
+    pub fn turn_active(&self) -> bool {
+        self.thread.turn_active
+    }
+
+    /// Give up the live connection so a companion terminal can own the session.
+    ///
+    /// The caller MUST shut down what it gets back — off the UI thread, because
+    /// the reap blocks until the child is confirmed dead — and must not spawn
+    /// the terminal until it has. Handing the lock over on a promise rather
+    /// than on an observed exit is the same race in slower clothes.
+    ///
+    /// Returns `None` when there is nothing to hand over (a dormant chat that
+    /// never connected, or one whose spawn failed); the terminal is free to
+    /// spawn either way.
+    pub fn take_connection_for_handoff(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> Option<Arc<dyn AgentConnection>> {
+        let conn = self.connection.take();
+        cx.notify();
+        conn
+    }
+
+    /// Take the session back after the companion terminal has been reaped.
+    ///
+    /// Only reconnects a chat that actually gave its connection away — a
+    /// backend without a handoff never lost one, and an unbound draft or import
+    /// bridge has none to rebuild. The respawn's `thread/resume` re-reads the
+    /// session log, so it also picks up whatever was typed in the terminal.
+    pub fn reconnect_after_handoff(&mut self, cx: &mut Context<Self>) {
+        if self.connection.is_some() || self.unbound || self.import_bridge.is_some() {
+            return;
+        }
+        self.respawn(cx);
+        self.sync_composer(cx);
     }
 
     /// Record that the chat sent a prompt while a companion terminal exists.

--- a/apps/desktop/src/shell/agent_chat/mod.rs
+++ b/apps/desktop/src/shell/agent_chat/mod.rs
@@ -3166,6 +3166,14 @@ impl AgentChatView {
         }
     }
 
+    /// Test-only: whether an agent connection is live behind this view. Lets a
+    /// test assert the chat is usable, rather than inferring it from a method
+    /// that would consume the connection to look.
+    #[cfg(test)]
+    pub(super) fn has_connection_for_test(&self) -> bool {
+        self.connection.is_some()
+    }
+
     /// Test-only: put this view into the unbound *New Agent* draft state (no
     /// connection, Claude picked) so a `#[gpui::test]` can drive `change_agent` /
     /// `change_model` on a draft without spawning a subprocess.

--- a/apps/desktop/src/shell/agent_chat/mod.rs
+++ b/apps/desktop/src/shell/agent_chat/mod.rs
@@ -720,6 +720,13 @@ pub struct AgentChatView {
     /// The chat sent a prompt after the companion spawned — its CLI loaded the
     /// session at spawn and is now missing turns; see `companion_sync`.
     chat_advanced_since_companion: bool,
+    /// A companion spawn is in flight. `terminal` and `view_mode` are only set
+    /// when the spawn LANDS, so without this every toggle-guard still passes
+    /// while one is running and a second ⌃⇧V schedules a second companion —
+    /// which on a single-writer backend resumes a session the first spawn has
+    /// already taken the connection for. Set at the toggle, cleared on attach
+    /// or on any failure that ends the attempt.
+    companion_spawn_pending: bool,
     /// Repaints this view when the companion terminal notifies (PTY output /
     /// scroll). Held alongside `terminal`; dropped when the companion is dropped.
     _terminal_observer: Option<Subscription>,
@@ -3104,6 +3111,7 @@ impl AgentChatView {
             terminal: None,
             companion_session: None,
             chat_advanced_since_companion: false,
+            companion_spawn_pending: false,
             _terminal_observer: None,
             expanded_thinking: HashSet::new(),
             collapsed_thinking: HashSet::new(),

--- a/apps/desktop/src/shell/agent_chat/tests.rs
+++ b/apps/desktop/src/shell/agent_chat/tests.rs
@@ -1895,6 +1895,58 @@
             .expect("window update");
     }
 
+    /// A companion spawn that fails after the handoff must give the chat its
+    /// connection back.
+    ///
+    /// The handoff shuts the chat's connection down so the companion can take
+    /// the thread's writer lock. If the spawn then fails, clearing the pending
+    /// flag alone leaves the tab in Chat mode with no agent behind it and the
+    /// user unable to type — the failure turns a working chat into a dead one.
+    #[gpui::test]
+    async fn a_failed_spawn_after_handoff_gives_the_chat_back(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let window = cx.add_window(|window, cx| {
+            AgentChatView::with_connection_for_test(
+                Arc::new(StubConnection::default()),
+                Theme::default(),
+                Density::default(),
+                Typography::default(),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        window
+            .update(cx, |view, _window, cx| {
+                view.backend.transport = Transport::AppServer;
+                // The spawn hands the connection over, then fails downstream.
+                assert!(
+                    view.take_connection_for_handoff(cx).is_some(),
+                    "a connected chat hands its connection over"
+                );
+                assert!(
+                    !view.has_connection_for_test(),
+                    "the chat is now agentless — this is the window the fix covers"
+                );
+
+                // What every failure path now does on the way out.
+                view.set_companion_spawn_pending(false);
+                view.reconnect_after_handoff(cx);
+
+                // The respawn is attempted rather than refused. It cannot
+                // succeed here — there is no agent binary to spawn — so the
+                // attempt shows as a connect error, which is precisely the
+                // signal we want: a chat that silently stayed dead would leave
+                // both of these untouched.
+                assert!(
+                    view.disconnected && view.thread.last_error.is_some(),
+                    "the chat must try to take its session back, not stay silently dead"
+                );
+                assert!(!view.companion_spawn_pending(), "and accept a retry");
+            })
+            .expect("window update");
+    }
+
     /// A second ⌃⇧V while the first spawn is still in flight must not schedule
     /// a second companion.
     ///

--- a/apps/desktop/src/shell/agent_chat/tests.rs
+++ b/apps/desktop/src/shell/agent_chat/tests.rs
@@ -1895,6 +1895,55 @@
             .expect("window update");
     }
 
+    /// A second ⌃⇧V while the first spawn is still in flight must not schedule
+    /// a second companion.
+    ///
+    /// `terminal` and `view_mode` are only set when a spawn LANDS, so every
+    /// toggle guard still passes during the async `start_session` — and on a
+    /// single-writer backend the second spawn would resume a session whose
+    /// connection the first spawn had already taken and shut down, then
+    /// overwrite its terminal and orphan the CLI. Found in review of the
+    /// handoff, which is what made the window damaging rather than merely
+    /// wasteful.
+    #[gpui::test]
+    async fn a_second_toggle_mid_spawn_is_refused(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let window = cx.add_window(|window, cx| {
+            AgentChatView::with_connection_for_test(
+                Arc::new(StubConnection::default()),
+                Theme::default(),
+                Density::default(),
+                Typography::default(),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        window
+            .update(cx, |view, _window, cx| {
+                assert!(!view.companion_spawn_pending(), "nothing in flight to begin with");
+                // The host marks the spawn before scheduling it.
+                view.set_companion_spawn_pending(true);
+                assert!(
+                    view.companion_spawn_pending(),
+                    "a toggle arriving now must be refused, not scheduled"
+                );
+                // Still no companion and still in Chat view — i.e. every OTHER
+                // guard would have let the second toggle through.
+                assert!(!view.has_companion_terminal());
+                assert_eq!(view.view_mode(), ChatViewMode::Chat);
+                // A failed spawn clears it, so the next toggle can try again.
+                view.set_companion_spawn_pending(false);
+                assert!(!view.companion_spawn_pending());
+                // So does a companion that lands (via drop, the reap path).
+                view.set_companion_spawn_pending(true);
+                view.drop_companion_terminal(cx);
+                assert!(!view.companion_spawn_pending(), "a dropped companion ends the attempt");
+            })
+            .expect("window update");
+    }
+
     /// The ACP session id is an external, agent-supplied string; only ids safe to
     /// place on a resume command line are accepted (the rest leave the toggle off).
     #[test]

--- a/apps/desktop/src/shell/agent_chat/tests.rs
+++ b/apps/desktop/src/shell/agent_chat/tests.rs
@@ -1833,6 +1833,68 @@
             .expect("window update");
     }
 
+    /// Which backends make the chat and its companion terminal take turns
+    /// owning the session, and what handing it over actually does.
+    ///
+    /// Codex is the one that must: since 0.153.4 it holds a per-thread writer
+    /// lock, so a companion spawned while the chat's app-server is live is
+    /// refused (`-32600 already has an active writer`) and dies on its first
+    /// frame. Every other backend tolerates a second reader of the session log
+    /// and keeps its companion alive underneath the chat for an instant
+    /// re-toggle — a handoff there would cost a respawn each way for nothing.
+    #[gpui::test]
+    async fn codex_alone_hands_the_session_to_its_companion_terminal(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let window = cx.add_window(|window, cx| {
+            AgentChatView::with_connection_for_test(
+                Arc::new(StubConnection::default()),
+                Theme::default(),
+                Density::default(),
+                Typography::default(),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        window
+            .update(cx, |view, _window, cx| {
+                for transport in [
+                    Transport::StreamJson,
+                    Transport::Rpc,
+                    Transport::OmpRpc,
+                    Transport::Acp,
+                ] {
+                    view.backend.transport = transport;
+                    assert!(
+                        !view.needs_session_handoff(),
+                        "{transport:?} has no single-writer lock — keep the instant re-toggle"
+                    );
+                }
+                view.backend.transport = Transport::AppServer;
+                assert!(view.needs_session_handoff(), "codex must hand the session over");
+
+                // Handing over yields the live connection for the caller to reap
+                // — the terminal must not spawn until that process is gone.
+                let handed = view.take_connection_for_handoff(cx);
+                assert!(handed.is_some(), "a connected chat hands its connection over");
+                assert!(
+                    view.take_connection_for_handoff(cx).is_none(),
+                    "nothing left to hand over twice"
+                );
+
+                // Taking it back is refused while the chat is a draft — there is
+                // no session to resume, so a respawn would mint a stray agent.
+                view.make_unbound_for_test();
+                view.reconnect_after_handoff(cx);
+                assert!(
+                    view.take_connection_for_handoff(cx).is_none(),
+                    "an unbound draft stays down rather than spawning a stray agent"
+                );
+            })
+            .expect("window update");
+    }
+
     /// The ACP session id is an external, agent-supplied string; only ids safe to
     /// place on a resume command line are accepted (the rest leave the toggle off).
     #[test]

--- a/apps/desktop/src/shell/agent_chat/transcript.rs
+++ b/apps/desktop/src/shell/agent_chat/transcript.rs
@@ -1574,8 +1574,9 @@ fn usage_footer(usage: &TurnUsage, theme: Theme, typo: &Typography) -> AnyElemen
         format!("{} out", fmt_tokens(usage.output_tokens)),
     ];
     if let Some(window) = usage.context_window.filter(|w| *w > 0) {
-        let used = usage.input_tokens + usage.cache_read_tokens + usage.cache_creation_tokens;
-        let pct = ((used as f64 / window as f64) * 100.0).round() as u64;
+        // Shares `context_used()` with the composer's meter so the footer and
+        // the meter cannot report two different percentages for one turn.
+        let pct = ((usage.context_used() as f64 / window as f64) * 100.0).round() as u64;
         parts.push(format!("{pct}% ctx"));
     }
     if let Some(cost) = usage.cost_usd.filter(|c| *c > 0.0) {

--- a/apps/desktop/src/shell/pane_group/state.rs
+++ b/apps/desktop/src/shell/pane_group/state.rs
@@ -377,6 +377,19 @@ impl PaneGroup {
         })
     }
 
+    /// Whether any chat tab here is bound to the agent session `session_id`.
+    ///
+    /// Keyed on the AGENT session id (Codex's thread id, Claude's session id),
+    /// not the remote id [`Self::agent_chat_view_by_remote_id`] matches — the
+    /// caller is asking "would resuming this session collide with a chat that
+    /// already owns it", and it is the agent's own id the CLI would resume.
+    pub fn has_agent_chat_for_session(&self, session_id: &str, cx: &gpui::App) -> bool {
+        self.tabs.iter().any(|tab| {
+            matches!(&tab.content, PaneContent::AgentChat(view)
+                if view.read(cx).session_id() == Some(session_id))
+        })
+    }
+
     /// The active tab's agent session id, if the active tab is an agent.
     /// Used by "send to active agent" actions to route directly to the
     /// agent in the focused tab — the most common layout has terminal +

--- a/apps/desktop/src/shell/pane_group/tabs.rs
+++ b/apps/desktop/src/shell/pane_group/tabs.rs
@@ -1427,6 +1427,30 @@ impl PaneGroup {
         .detach();
     }
 
+    /// Abandon an in-flight companion spawn, leaving the chat usable.
+    ///
+    /// Clearing the pending flag is only half of it. When the spawn began with
+    /// a handoff, the chat already gave up its connection and shut it down so
+    /// the companion could take the thread's writer lock — so a failure after
+    /// that point strands the tab in Chat mode with no agent behind it, and the
+    /// user cannot type. Taking the session back is what makes a failed
+    /// terminal launch a non-event rather than a dead chat.
+    ///
+    /// `handoff` gates the reconnect because without one the chat never let go,
+    /// and respawning a connection it still holds would be a second agent.
+    fn abandon_spawn(
+        view: &Entity<crate::shell::agent_chat::AgentChatView>,
+        handoff: bool,
+        cx: &mut gpui::AsyncWindowContext,
+    ) {
+        let _ = view.update_in(cx, |v, _window, cx| {
+            v.set_companion_spawn_pending(false);
+            if handoff {
+                v.reconnect_after_handoff(cx);
+            }
+        });
+    }
+
     /// Spawn a companion terminal that resumes the chat's session interactively
     /// (`--resume`), then hand it to the chat view. Mirrors `spawn_agent_tab`'s
     /// runtime dance but mounts into the existing chat tab instead of a new tab,
@@ -1535,7 +1559,7 @@ impl PaneGroup {
                     let _ = cx.update(|_, cx| {
                         crate::shell::toast::toast_op_error(cx, "Terminal view", &err.to_string());
                     });
-                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
+                    Self::abandon_spawn(&view, handoff, cx);
                     return;
                 }
             };
@@ -1544,7 +1568,7 @@ impl PaneGroup {
                 Err(err) => {
                     tracing::warn!(?err, "companion terminal backend_for failed");
                     let _ = runtime.cancel(session).await;
-                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
+                    Self::abandon_spawn(&view, handoff, cx);
                     return;
                 }
             };
@@ -1553,7 +1577,7 @@ impl PaneGroup {
                 Err(err) => {
                     tracing::warn!(?err, "companion terminal terminal_session_id failed");
                     let _ = runtime.cancel(session).await;
-                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
+                    Self::abandon_spawn(&view, handoff, cx);
                     return;
                 }
             };
@@ -2762,4 +2786,43 @@ impl PaneGroup {
 /// empty transcript seed — the thread resume still works).
 fn codex_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".codex"))
+}
+
+#[cfg(test)]
+mod companion_spawn_recovery_tests {
+    /// Every abandoned companion spawn must go through `abandon_spawn`.
+    ///
+    /// The behavioural half of this lives in `agent_chat::tests`
+    /// (`a_failed_spawn_after_handoff_gives_the_chat_back`), which proves the
+    /// recovery works. What it cannot reach is the *wiring*: driving the real
+    /// `spawn_companion_terminal` to each of its three failure points needs a
+    /// runtime that fails on demand. So this pins the invariant that makes the
+    /// wiring correct by construction — the pending flag is cleared in exactly
+    /// one place in this file, and that place also offers the chat its session
+    /// back. A new failure path that clears the flag inline would reintroduce
+    /// the dead-chat bug and fail here.
+    #[test]
+    fn the_pending_flag_is_only_ever_cleared_by_abandon_spawn() {
+        // Scan only the production half — this module's own assertions quote
+        // the very strings being counted.
+        let src = include_str!("tabs.rs")
+            .split("mod companion_spawn_recovery_tests")
+            .next()
+            .expect("source before this test module");
+        assert_eq!(
+            src.matches("set_companion_spawn_pending(false)").count(),
+            1,
+            "clear the flag via abandon_spawn, so the handed-off connection comes back too"
+        );
+        let helper = src
+            .split_once("fn abandon_spawn(")
+            .expect("abandon_spawn exists")
+            .1;
+        let body = &helper[..helper.find("\n    }").expect("helper body ends")];
+        assert!(
+            body.contains("set_companion_spawn_pending(false)")
+                && body.contains("reconnect_after_handoff"),
+            "abandon_spawn must do both halves: clear the flag AND restore the chat"
+        );
+    }
 }

--- a/apps/desktop/src/shell/pane_group/tabs.rs
+++ b/apps/desktop/src/shell/pane_group/tabs.rs
@@ -1375,6 +1375,15 @@ impl PaneGroup {
             );
             return;
         };
+        // One spawn at a time. `terminal`/`view_mode` are only set when the
+        // spawn LANDS, so until then every guard above still passes and a second
+        // ⌃⇧V would schedule a second companion — which on a single-writer
+        // backend resumes a session the first spawn has already taken the
+        // connection for, then overwrites its terminal and orphans the CLI.
+        if view.read(cx).companion_spawn_pending() {
+            return;
+        }
+        view.update(cx, |v, _cx| v.set_companion_spawn_pending(true));
         self.spawn_companion_terminal(view, spec, stale, window, cx);
     }
 
@@ -1526,6 +1535,7 @@ impl PaneGroup {
                     let _ = cx.update(|_, cx| {
                         crate::shell::toast::toast_op_error(cx, "Terminal view", &err.to_string());
                     });
+                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
                     return;
                 }
             };
@@ -1534,6 +1544,7 @@ impl PaneGroup {
                 Err(err) => {
                     tracing::warn!(?err, "companion terminal backend_for failed");
                     let _ = runtime.cancel(session).await;
+                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
                     return;
                 }
             };
@@ -1542,6 +1553,7 @@ impl PaneGroup {
                 Err(err) => {
                     tracing::warn!(?err, "companion terminal terminal_session_id failed");
                     let _ = runtime.cancel(session).await;
+                    let _ = view.update_in(cx, |v, _window, _cx| v.set_companion_spawn_pending(false));
                     return;
                 }
             };

--- a/apps/desktop/src/shell/pane_group/tabs.rs
+++ b/apps/desktop/src/shell/pane_group/tabs.rs
@@ -1323,10 +1323,39 @@ impl PaneGroup {
     ) {
         // In terminal view → back to chat (no spawn).
         if view.read(cx).view_mode() == ChatViewMode::Terminal {
+            // A single-writer backend handed the session to the terminal on the
+            // way in; hand it back the same way — reap the CLI first, then
+            // reconnect once its exit is observed.
+            if view.read(cx).needs_session_handoff() {
+                self.return_session_from_companion(view, window, cx);
+                return;
+            }
             view.update(cx, |v, cx| v.set_view_mode(ChatViewMode::Chat, window, cx));
             self.focus_active(window, cx);
             return;
         }
+        // Never hand the session over mid-answer: the chat is streaming a turn
+        // the user asked for, and killing the connection under it strands the
+        // reply half-written with no way to get the rest back. Checked before
+        // anything is reaped or dropped, so a refused toggle changes nothing.
+        if view.read(cx).needs_session_handoff() && view.read(cx).turn_active() {
+            crate::shell::toast::toast_op_error(
+                cx,
+                "Terminal view",
+                "Wait for this turn to finish (or Stop it) — only one process at a time can hold a Codex session.",
+            );
+            return;
+        }
+        // A companion the chat has outrun must be replaced rather than shown:
+        // its CLI loaded the session at spawn and never re-reads the log, so
+        // chat-sent turns are missing from BOTH its display and its context and
+        // it would answer the next terminal prompt without them. Reaped below,
+        // before the fresh spawn whose `--resume` re-reads the full log.
+        //
+        // On a single-writer backend the chat never has a live companion here
+        // at all (the toggle back reaps it), so `stale` only ever carries the
+        // other backends' outrun CLI.
+        let mut stale = None;
         if view.read(cx).has_companion_terminal() {
             // Current companion → just show it (instant, the CLI stayed alive).
             if !view.read(cx).companion_terminal_stale() {
@@ -1334,21 +1363,7 @@ impl PaneGroup {
                 self.focus_active(window, cx);
                 return;
             }
-            // The chat sent prompts after this companion spawned. Its CLI
-            // loaded the session at spawn and never re-reads the log, so those
-            // turns are missing from BOTH its display and its context — it
-            // would answer the next terminal prompt without them. Reap it and
-            // fall through to a fresh spawn, whose `--resume` re-reads the
-            // full log.
-            if let Some(stale) = view.read(cx).companion_session_id() {
-                let runtime = self.cli_runtime.clone();
-                cx.spawn_in(window, async move |_this, _cx| {
-                    if let Err(err) = runtime.cancel(stale).await {
-                        tracing::warn!(?err, "stale companion terminal cancel failed");
-                    }
-                })
-                .detach();
-            }
+            stale = view.read(cx).companion_session_id();
             view.update(cx, |v, cx| v.drop_companion_terminal(cx));
         }
         // First switch: spawn the resume terminal, then attach it.
@@ -1360,7 +1375,47 @@ impl PaneGroup {
             );
             return;
         };
-        self.spawn_companion_terminal(view, spec, window, cx);
+        self.spawn_companion_terminal(view, spec, stale, window, cx);
+    }
+
+    /// Take the session back from a companion terminal on a backend where only
+    /// one process may write it (Codex). Reap the CLI, wait for its exit to be
+    /// observed, then fold its turns in and reconnect the chat.
+    ///
+    /// The order is the whole point. The terminal's lock outlives a `cancel()`
+    /// that is merely *sent*, so reconnecting before the exit lands would race
+    /// the chat's own `thread/resume` against a lock still held — and the fold
+    /// would read a rollout the CLI had not finished flushing.
+    fn return_session_from_companion(
+        &mut self,
+        view: Entity<crate::shell::agent_chat::AgentChatView>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let companion = view.read(cx).companion_session_id();
+        let runtime = self.cli_runtime.clone();
+        cx.spawn_in(window, async move |group, cx| {
+            if let Some(session) = companion
+                && let Err(err) = runtime.cancel(session).await
+            {
+                tracing::warn!(?err, "companion terminal cancel failed on session handback");
+            }
+            let _ = view.update_in(cx, |v, window, cx| {
+                // Fold first (the mode switch is what triggers it), while the
+                // companion is still registered — then drop it, then reconnect.
+                // The fold reads the rollout on a background thread and applies
+                // its tail after this returns, so a session that grew in the
+                // terminal respawns once more when that lands. Redundant (this
+                // reconnect already re-read the log, the CLI having been reaped
+                // above) but harmless — the respawn reaps before it connects,
+                // so the two never hold the thread at once.
+                v.set_view_mode(ChatViewMode::Chat, window, cx);
+                v.drop_companion_terminal(cx);
+                v.reconnect_after_handoff(cx);
+            });
+            let _ = group.update_in(cx, |g, window, cx| g.focus_active(window, cx));
+        })
+        .detach();
     }
 
     /// Spawn a companion terminal that resumes the chat's session interactively
@@ -1372,10 +1427,12 @@ impl PaneGroup {
         &mut self,
         view: Entity<crate::shell::agent_chat::AgentChatView>,
         spec: ChatTerminalSpec,
+        stale: Option<AgentSessionId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let runtime = self.cli_runtime.clone();
+        let handoff = view.read(cx).needs_session_handoff();
         // Per-agent launch defaults (model fallback + extra args + env), read
         // under the chat's own profile so the companion terminal reaches the
         // same endpoint/account as the chat it is resuming.
@@ -1418,6 +1475,29 @@ impl PaneGroup {
             })
             .flatten();
         cx.spawn_in(window, async move |group, cx| {
+            // Reap an outrun companion before its replacement resumes the same
+            // session — awaited, not detached, because on a single-writer
+            // backend the two would otherwise contend for the same lock.
+            if let Some(session) = stale
+                && let Err(err) = runtime.cancel(session).await
+            {
+                tracing::warn!(?err, "stale companion terminal cancel failed");
+            }
+            // Codex 0.153.4 took a per-thread writer lock
+            // (`$CODEX_HOME/thread-writer-locks/<thread>.lock`), and the chat's
+            // own app-server is holding this thread's. The companion's
+            // `thread/resume` is refused while it does — `-32600 already has an
+            // active writer`, and the terminal dies on its first frame — so the
+            // chat gives the session up here and takes it back on the way out
+            // (`return_session_from_companion`). Shutdown reaps: it returns
+            // once the child is confirmed dead, which is what makes the lock
+            // provably free rather than probably free.
+            if handoff
+                && let Ok(Some(conn)) =
+                    view.update_in(cx, |v, _window, cx| v.take_connection_for_handoff(cx))
+            {
+                cx.background_spawn(async move { conn.shutdown() }).await;
+            }
             let cfg = AgentSessionConfig {
                 adapter,
                 worktree_path: cwd,

--- a/apps/desktop/src/shell/project_panes/state.rs
+++ b/apps/desktop/src/shell/project_panes/state.rs
@@ -119,6 +119,13 @@ impl ProjectPanes {
             .find_map(|g| g.read(cx).agent_chat_view_by_remote_id(remote_session_id, cx))
     }
 
+    /// Whether any chat tab in any of this project's groups is bound to the
+    /// agent session `session_id` — a split pane counts, so the answer does not
+    /// depend on which group happens to be focused.
+    pub fn has_agent_chat_for_session(&self, session_id: &str, cx: &App) -> bool {
+        self.groups.values().any(|g| g.read(cx).has_agent_chat_for_session(session_id, cx))
+    }
+
     pub fn group(&self, id: PaneGroupId) -> Option<Entity<PaneGroup>> {
         self.groups.get(&id).cloned()
     }

--- a/apps/desktop/src/workspace_root/render.rs
+++ b/apps/desktop/src/workspace_root/render.rs
@@ -722,6 +722,35 @@ impl Render for WorkspaceRoot {
                     );
                     return;
                 }
+                // Codex lets only ONE process write a thread (its
+                // `thread-writer-locks/<id>.lock`, new in 0.153.4). Resuming
+                // one a chat tab already owns spawns a TUI whose
+                // `thread/resume` is refused — `-32600 already has an active
+                // writer` — and the tab is dead on arrival. Say so instead.
+                //
+                // Resume only: a FORK opens a new thread and takes only the new
+                // lock, so it never collides (probed on codex 0.153.4). Every
+                // other adapter tolerates a second reader of one session log
+                // and keeps this path.
+                //
+                // Scoped to this window's projects. A holder elsewhere — another
+                // window, the ChatGPT app, an editor extension — is not ours to
+                // see, and those still land on codex's own error in the terminal.
+                if resume_collides_with_open_chat(action.adapter, action.fork, || {
+                    this.all_project_panes()
+                        .iter()
+                        .any(|p| p.read(cx).has_agent_chat_for_session(&action.session_id, cx))
+                }) {
+                    // Kept short on purpose: the toast renders ONE line and
+                    // clips around 70 characters, so a longer message loses
+                    // exactly the half that says what to do about it.
+                    crate::shell::toast::toast_op_error(
+                        cx,
+                        "Resume",
+                        "that session is open in a chat tab — use ⌃⇧V there",
+                    );
+                    return;
+                }
                 let (adapter, adapter_id, resumption, custom_command) = match action
                     .preset_id
                     .as_deref()
@@ -2032,5 +2061,59 @@ impl Render for WorkspaceRoot {
             // (e.g. the editor breadcrumb's copy/reveal actions) need it here
             // or their toasts never paint.
             .children(gpui_component::Root::render_notification_layer(window, cx))
+    }
+}
+
+/// Whether a session-history relaunch must be refused because a chat tab in
+/// this window already owns the session.
+///
+/// Codex holds a per-thread writer lock (0.153.4+), so a second process
+/// resuming the same thread is refused (`-32600 already has an active writer`)
+/// and its tab dies on the first frame. `chat_holds_session` is lazy: the pane
+/// walk only runs for the adapter that can actually collide.
+///
+/// The two carve-outs are the whole point of the predicate:
+/// - **fork never collides** — it opens a NEW thread and takes only the new
+///   thread's lock (probed on codex 0.153.4, parent lock undisturbed);
+/// - **every other adapter** tolerates a second reader of one session log, and
+///   resuming one in a terminal beside its chat is supported behavior.
+fn resume_collides_with_open_chat(
+    adapter: oximux_core::AgentAdapter,
+    fork: bool,
+    chat_holds_session: impl FnOnce() -> bool,
+) -> bool {
+    adapter == oximux_core::AgentAdapter::Codex && !fork && chat_holds_session()
+}
+
+#[cfg(test)]
+mod resume_guard_tests {
+    use super::resume_collides_with_open_chat;
+    use oximux_core::AgentAdapter;
+
+    #[test]
+    fn only_a_codex_resume_onto_an_open_chat_is_refused() {
+        // The case that produced a dead tab: resume, Codex, chat owns it.
+        assert!(resume_collides_with_open_chat(AgentAdapter::Codex, false, || true));
+        // A fork opens its own thread — never blocked, even with the chat open.
+        assert!(!resume_collides_with_open_chat(AgentAdapter::Codex, true, || true));
+        // No chat owns it: the ordinary resume-in-terminal must still work.
+        assert!(!resume_collides_with_open_chat(AgentAdapter::Codex, false, || false));
+        // Lockless adapters keep resuming beside their chat.
+        for adapter in [AgentAdapter::ClaudeCode, AgentAdapter::Pi, AgentAdapter::Omp] {
+            assert!(
+                !resume_collides_with_open_chat(adapter, false, || true),
+                "{adapter:?} has no writer lock — must not be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn the_pane_walk_is_skipped_when_the_adapter_cannot_collide() {
+        let mut walked = false;
+        let _ = resume_collides_with_open_chat(AgentAdapter::ClaudeCode, false, || {
+            walked = true;
+            true
+        });
+        assert!(!walked, "no reason to scan every pane for an adapter with no lock");
     }
 }

--- a/crates/agent-core/src/thread/event.rs
+++ b/crates/agent-core/src/thread/event.rs
@@ -15,6 +15,15 @@ use super::tool_call::{PermissionKind, PermissionSuggestion};
 /// Per-turn token/cost usage, decoded from the final `result` event. All counts
 /// are best-effort (0 when the field is absent); `cost_usd`/`context_window` are
 /// optional because not every turn reports them.
+///
+/// **Never sum these fields by hand — call [`TurnUsage::context_used`].** The
+/// cache counts follow Anthropic's convention, where a cache read is billed
+/// *beside* `input_tokens` and so adds to occupancy. Codex uses the opposite
+/// convention: its `cachedInputTokens` is a *subset* of its `inputTokens` (the
+/// app-server publishes a separate `netNewInputTokens` for the difference), so
+/// adding them double-counts the cache — which is exactly what the context
+/// meter used to do, reporting 61% for a thread sitting at 31%. Backends on the
+/// subset convention publish their own occupancy in `total_tokens` instead.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct TurnUsage {
     pub input_tokens: u64,
@@ -24,6 +33,32 @@ pub struct TurnUsage {
     /// The model's context-window size (from `modelUsage`), for a "% of Nk" readout.
     pub context_window: Option<u64>,
     pub cost_usd: Option<f64>,
+    /// The backend's *own* total-occupancy count, when it publishes one. Set
+    /// only by backends whose breakdown cannot be summed (see the type doc);
+    /// `None` everywhere else, which is why it is the preferred numerator
+    /// rather than a redundant one. Codex also fills this on turns where every
+    /// component field is zero but the total is real — 224 of 56,074 readings
+    /// in a live rollout corpus — so reconstructing it would read those as 0%.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_tokens: Option<u64>,
+}
+
+impl TurnUsage {
+    /// Total context occupancy in tokens — the one numerator every meter and
+    /// footer must use, so the two can never drift apart again (they had:
+    /// one summed the output tokens, the other didn't).
+    ///
+    /// Prefers the backend's published [`total_tokens`](Self::total_tokens) and
+    /// otherwise sums the breakdown, which is correct for every backend on the
+    /// additive cache convention.
+    pub fn context_used(&self) -> u64 {
+        self.total_tokens.unwrap_or_else(|| {
+            self.input_tokens
+                + self.cache_read_tokens
+                + self.cache_creation_tokens
+                + self.output_tokens
+        })
+    }
 }
 
 /// One authentication method an ACP agent advertises when it needs login, in a
@@ -564,6 +599,53 @@ impl ThreadEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn occupancy_prefers_a_published_total_over_the_breakdown() {
+        // Codex's shape: the cache read is already inside `input_tokens`.
+        let codex = TurnUsage {
+            input_tokens: 81_099,
+            output_tokens: 11,
+            cache_read_tokens: 75_776,
+            total_tokens: Some(81_110),
+            ..Default::default()
+        };
+        assert_eq!(codex.context_used(), 81_110, "summing would give 156,886");
+    }
+
+    #[test]
+    fn occupancy_sums_the_breakdown_for_additive_backends() {
+        // Anthropic's shape: the cache read is billed beside the input, so it
+        // genuinely adds to what the window holds.
+        let claude = TurnUsage {
+            input_tokens: 1_000,
+            output_tokens: 200,
+            cache_read_tokens: 5_000,
+            cache_creation_tokens: 300,
+            ..Default::default()
+        };
+        assert_eq!(claude.context_used(), 6_500);
+    }
+
+    #[test]
+    fn a_published_total_survives_a_persistence_round_trip() {
+        // The field is `skip_serializing_if`, so it must both stay absent for
+        // the additive backends and come back for the ones that publish it.
+        let codex = TurnUsage { total_tokens: Some(81_110), ..Default::default() };
+        let json = serde_json::to_string(&codex).unwrap();
+        assert_eq!(serde_json::from_str::<TurnUsage>(&json).unwrap(), codex);
+        let claude = TurnUsage { input_tokens: 7, ..Default::default() };
+        assert!(!serde_json::to_string(&claude).unwrap().contains("total_tokens"));
+    }
+
+    #[test]
+    fn a_blob_written_before_the_field_existed_still_loads() {
+        let legacy = r#"{"input_tokens":10,"output_tokens":2,"cache_read_tokens":0,
+                         "cache_creation_tokens":0,"context_window":null,"cost_usd":null}"#;
+        let u: TurnUsage = serde_json::from_str(legacy).unwrap();
+        assert_eq!(u.total_tokens, None);
+        assert_eq!(u.context_used(), 12);
+    }
 
     #[test]
     fn only_content_extending_events_are_deltas() {

--- a/crates/agent-core/src/thread/state.rs
+++ b/crates/agent-core/src/thread/state.rs
@@ -1584,6 +1584,7 @@ mod tests {
                 input_tokens: 714, output_tokens: 7,
                 cache_read_tokens: 16681, cache_creation_tokens: 5571,
                 context_window: Some(200000), cost_usd: Some(0.33),
+                total_tokens: None,
             }),
             is_error: false, turn_diff: None });
         let u = t.usage.as_ref().expect("usage stored");

--- a/crates/agent-core/src/thread/stream_json.rs
+++ b/crates/agent-core/src/thread/stream_json.rs
@@ -347,6 +347,7 @@ fn live_usage(usage: Option<&Value>) -> Vec<ThreadEvent> {
         cache_creation_tokens: count("cache_creation_input_tokens"),
         context_window: None,
         cost_usd: None,
+        total_tokens: None,
     })]
 }
 
@@ -640,6 +641,8 @@ fn decode_usage(v: &Value) -> Option<TurnUsage> {
         cache_creation_tokens: count("cache_creation_input_tokens"),
         context_window,
         cost_usd: v.get("total_cost_usd").and_then(Value::as_f64),
+        // Anthropic bills cache reads beside `input_tokens`; the sum is right.
+        total_tokens: None,
     })
 }
 

--- a/crates/agents/src/thread/acp/worker.rs
+++ b/crates/agents/src/thread/acp/worker.rs
@@ -755,6 +755,9 @@ fn usage_from_acp(u: &UsageUpdate) -> TurnUsage {
         cache_creation_tokens: 0,
         context_window: Some(u.size),
         cost_usd: u.cost.as_ref().map(|c| c.amount),
+        // `used` already IS the occupancy, and it lands in `input_tokens` with
+        // every other count zero — so the sum reproduces it exactly.
+        total_tokens: None,
     }
 }
 

--- a/crates/agents/src/thread/codex/map.rs
+++ b/crates/agents/src/thread/codex/map.rs
@@ -856,6 +856,15 @@ fn web_search_action(action: Option<&Value>) -> String {
 
 /// Parse `thread/tokenUsage/updated` → `TurnUsage` from the `.tokenUsage.last`
 /// breakdown (the most recent turn's counts).
+///
+/// `cachedInputTokens` is a **subset** of `inputTokens`, not an addition to it —
+/// codex publishes `netNewInputTokens` alongside them for the difference. So the
+/// occupancy the meter needs is codex's own `totalTokens`, carried through
+/// verbatim; summing the breakdown here would count the cache twice. Codex also
+/// reports a `cacheWriteInputTokens`, deliberately left unmapped: its subset
+/// relationship to `inputTokens` is unverifiable from the field alone (it is 0
+/// in all 12,864 readings of a live rollout corpus), and `totalTokens` already
+/// accounts for it.
 fn parse_usage(params: &Value) -> Option<TurnUsage> {
     let usage = params.get("tokenUsage")?;
     let last = usage.get("last")?;
@@ -864,9 +873,10 @@ fn parse_usage(params: &Value) -> Option<TurnUsage> {
         input_tokens: get("inputTokens"),
         output_tokens: get("outputTokens"),
         cache_read_tokens: get("cachedInputTokens"),
-        cache_creation_tokens: 0, // Codex reports no separate cache-creation count.
+        cache_creation_tokens: 0,
         context_window: usage.get("modelContextWindow").and_then(|v| v.as_u64()),
         cost_usd: None, // Codex doesn't report per-turn cost here.
+        total_tokens: last.get("totalTokens").and_then(|v| v.as_u64()),
     })
 }
 
@@ -1197,6 +1207,61 @@ mod tests {
         // The stash is still present for turn/completed to fold into the footer.
         let ended = map_notification("turn/completed", &json!({"turn": {"status": "completed"}}), &mut s);
         assert!(matches!(&ended[..], [ThreadEvent::TurnEnded { usage: Some(_), .. }]), "footer still fed");
+    }
+
+    #[test]
+    fn cached_input_is_a_subset_so_occupancy_is_codex_own_total() {
+        // The real numbers from a live rollout: cached (75,776) is part of the
+        // 81,099 input, and codex's own total agrees — 81,099 + 11 = 81,110.
+        // Summing the breakdown instead gave 156,886, which showed a thread at
+        // 31% of its window as 61% full.
+        let mut s = st();
+        let evs = map_notification(
+            "thread/tokenUsage/updated",
+            &json!({"tokenUsage": {"last": {"inputTokens": 81099, "outputTokens": 11,
+                                            "cachedInputTokens": 75776, "cacheWriteInputTokens": 0,
+                                            "totalTokens": 81110},
+                                    "modelContextWindow": 258400}}),
+            &mut s,
+        );
+        let [ThreadEvent::LiveUsage(u)] = &evs[..] else { panic!("expected LiveUsage, got {evs:?}") };
+        assert_eq!(u.total_tokens, Some(81110), "codex's own total is carried verbatim");
+        assert_eq!(u.context_used(), 81110, "not 156886 — the cache is not added twice");
+        let pct = (u.context_used() as f64 / 258400.0 * 100.0).round() as u64;
+        assert_eq!(pct, 31, "the meter reads 31%, as codex itself reports");
+    }
+
+    #[test]
+    fn an_all_zero_breakdown_still_reports_its_total() {
+        // 224 of 56,074 readings in a live corpus zero every component field
+        // while carrying a real total. Reconstructing occupancy reads those as
+        // an empty context; codex's total is the only truth on such a turn.
+        let mut s = st();
+        let evs = map_notification(
+            "thread/tokenUsage/updated",
+            &json!({"tokenUsage": {"last": {"inputTokens": 0, "outputTokens": 0,
+                                            "cachedInputTokens": 0, "totalTokens": 11506},
+                                    "modelContextWindow": 258400}}),
+            &mut s,
+        );
+        let [ThreadEvent::LiveUsage(u)] = &evs[..] else { panic!("expected LiveUsage, got {evs:?}") };
+        assert_eq!(u.context_used(), 11506, "a zeroed breakdown is not an empty context");
+    }
+
+    #[test]
+    fn a_payload_without_a_total_falls_back_to_the_breakdown() {
+        // Older app-servers omit `totalTokens`; the meter must still read
+        // something rather than collapsing to zero.
+        let mut s = st();
+        let evs = map_notification(
+            "thread/tokenUsage/updated",
+            &json!({"tokenUsage": {"last": {"inputTokens": 40, "outputTokens": 8},
+                                    "modelContextWindow": 272000}}),
+            &mut s,
+        );
+        let [ThreadEvent::LiveUsage(u)] = &evs[..] else { panic!("expected LiveUsage, got {evs:?}") };
+        assert_eq!(u.total_tokens, None);
+        assert_eq!(u.context_used(), 48);
     }
 
     #[test]

--- a/crates/agents/src/thread/codex/mod.rs
+++ b/crates/agents/src/thread/codex/mod.rs
@@ -579,54 +579,90 @@ fn worker_loop(
     };
     let posture = protocol::Posture { approval_policy: &approval, sandbox: &sandbox };
 
-    // Resume the persisted thread when restoring; else start fresh. A failed
-    // resume (thread gone / experimental) degrades to a fresh start.
+    // Resume the persisted thread when restoring; else start fresh.
+    //
+    // A resume that FAILS is never answered with `thread/start`. That seats a
+    // thread the agent has no memory of underneath the transcript the user is
+    // reading, writing a different rollout, with nothing on screen to say so —
+    // and the failures that reach here are mostly not "this thread is gone"
+    // anyway: a writer conflict means someone else holds it, `database is
+    // locked` is transient sqlite contention, and an archived thread is one
+    // `thread/unarchive` away from resuming exactly where it left off. The one
+    // genuinely-gone case (a deleted rollout) is still better shown than
+    // silently replaced, because the conversation is on screen either way.
     let resume_id = resume.as_deref().filter(|s| !s.is_empty());
-    let started = match resume_id {
-        Some(tid) => rpc.request(
-            protocol::M_THREAD_RESUME,
-            protocol::thread_resume_params(tid, model.as_deref(), posture),
-            HANDSHAKE_TIMEOUT,
-        ),
-        None => rpc.request(
+    let res = match resume_id {
+        None => match rpc.request(
             protocol::M_THREAD_START,
             protocol::thread_start_params(model.as_deref(), &cwd, posture),
             HANDSHAKE_TIMEOUT,
-        ),
-    };
-    let res = match started {
-        Ok(r) => Some(r),
-        // A thread another process is writing is NOT a thread to replace. Fail
-        // the connection so the user sees why, rather than silently seating a
-        // memory-less fresh thread under the transcript they are reading
-        // (see `protocol::is_thread_writer_conflict`).
-        Err(e) if resume_id.is_some() && protocol::is_thread_writer_conflict(&e.to_string()) => {
-            tracing::warn!(error = %e, "codex thread/resume refused: another writer holds the thread");
-            abandon_handshake(
-                &rpc,
-                &event_tx,
-                "This Codex session is open somewhere else — another window, tab, \
-                 or terminal is holding it. Close that one, then reconnect.",
-            );
-            return;
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                abandon_handshake(&rpc, &event_tx, format!("codex thread/start failed: {e}"));
+                return;
+            }
+        },
+        Some(tid) => {
+            let params = protocol::thread_resume_params(tid, model.as_deref(), posture);
+            match rpc.request(protocol::M_THREAD_RESUME, params.clone(), HANDSHAKE_TIMEOUT) {
+                Ok(r) => r,
+                Err(e) => {
+                    let err = e.to_string();
+                    if protocol::is_thread_writer_conflict(&err) {
+                        tracing::warn!(error = %e, "codex thread/resume refused: another writer holds the thread");
+                        abandon_handshake(
+                            &rpc,
+                            &event_tx,
+                            "This Codex session is open somewhere else — another window, tab, \
+                             or terminal is holding it. Close that one, then reconnect.",
+                        );
+                        return;
+                    }
+                    if !protocol::is_archived_thread(&err, tid) {
+                        tracing::warn!(error = %e, "codex thread/resume failed");
+                        abandon_handshake(
+                            &rpc,
+                            &event_tx,
+                            format!("Codex could not reopen this session: {err}"),
+                        );
+                        return;
+                    }
+                    // Archived: unarchive, then resume for real. A racing
+                    // unarchive (or a thread that was never archived) reports
+                    // "no archived rollout found" — nothing left to do, so the
+                    // retry below simply goes ahead.
+                    tracing::info!(thread_id = %tid, "unarchiving an archived codex thread to resume it");
+                    match rpc.request(
+                        protocol::M_THREAD_UNARCHIVE,
+                        json!({ "threadId": tid }),
+                        HANDSHAKE_TIMEOUT,
+                    ) {
+                        Ok(_) => {}
+                        Err(ue) if protocol::is_already_unarchived(&ue.to_string(), tid) => {}
+                        Err(ue) => {
+                            abandon_handshake(
+                                &rpc,
+                                &event_tx,
+                                format!("Codex could not unarchive this session: {ue}"),
+                            );
+                            return;
+                        }
+                    }
+                    match rpc.request(protocol::M_THREAD_RESUME, params, HANDSHAKE_TIMEOUT) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            abandon_handshake(
+                                &rpc,
+                                &event_tx,
+                                format!("Codex could not reopen this unarchived session: {e}"),
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
         }
-        Err(e) if resume_id.is_some() => {
-            tracing::warn!(error = %e, "codex thread/resume failed; starting a fresh thread");
-            rpc.request(
-                protocol::M_THREAD_START,
-                protocol::thread_start_params(model.as_deref(), &cwd, posture),
-                HANDSHAKE_TIMEOUT,
-            )
-            .ok()
-        }
-        Err(e) => {
-            abandon_handshake(&rpc, &event_tx, format!("codex thread/start failed: {e}"));
-            return;
-        }
-    };
-    let Some(res) = res else {
-        abandon_handshake(&rpc, &event_tx, "codex thread/start failed after resume");
-        return;
     };
     // A handshake with no thread id is a hard failure — every later turn/cancel
     // would target an empty id. Surface it rather than pretending to connect.
@@ -901,11 +937,15 @@ while read line; do :; done
         drop(inbound);
     }
 
-    /// The other resume failures still degrade to a fresh thread — a rollout
-    /// that is gone really is a thread to replace, and narrowing that to the
-    /// writer conflict is the whole point of classifying.
+    /// An ARCHIVED thread is unarchived and resumed, not replaced.
+    ///
+    /// codex refuses the resume with "session <id> is archived. Run `codex
+    /// unarchive <id>` to unarchive it first." — a thread that is one call away
+    /// from reopening exactly where the user left it, which the old
+    /// degrade-to-`thread/start` answered with an empty one.
     #[test]
-    fn a_missing_thread_still_degrades_to_a_fresh_start() {
+    fn an_archived_thread_is_unarchived_and_resumed() {
+        // ids: 1 initialize, 2 model/list, 3 resume (archived), 4 unarchive, 5 resume.
         let script = r#"
 read line
 printf '{"id":1,"result":{}}\n'
@@ -913,9 +953,11 @@ read line
 printf '{"id":2,"result":{}}\n'
 read line
 read line
-printf '{"id":3,"error":{"code":-32600,"message":"no rollout found for thread id t-1"}}\n'
+printf '{"id":3,"error":{"code":-32600,"message":"session t-1 is archived. Run `codex unarchive t-1` to unarchive it first."}}\n'
 read line
-printf '{"id":4,"result":{"thread":{"id":"fresh-thread"},"model":"m"}}\n'
+printf '{"id":4,"result":{}}\n'
+read line
+printf '{"id":5,"result":{"thread":{"id":"t-1"},"model":"m"}}\n'
 sleep 0.5
 "#;
         let (rpc, _inbound, _child) =
@@ -938,8 +980,51 @@ sleep 0.5
         let _ = out_tx.send(Outbound::Shutdown);
         let _ = worker.join();
         assert!(
-            matches!(init, Ok(ThreadEvent::SessionInit { ref session_id, .. }) if session_id == "fresh-thread"),
-            "a vanished thread still starts fresh, got {init:?}"
+            matches!(init, Ok(ThreadEvent::SessionInit { ref session_id, .. }) if session_id == "t-1"),
+            "the archived thread itself must come back, got {init:?}"
+        );
+    }
+
+    /// Every other resume failure is reported, never answered with a fresh
+    /// thread. `database is locked` stands in for the whole class: transient,
+    /// retryable, and emphatically not a reason to replace the conversation the
+    /// user is looking at.
+    #[test]
+    fn an_unrecoverable_resume_is_reported_not_replaced() {
+        let script = r#"
+read line
+printf '{"id":1,"result":{}}\n'
+read line
+printf '{"id":2,"result":{}}\n'
+read line
+read line
+printf '{"id":3,"error":{"code":-32600,"message":"database is locked"}}\n'
+read line
+printf '{"id":4,"result":{"thread":{"id":"fresh-thread"},"model":"m"}}\n'
+sleep 0.5
+"#;
+        let (rpc, _inbound, _child) =
+            transport::RpcClient::spawn_command(crate::thread::sh_fixture::sh_script(script))
+                .expect("spawn fake app-server");
+        let (event_tx, events) = mpsc::channel();
+        let (_out_tx, out_rx) = mpsc::channel();
+        worker_loop(
+            rpc,
+            event_tx,
+            Arc::new(Mutex::new(CodexState::default())),
+            out_rx,
+            std::path::PathBuf::from("."),
+            None,
+            Some("t-1".to_string()),
+        );
+        let seen: Vec<ThreadEvent> = events.try_iter().collect();
+        assert!(
+            !seen.iter().any(|e| matches!(e, ThreadEvent::SessionInit { .. })),
+            "a failed resume must not seat a fresh thread: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|e| matches!(e, ThreadEvent::Error(m) if m.contains("database is locked"))),
+            "the real reason must reach the user: {seen:?}"
         );
     }
 

--- a/crates/agents/src/thread/codex/mod.rs
+++ b/crates/agents/src/thread/codex/mod.rs
@@ -532,6 +532,20 @@ fn chatgpt_signin_method() -> AuthMethodInfo {
     }
 }
 
+/// Give up on the handshake: say why, then end the session.
+///
+/// The bare `return` is not enough. The child would stay alive with nobody
+/// talking to it, and since the event stream only closes when the child exits
+/// (see `RpcClient::is_alive`), the chat could never learn it was disconnected
+/// — its error card's Retry would re-send a turn into a worker that is gone,
+/// and the tab would have to be closed and reopened to recover. Closing stdin
+/// is what makes `codex app-server` exit, which is what makes the disconnect
+/// land and Retry mean "reconnect".
+fn abandon_handshake(rpc: &RpcClient, event_tx: &Sender<ThreadEvent>, msg: impl Into<String>) {
+    let _ = event_tx.send(ThreadEvent::Error(msg.into()));
+    rpc.close_stdin();
+}
+
 /// The worker: async handshake (`initialize` → cache `model/list` → `initialized`
 /// → `thread/resume` or `thread/start`), then forward prompts as `turn/start`.
 fn worker_loop(
@@ -544,7 +558,7 @@ fn worker_loop(
     resume: Option<String>,
 ) {
     if let Err(e) = rpc.request(protocol::M_INITIALIZE, protocol::initialize_params(), HANDSHAKE_TIMEOUT) {
-        let _ = event_tx.send(ThreadEvent::Error(format!("codex initialize failed: {e}")));
+        abandon_handshake(&rpc, &event_tx, format!("codex initialize failed: {e}"));
         return;
     }
     // Fetch the model catalog BEFORE emitting SessionInit, so the composer's
@@ -582,6 +596,20 @@ fn worker_loop(
     };
     let res = match started {
         Ok(r) => Some(r),
+        // A thread another process is writing is NOT a thread to replace. Fail
+        // the connection so the user sees why, rather than silently seating a
+        // memory-less fresh thread under the transcript they are reading
+        // (see `protocol::is_thread_writer_conflict`).
+        Err(e) if resume_id.is_some() && protocol::is_thread_writer_conflict(&e.to_string()) => {
+            tracing::warn!(error = %e, "codex thread/resume refused: another writer holds the thread");
+            abandon_handshake(
+                &rpc,
+                &event_tx,
+                "This Codex session is open somewhere else — another window, tab, \
+                 or terminal is holding it. Close that one, then reconnect.",
+            );
+            return;
+        }
         Err(e) if resume_id.is_some() => {
             tracing::warn!(error = %e, "codex thread/resume failed; starting a fresh thread");
             rpc.request(
@@ -592,18 +620,18 @@ fn worker_loop(
             .ok()
         }
         Err(e) => {
-            let _ = event_tx.send(ThreadEvent::Error(format!("codex thread/start failed: {e}")));
+            abandon_handshake(&rpc, &event_tx, format!("codex thread/start failed: {e}"));
             return;
         }
     };
     let Some(res) = res else {
-        let _ = event_tx.send(ThreadEvent::Error("codex thread/start failed after resume".into()));
+        abandon_handshake(&rpc, &event_tx, "codex thread/start failed after resume");
         return;
     };
     // A handshake with no thread id is a hard failure — every later turn/cancel
     // would target an empty id. Surface it rather than pretending to connect.
     let Some(tid) = protocol::thread_id_from_start_response(&res).filter(|t| !t.is_empty()) else {
-        let _ = event_tx.send(ThreadEvent::Error("codex handshake returned no thread id".into()));
+        abandon_handshake(&rpc, &event_tx, "codex handshake returned no thread id");
         return;
     };
     let resolved_model = protocol::model_from_start_response(&res).or(model.clone()).unwrap_or_default();
@@ -772,6 +800,148 @@ fn map_inbound(
 #[cfg(test)]
 mod tests {
     use super::fork_last_turn_id;
+    use super::*;
+
+    /// A thread another process is writing must NOT become a fresh thread.
+    ///
+    /// The fake server refuses `thread/resume` the way codex ≥0.153.4 does when
+    /// its per-thread writer lock is held, and then answers a `thread/start`
+    /// with a perfectly good thread — so a build that still falls back reports
+    /// a healthy session (`SessionInit`) under a transcript the agent has never
+    /// seen, which is exactly the silent failure this refuses to ship.
+    #[test]
+    fn resume_refused_by_another_writer_fails_instead_of_starting_fresh() {
+        // ids: 1 initialize, 2 model/list, 3 thread/resume, 4 thread/start.
+        let script = r#"
+read line
+printf '{"id":1,"result":{}}\n'
+read line
+printf '{"id":2,"result":{}}\n'
+read line
+read line
+printf '{"id":3,"error":{"code":-32600,"message":"thread t-1 already has an active writer"}}\n'
+read line
+printf '{"id":4,"result":{"thread":{"id":"fresh-thread"},"model":"m"}}\n'
+sleep 0.5
+"#;
+        let (rpc, _inbound, _child) =
+            transport::RpcClient::spawn_command(crate::thread::sh_fixture::sh_script(script))
+                .expect("spawn fake app-server");
+        let (event_tx, events) = mpsc::channel();
+        let (_out_tx, out_rx) = mpsc::channel();
+        worker_loop(
+            rpc,
+            event_tx,
+            Arc::new(Mutex::new(CodexState::default())),
+            out_rx,
+            std::path::PathBuf::from("."),
+            None,
+            Some("t-1".to_string()),
+        );
+        let seen: Vec<ThreadEvent> = events.try_iter().collect();
+        assert!(
+            !seen.iter().any(|e| matches!(e, ThreadEvent::SessionInit { .. })),
+            "a held thread must not be replaced by a fresh one: {seen:?}"
+        );
+        let errored = seen.iter().any(
+            |e| matches!(e, ThreadEvent::Error(msg) if msg.contains("open somewhere else")),
+        );
+        assert!(errored, "the refusal must reach the user: {seen:?}");
+    }
+
+    /// A handshake the worker gives up on must END the session, not just report
+    /// it.
+    ///
+    /// Found live: the refusal above left the `codex` child alive with nobody
+    /// talking to it. The event stream only closes when that child exits, so
+    /// the chat never learned it was disconnected and its Retry re-sent a turn
+    /// into a departed worker (`Send failed: codex worker is gone`) — the tab
+    /// had to be closed and reopened. Proven here by the client going dead,
+    /// which happens only when the fake server saw EOF on stdin and exited.
+    #[test]
+    fn abandoning_the_handshake_ends_the_session_so_the_chat_can_reconnect() {
+        // Refuses the resume, then reads until stdin closes. `read line` returns
+        // non-zero at EOF, so the loop ends and the fake server exits — exactly
+        // what a real `codex app-server` does when its stdin goes away.
+        let script = r#"
+read line
+printf '{"id":1,"result":{}}\n'
+read line
+printf '{"id":2,"result":{}}\n'
+read line
+read line
+printf '{"id":3,"error":{"code":-32600,"message":"thread t-1 already has an active writer"}}\n'
+while read line; do :; done
+"#;
+        let (rpc, inbound, _child) =
+            transport::RpcClient::spawn_command(crate::thread::sh_fixture::sh_script(script))
+                .expect("spawn fake app-server");
+        let (event_tx, _events) = mpsc::channel();
+        let (_out_tx, out_rx) = mpsc::channel();
+        worker_loop(
+            rpc.clone(),
+            event_tx,
+            Arc::new(Mutex::new(CodexState::default())),
+            out_rx,
+            std::path::PathBuf::from("."),
+            None,
+            Some("t-1".to_string()),
+        );
+        // The reader thread clears `alive` on the child's stdout EOF; the mapper
+        // ends with it, which is what drops the last ThreadEvent sender and
+        // fires the app's disconnect handler.
+        // Polled, not spun: the reader thread clears `alive` from its own
+        // thread and a tight loop would burn a core for the whole timeout on
+        // the run where this regresses.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while rpc.is_alive() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!rpc.is_alive(), "an abandoned handshake must end the child, not orphan it");
+        drop(inbound);
+    }
+
+    /// The other resume failures still degrade to a fresh thread — a rollout
+    /// that is gone really is a thread to replace, and narrowing that to the
+    /// writer conflict is the whole point of classifying.
+    #[test]
+    fn a_missing_thread_still_degrades_to_a_fresh_start() {
+        let script = r#"
+read line
+printf '{"id":1,"result":{}}\n'
+read line
+printf '{"id":2,"result":{}}\n'
+read line
+read line
+printf '{"id":3,"error":{"code":-32600,"message":"no rollout found for thread id t-1"}}\n'
+read line
+printf '{"id":4,"result":{"thread":{"id":"fresh-thread"},"model":"m"}}\n'
+sleep 0.5
+"#;
+        let (rpc, _inbound, _child) =
+            transport::RpcClient::spawn_command(crate::thread::sh_fixture::sh_script(script))
+                .expect("spawn fake app-server");
+        let (event_tx, events) = mpsc::channel();
+        let (out_tx, out_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            worker_loop(
+                rpc,
+                event_tx,
+                Arc::new(Mutex::new(CodexState::default())),
+                out_rx,
+                std::path::PathBuf::from("."),
+                None,
+                Some("t-1".to_string()),
+            )
+        });
+        let init = events.recv_timeout(std::time::Duration::from_secs(10));
+        let _ = out_tx.send(Outbound::Shutdown);
+        let _ = worker.join();
+        assert!(
+            matches!(init, Ok(ThreadEvent::SessionInit { ref session_id, .. }) if session_id == "fresh-thread"),
+            "a vanished thread still starts fresh, got {init:?}"
+        );
+    }
 
     #[test]
     fn fork_last_turn_id_maps_ordinal_to_prior_turn() {

--- a/crates/agents/src/thread/codex/protocol.rs
+++ b/crates/agents/src/thread/codex/protocol.rs
@@ -24,6 +24,7 @@ pub const M_INITIALIZE: &str = "initialize";
 pub const M_THREAD_START: &str = "thread/start";
 pub const M_THREAD_RESUME: &str = "thread/resume";
 pub const M_THREAD_FORK: &str = "thread/fork";
+pub const M_THREAD_UNARCHIVE: &str = "thread/unarchive";
 pub const M_MODEL_LIST: &str = "model/list";
 pub const M_TURN_START: &str = "turn/start";
 pub const M_TURN_INTERRUPT: &str = "turn/interrupt";
@@ -188,6 +189,26 @@ pub fn is_thread_writer_conflict(err: &str) -> bool {
     err.contains("already has an active writer")
 }
 
+/// Whether a `thread/resume` failure is codex saying the thread is ARCHIVED
+/// rather than gone: `session <id> is archived. Run `codex unarchive <id>` to
+/// unarchive it first.` The caller answers it with
+/// [`M_THREAD_UNARCHIVE`] and retries, so an archived session reopens where the
+/// user left it instead of being replaced by an empty one.
+///
+/// Requires the thread id as well as the phrase, so a message about some OTHER
+/// session cannot be mistaken for this one's.
+pub fn is_archived_thread(err: &str, thread_id: &str) -> bool {
+    err.contains("is archived") && err.contains(thread_id)
+}
+
+/// Whether a `thread/unarchive` failure means there was nothing to unarchive —
+/// someone else got there first, or the thread was never archived. Success as
+/// far as the caller is concerned: the resume it was clearing the way for can
+/// go ahead.
+pub fn is_already_unarchived(err: &str, thread_id: &str) -> bool {
+    err.contains("no archived rollout found") && err.contains(thread_id)
+}
+
 /// Pull `thread.id` out of a `thread/start` (or `thread/resume`) response.
 pub fn thread_id_from_start_response(result: &Value) -> Option<String> {
     result.get("thread")?.get("id")?.as_str().map(String::from)
@@ -302,6 +323,21 @@ mod tests {
             assert!(!is_thread_writer_conflict(other), "{other} is not a writer conflict");
         }
         assert!(!is_thread_writer_conflict("codex thread/resume timed out"));
+    }
+
+    #[test]
+    fn archived_and_already_unarchived_are_told_apart() {
+        // codex 0.153.4's wording, verbatim.
+        let archived = r#"{"code":-32600,"message":"session t-1 is archived. Run `codex unarchive t-1` to unarchive it first."}"#;
+        assert!(is_archived_thread(archived, "t-1"));
+        // Another session's archive notice is not this session's problem.
+        assert!(!is_archived_thread(archived, "t-2"));
+        assert!(!is_archived_thread(r#"{"message":"database is locked"}"#, "t-1"));
+        // Nothing to unarchive = the resume may proceed.
+        let none = r#"{"message":"no archived rollout found for thread id t-1"}"#;
+        assert!(is_already_unarchived(none, "t-1"));
+        assert!(!is_already_unarchived(none, "t-2"));
+        assert!(!is_already_unarchived(archived, "t-1"));
     }
 
     #[test]

--- a/crates/agents/src/thread/codex/protocol.rs
+++ b/crates/agents/src/thread/codex/protocol.rs
@@ -168,6 +168,26 @@ pub fn thread_fork_params(thread_id: &str, last_turn_id: Option<&str>) -> Value 
     p
 }
 
+/// Whether a `thread/resume` failure is codex refusing a SECOND writer for a
+/// thread some other process already owns.
+///
+/// codex 0.153.4 took a per-thread writer lock (`$CODEX_HOME/thread-writer-locks/
+/// <thread-id>.lock`, plus a `.coordination.lock` for stale sweeps) — before
+/// that, two writers on one rollout were merely discouraged. A resume that
+/// loses the race comes back as `{"code":-32600,"message":"thread <id> already
+/// has an active writer"}`, and unlike every other resume failure it says the
+/// thread is FINE — someone else is simply holding it. Falling back to
+/// `thread/start` there mints a fresh thread under a transcript the user is
+/// looking at: an agent that remembers none of it, writing to a different
+/// rollout, with no visible sign either happened.
+///
+/// Matched on the message, never on the code: codex spends `-32600` on
+/// unrelated refusals too (a missing rollout, an unparseable one, a locked
+/// state db, an auth failure), and those genuinely are "this thread is gone".
+pub fn is_thread_writer_conflict(err: &str) -> bool {
+    err.contains("already has an active writer")
+}
+
 /// Pull `thread.id` out of a `thread/start` (or `thread/resume`) response.
 pub fn thread_id_from_start_response(result: &Value) -> Option<String> {
     result.get("thread")?.get("id")?.as_str().map(String::from)
@@ -263,6 +283,26 @@ pub fn parse_model_list(result: &Value) -> Vec<CodexModel> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn writer_conflict_is_told_apart_from_the_other_refusals() {
+        // The real refusal, verbatim off the wire (the transport hands the whole
+        // error object through as a string, code included).
+        assert!(is_thread_writer_conflict(
+            r#"codex thread/resume error: {"code":-32600,"message":"thread 01a07133-8b0b-7c51-b2a3-720cc04fe4c4 already has an active writer"}"#
+        ));
+        // -32600 is NOT the discriminator: codex spends it on refusals that DO
+        // mean the thread is gone or unusable, and those must keep degrading to
+        // a fresh start rather than dead-ending the chat.
+        for other in [
+            r#"{"code":-32600,"message":"no rollout found for thread id t-1"}"#,
+            r#"{"code":-32600,"message":"failed to parse rollout"}"#,
+            r#"{"code":-32600,"message":"database is locked"}"#,
+        ] {
+            assert!(!is_thread_writer_conflict(other), "{other} is not a writer conflict");
+        }
+        assert!(!is_thread_writer_conflict("codex thread/resume timed out"));
+    }
 
     #[test]
     fn account_read_detects_logged_out() {

--- a/crates/agents/src/thread/codex/transport.rs
+++ b/crates/agents/src/thread/codex/transport.rs
@@ -39,7 +39,8 @@ type Pending = Arc<Mutex<HashMap<u64, Sender<Result<Value, String>>>>>;
 /// registry. Cloning shares the same child (all fields are `Arc`).
 #[derive(Clone)]
 pub struct RpcClient {
-    stdin: Arc<Mutex<ChildStdin>>,
+    /// `None` once [`RpcClient::close_stdin`] has ended the session.
+    stdin: Arc<Mutex<Option<ChildStdin>>>,
     next_id: Arc<AtomicU64>,
     pending: Pending,
     /// Cleared by the reader thread when the child's stdout hits EOF (the
@@ -120,7 +121,7 @@ impl RpcClient {
 
         Ok((
             RpcClient {
-                stdin: Arc::new(Mutex::new(stdin)),
+                stdin: Arc::new(Mutex::new(Some(stdin))),
                 next_id: Arc::new(AtomicU64::new(1)),
                 pending,
                 alive,
@@ -181,11 +182,31 @@ impl RpcClient {
         self.write_msg(&json!({"id": id, "result": result}))
     }
 
+    /// End the session by closing the child's stdin.
+    ///
+    /// `codex app-server` reads newline-delimited JSON from stdin, so EOF is how
+    /// it is asked to exit. That exit is what the rest of the stack is waiting
+    /// for: stdout closes → the reader marks the client dead and drops
+    /// `inbound_tx` → the mapper ends → the last `ThreadEvent` sender drops →
+    /// the app's disconnect handler runs. A worker that gives up on the
+    /// handshake must call this, or it leaves a live child nobody is talking to
+    /// and a chat that can never notice it is disconnected (see `is_alive`'s
+    /// note above — the same freeze, arrived at from the other direction).
+    ///
+    /// Idempotent; every later `write_msg` fails rather than silently
+    /// pretending to have sent.
+    pub fn close_stdin(&self) {
+        if let Ok(mut stdin) = self.stdin.lock() {
+            stdin.take();
+        }
+    }
+
     fn write_msg(&self, v: &Value) -> Result<()> {
-        let mut stdin = self
+        let mut guard = self
             .stdin
             .lock()
             .map_err(|_| anyhow!("codex stdin lock poisoned"))?;
+        let stdin = guard.as_mut().ok_or_else(|| anyhow!("codex stdin is closed"))?;
         let line = serde_json::to_string(v).context("serialize codex message")?;
         stdin.write_all(line.as_bytes()).context("write codex stdin")?;
         stdin.write_all(b"\n").context("write codex newline")?;

--- a/crates/agents/src/thread/omp/map.rs
+++ b/crates/agents/src/thread/omp/map.rs
@@ -272,6 +272,8 @@ fn usage_of(message: Option<&Value>, context_window: Option<u64>) -> Option<Turn
         cache_creation_tokens: n("cacheWrite"),
         context_window,
         cost_usd: u.get("cost").and_then(|c| c.get("total")).and_then(Value::as_f64),
+        // Same additive cache convention as Pi, whose fields these mirror.
+        total_tokens: None,
     })
 }
 

--- a/crates/agents/src/thread/omp/mod.rs
+++ b/crates/agents/src/thread/omp/mod.rs
@@ -325,6 +325,8 @@ impl OmpRpcConnection {
                 cache_creation_tokens: 0,
                 context_window: u.context_window.or(context_window),
                 cost_usd: None,
+                // `tokens` is omp's occupancy and lands in `input_tokens` alone.
+                total_tokens: None,
             }));
         }
         if let Some(n) = notice {

--- a/crates/agents/src/thread/pi/map.rs
+++ b/crates/agents/src/thread/pi/map.rs
@@ -255,6 +255,8 @@ fn usage_of(message: Option<&Value>, context_window: Option<u64>) -> Option<Turn
         context_window,
         // pi reports real dollars, unlike backends that only expose tokens.
         cost_usd: u.get("cost").and_then(|c| c.get("total")).and_then(Value::as_f64),
+        // Pi bills cache reads beside `input`, so the breakdown sums correctly.
+        total_tokens: None,
     })
 }
 

--- a/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
+++ b/crates/agents/tests/snapshots/codex-mcp-call-turn.transcript.json
@@ -13,7 +13,8 @@
     "cache_read_tokens": 30464,
     "cache_creation_tokens": 0,
     "context_window": 258400,
-    "cost_usd": null
+    "cost_usd": null,
+    "total_tokens": 30853
   },
   "entries": [
     {


### PR DESCRIPTION
codex 0.153.4 added a cross-process writer lock, one per thread
(`\$CODEX_HOME/thread-writer-locks/<id>.lock`, plus a `.coordination.lock`
for stale sweeps). It did not exist on 0.145, which is the version the
companion terminal was verified against. Three things broke on it.

Reported as: pressing ⌃⇧V on a Codex chat gave a terminal that died on its
first frame with
`thread/resume failed: thread <id> already has an active writer (code -32600)`,
while the chat kept working. `lsof` named the lock holder as the chat tab's
own `codex app-server`, whose PPID was the app.

## What changed

**1. A held thread is no longer replaced.** The worker degraded *any* failed
resume to `thread/start`, so under the lock it routinely seated a
memory-less fresh thread under an imported transcript, writing a different
rollout, silently. Now a writer conflict surfaces; every other resume
failure still starts fresh. Classified on the message, never on `-32600` —
codex spends that code on a missing rollout, an unparseable one, a locked
state db and auth failures too.

**2. The chat and its companion terminal take turns.** Toggling in stops
the old owner and *observes* its exit before the new one spawns; toggling
out reaps the CLI, folds its turns in, and reconnects. Refused mid-turn.
Only the app-server transport pays for it — Claude, Pi, omp and OpenCode
keep their instant re-toggle.

**3. A refused handshake is recoverable.** Fixing (1) exposed an older
hole: the worker returned but left the child alive, and the event stream
only closes when that child exits, so the chat never learned it was
disconnected and Retry re-sent a turn into a departed worker. `stdin` now
closes on all four terminal bail-outs, so the disconnect lands and Retry
means reconnect.

**4. The fresh-start fallback is gone entirely, not narrowed.** A second
review found the same silent replacement still reachable two ways, both
confirmed in the 0.153.4 binary: an ARCHIVED thread (`session <id> is
archived. Run \`codex unarchive <id>\`…`) — now unarchived and resumed for
real — and `database is locked`, transient sqlite contention that is no
reason to replace a conversation. Even a genuinely deleted rollout is now
shown rather than substituted; the transcript is on screen either way, and
a fresh thread means the next message goes to an agent that cannot see it.
`thread/start` is left with exactly one call site: the arm with no session
to resume.

**5. Session-history "Resume in terminal" got the same guard**, which had
the identical gap. Fork is deliberately exempt — it opens a new thread and
takes only the new lock.

## Verification

Unit + mutation: removing each fix makes its test fail with the real
symptom (`SessionInit { session_id: "fresh-thread" }` for 1; a still-alive
client for 3).

Live, in the app, against a real session:
- ⌃⇧V → app-server gone, `codex resume` TUI holds the lock, live prompt.
  Back → TUI reaped, app-server holds the **same** thread, transcript intact.
- External writer holding the lock → the chat shows the refusal, **no new
  rollout is created**, and the app-server holds no lock. Release it, click
  Retry → reconnects and answers with `75.9k in · 57% ctx`, i.e. the real
  history.
- History resume onto a held session → toast, no tab, no second writer.
- Fork against a held thread → new thread, new lock, parent undisturbed.

`oximux-agents` 814 passed · `oximux-app` 1876 passed · clippy clean under
`RUSTFLAGS=-D warnings`.

## Known limits

The history guard sees only this window's projects — a holder in another
window, or outside the app, still lands on the CLI's own error. And an
app-server still lives as long as its chat tab, so an open Codex chat pins
a process and a thread lock; a refcounted release clock is the follow-up.

https://claude.ai/code/session_01SLvFa9LzT4Mnfx2W9yQsCR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added smoother switching between Codex chat sessions and companion terminals.
  - Added support for recovering archived sessions when resuming them.
  - Context usage meters now reflect backend-reported totals more accurately.

- **Bug Fixes**
  - Prevented duplicate chat tabs and companion terminals from taking over the same active session.
  - Session handoffs now wait for companion terminals to exit before reconnecting.
  - Failed session resumes report clear errors instead of starting unrelated sessions.
  - Prevented stray agent processes and invalid connections after interrupted handoffs.
  - Switching to a terminal during an active response is blocked with a notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->