### PR TITLE
feat(ports): show every listener on the machine, not just this window's

### DIFF
--- a/apps/desktop/src/shell/ports_panel/kill.rs
+++ b/apps/desktop/src/shell/ports_panel/kill.rs
@@ -182,10 +182,18 @@ fn signal(pid: u32, which: Signal) -> Result<(), Refusal> {
         .stderr(std::process::Stdio::null())
         .status()
     {
-        // A non-zero status is nearly always "the process is already gone",
-        // which the caller treats the same as success for the same reason
-        // ESRCH is fine above.
-        Ok(_) => Ok(()),
+        // 0 is "the request was delivered". 128 is `taskkill`'s "no such
+        // process", which is the ESRCH case above: it exited between the
+        // re-check and the signal, which is the outcome the click wanted.
+        //
+        // Every other status is a refusal — most often access denied on a
+        // process owned by another user or running elevated — and must be
+        // reported as one. Treating them all as success was a lie the panel
+        // showed as "Stopping the process on 3000" while the port stayed up.
+        Ok(status) => match status.code() {
+            Some(0) | Some(128) => Ok(()),
+            _ => Err(Refusal::Denied),
+        },
         Err(_) => Err(Refusal::Denied),
     }
 }

--- a/apps/desktop/src/shell/ports_panel/kill.rs
+++ b/apps/desktop/src/shell/ports_panel/kill.rs
@@ -1,0 +1,285 @@
+//! Stopping the process behind a port.
+//!
+//! **Why the panel offers this at all.** "Port 3000 is already in use" is the
+//! most common way a dev server fails to start, and the fix is always the
+//! same: find what has it, stop that, try again. The finding half is what the
+//! rest of this module already does; making the user leave for a terminal to
+//! type `kill $(lsof -ti:3000)` is asking them to re-derive by hand a pid the
+//! panel is already showing them.
+//!
+//! **Why only project-attributed rows.** An external row is something this
+//! window merely noticed — a system daemon, another app's helper, a container.
+//! The panel has no evidence the user meant to be responsible for it, and a
+//! stop button next to `ControlCenter` is a footgun with a tooltip. So the
+//! action exists only where attribution said "this is yours"; see
+//! [`super::scan::PortRow::is_owned`].
+//!
+//! **Why the pid is re-checked.** A rendered row is up to one poll old, and a
+//! pid that exited in that window can have been recycled by something else.
+//! Killing on a stale row would then kill an innocent process that happens to
+//! have inherited the number. So [`stop_listener`] re-reads the socket table
+//! at the moment of the click and refuses unless that pid is *still* listening
+//! on *that* port — the same fact the row was claiming, re-established rather
+//! than trusted.
+//!
+//! **Why SIGTERM first.** A dev server asked to stop flushes its build cache,
+//! removes its socket file, and lets its own children exit; killed outright it
+//! leaves all three behind. The escalation to SIGKILL exists for the process
+//! that ignores the polite request, and it happens on a detached timer so the
+//! UI thread never waits on it.
+
+use std::time::Duration;
+
+/// How long a process gets to exit on its own before the escalation lands.
+///
+/// Matches the agent runtimes' grace elsewhere in the app: long enough for a
+/// bundler to finish writing, short enough that a user who clicked Stop does
+/// not start wondering whether the click registered.
+const TERM_GRACE: Duration = Duration::from_secs(5);
+
+/// Why a stop request was refused. Every variant is a sentence the panel can
+/// show as-is — a refusal the user cannot read is indistinguishable from a
+/// button that does nothing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Refusal {
+    /// The row was stale: nothing with that pid holds that port any more.
+    GoneOrRecycled,
+    /// The pid is this application, or something it needs to keep running.
+    ProtectedProcess,
+    /// The kernel refused — another user's process, most often.
+    Denied,
+}
+
+impl Refusal {
+    pub(crate) fn message(&self, port: u16) -> String {
+        match self {
+            Self::GoneOrRecycled => {
+                format!("Nothing is listening on {port} any more")
+            }
+            Self::ProtectedProcess => {
+                "OxiMux will not stop its own process".to_string()
+            }
+            Self::Denied => format!("Not allowed to stop the process on {port}"),
+        }
+    }
+}
+
+/// Pids this app must never signal, whatever a row says.
+///
+/// The app itself and its parent: OxiMux binds no TCP port of its own, so
+/// neither should ever reach this code — which is exactly why the guard is
+/// cheap enough to keep. A future feature that does listen (a preview server,
+/// the remote-control bridge) would otherwise ship a button that quits the app.
+fn is_protected(pid: u32) -> bool {
+    // Pid 0 and 1 are the kernel and init; on Windows pid 0 is what the
+    // socket table attributes kernel-held listeners to, which is precisely
+    // the row a user would be tempted to click.
+    pid <= 1 || pid == std::process::id() || Some(pid) == parent_pid()
+}
+
+fn parent_pid() -> Option<u32> {
+    #[cfg(unix)]
+    {
+        Some(unsafe { libc::getppid() } as u32)
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+/// Ask the process holding `port` to stop, escalating if it will not.
+/// **Blocking only for the initial signal** — the grace wait and the
+/// escalation run on `spawner`.
+///
+/// Returns `Ok(())` once the polite signal has been delivered, not once the
+/// process is gone: a caller that waited for the latter would be blocking a
+/// click on a process that may take seconds to unwind. The next poll is what
+/// makes the row disappear, which is the same mechanism that notices a server
+/// the user stopped in a terminal.
+pub(crate) fn stop_listener(
+    pid: u32,
+    port: u16,
+    spawner: impl FnOnce(Duration, Box<dyn FnOnce() + Send>) + 'static,
+) -> Result<(), Refusal> {
+    if is_protected(pid) {
+        return Err(Refusal::ProtectedProcess);
+    }
+    // Re-establish the row's claim rather than trusting it. This is the guard
+    // against a recycled pid, and it costs one scoped socket read.
+    if !still_listening(pid, port) {
+        return Err(Refusal::GoneOrRecycled);
+    }
+    signal(pid, Signal::Term)?;
+    spawner(
+        TERM_GRACE,
+        Box::new(move || {
+            // Re-check before escalating for the same reason as above, and
+            // because the ordinary outcome is that SIGTERM already worked.
+            if still_listening(pid, port) {
+                let _ = signal(pid, Signal::Kill);
+            }
+        }),
+    );
+    Ok(())
+}
+
+/// Whether `pid` still holds `port`. A scoped query — the pid is known, so
+/// there is no reason to read the whole machine's table to answer this.
+fn still_listening(pid: u32, port: u16) -> bool {
+    oximux_proc_ports::listening_ports_of(&[pid])
+        .iter()
+        .any(|row| row.port == port)
+}
+
+/// `unix` and `windows` are the only arms, and there is deliberately no
+/// fallback: a platform this app can be built for and cannot signal on would
+/// ship a Stop button that silently does nothing, and a compile error is the
+/// better way to find that out.
+#[derive(Clone, Copy)]
+enum Signal {
+    Term,
+    Kill,
+}
+
+#[cfg(unix)]
+fn signal(pid: u32, which: Signal) -> Result<(), Refusal> {
+    let sig = match which {
+        Signal::Term => libc::SIGTERM,
+        Signal::Kill => libc::SIGKILL,
+    };
+    // Signalling the pid rather than its process group: the group of a server
+    // started in a terminal contains that terminal's shell, and taking the
+    // shell down with the server would close the pane the user is watching.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, sig) };
+    if rc == 0 {
+        return Ok(());
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        // ESRCH: it exited between the check and the signal. That is the
+        // outcome the click wanted, so it is not a failure.
+        Some(libc::ESRCH) => Ok(()),
+        _ => Err(Refusal::Denied),
+    }
+}
+
+#[cfg(windows)]
+fn signal(pid: u32, which: Signal) -> Result<(), Refusal> {
+    // Windows has no SIGTERM. `taskkill` without `/F` posts WM_CLOSE and asks
+    // a console process to end, which is the closest thing to a polite
+    // request; `/F` is the escalation. Shelling out rather than calling
+    // `TerminateProcess` directly because the polite half has no single API
+    // equivalent, and having the two paths differ in shape is how one of them
+    // rots unnoticed.
+    let mut cmd = std::process::Command::new("taskkill");
+    cmd.args(["/PID", &pid.to_string()]);
+    if matches!(which, Signal::Kill) {
+        cmd.arg("/F");
+    }
+    match cmd
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        // A non-zero status is nearly always "the process is already gone",
+        // which the caller treats the same as success for the same reason
+        // ESRCH is fine above.
+        Ok(_) => Ok(()),
+        Err(_) => Err(Refusal::Denied),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    /// A spawner that records whether an escalation was scheduled without
+    /// ever running it — the tests below must not depend on a timer.
+    fn recording_spawner(flag: Arc<AtomicBool>) -> impl FnOnce(Duration, Box<dyn FnOnce() + Send>) {
+        move |_, _| flag.store(true, Ordering::SeqCst)
+    }
+
+    #[test]
+    fn our_own_process_is_protected() {
+        assert!(is_protected(std::process::id()));
+    }
+
+    #[test]
+    fn the_kernel_and_init_are_protected() {
+        // Windows attributes kernel-held listeners to pid 0, and those rows do
+        // reach the panel.
+        assert!(is_protected(0));
+        assert!(is_protected(1));
+    }
+
+    #[test]
+    fn stopping_our_own_process_is_refused_before_any_signal() {
+        let escalated = Arc::new(AtomicBool::new(false));
+        let result = stop_listener(
+            std::process::id(),
+            3000,
+            recording_spawner(escalated.clone()),
+        );
+        assert_eq!(result, Err(Refusal::ProtectedProcess));
+        assert!(!escalated.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn a_stale_row_is_refused_rather_than_signalling_a_recycled_pid() {
+        // A pid past every platform's ceiling cannot be listening on anything,
+        // which is the shape of a row whose process exited a poll ago.
+        let escalated = Arc::new(AtomicBool::new(false));
+        let result = stop_listener(u32::MAX, 3000, recording_spawner(escalated.clone()));
+        assert_eq!(result, Err(Refusal::GoneOrRecycled));
+        assert!(!escalated.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn a_live_listener_that_is_not_on_that_port_is_refused() {
+        // Our own process holds a socket, but not this port. Guards against a
+        // check that only asks "is the pid alive".
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let ours = listener.local_addr().expect("local addr").port();
+        let other = ours.wrapping_add(1).max(1024);
+        assert!(!still_listening(std::process::id(), other));
+        assert!(still_listening(std::process::id(), ours));
+    }
+
+    /// End to end against a real process: spawn a listener, stop it, and
+    /// assert the socket is gone. The only test here that proves the signal
+    /// path actually signals.
+    #[cfg(unix)]
+    #[test]
+    fn a_spawned_listener_is_stopped_by_the_polite_signal() {
+        // A shell holding a socket open with nothing else to do: it exits on
+        // SIGTERM, which is the ordinary case the escalation never sees.
+        let mut child = std::process::Command::new("python3")
+            .args(["-c", "import socket,time\ns=socket.socket()\ns.bind(('127.0.0.1',0))\ns.listen(1)\nprint(s.getsockname()[1],flush=True)\ntime.sleep(60)"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn a listener");
+        let mut port_line = String::new();
+        {
+            use std::io::{BufRead as _, BufReader};
+            let stdout = child.stdout.take().expect("piped stdout");
+            BufReader::new(stdout)
+                .read_line(&mut port_line)
+                .expect("the child prints its port");
+        }
+        let port: u16 = port_line.trim().parse().expect("a port number");
+        let pid = child.id();
+        assert!(still_listening(pid, port), "the child is holding the socket");
+
+        let escalated = Arc::new(AtomicBool::new(false));
+        stop_listener(pid, port, recording_spawner(escalated.clone())).expect("the stop lands");
+        assert!(escalated.load(Ordering::SeqCst), "an escalation is armed");
+
+        // SIGTERM is asynchronous; wait for the process rather than the clock.
+        let status = child.wait().expect("the child exits");
+        assert!(!status.success() || status.code().is_none());
+        let _ = child.kill();
+    }
+}

--- a/apps/desktop/src/shell/ports_panel/labels.rs
+++ b/apps/desktop/src/shell/ports_panel/labels.rs
@@ -6,6 +6,8 @@
 
 use std::path::Path;
 
+use super::scan::Attribution;
+
 /// `"1 port"` / `"N ports"`. The status bar's metric, plural-aware to match
 /// the `N agents` / `N panes` segments beside it.
 pub(crate) fn port_metric_label(count: usize) -> String {
@@ -50,6 +52,41 @@ pub(crate) fn reach_label(loopback: bool) -> &'static str {
     }
 }
 
+/// The whole second line of a row: what holds the port, and who can reach it.
+///
+/// One string rather than two elements because the two facts are read
+/// together and a row that wraps between them reads as two rows.
+pub(crate) fn detail_label(process: &str, pid: u32, loopback: bool) -> String {
+    format!("{} · {}", origin_label(process, pid), reach_label(loopback))
+}
+
+/// Why the panel filed a port under a project — the tooltip on an owned row.
+///
+/// Shown rather than kept internal because "why is this listed under my other
+/// worktree" is a real question with a real answer, and the answer is short.
+pub(crate) fn attribution_tooltip(how: Attribution) -> &'static str {
+    match how {
+        Attribution::Terminal => "Started in a terminal in this window",
+        Attribution::Cwd => "Running in this project's directory",
+        Attribution::Command => "This project's path is in the command line",
+    }
+}
+
+/// Heading for the section holding everything no project claimed.
+pub(crate) fn external_section_label() -> &'static str {
+    "EXTERNAL"
+}
+
+/// Shown above the external section when the machine is serving things but
+/// none of them are yours.
+///
+/// Distinct from the fully-empty state on purpose: "nothing at all is
+/// listening" and "plenty is listening, none of it yours" look identical if
+/// they share copy, and only one of them means a dev server failed to start.
+pub(crate) fn no_owned_hint() -> &'static str {
+    "Nothing listening in your projects"
+}
+
 /// Heading for a project's section: the directory's own name.
 ///
 /// Falls back to the full path for a root or a path that ends in `..` — rare,
@@ -77,26 +114,19 @@ pub(crate) fn row_title(label: Option<&str>, process: &str, port: u16) -> String
     format!("port {port}")
 }
 
-/// Headline for the panel when nothing is listening.
+/// Headline for the panel when *nothing on the machine* is listening.
 ///
-/// The two cases are genuinely different and must not share copy: no
-/// terminals open at all is a "do this first"; terminals open with nothing
-/// serving is the ordinary resting state and needs no instruction.
-pub(crate) fn empty_headline(has_terminals: bool) -> &'static str {
-    if has_terminals {
-        "Nothing listening"
-    } else {
-        "No terminals open"
-    }
+/// Genuinely rare now that the scan is machine-wide — a desktop with no
+/// listening TCP socket at all is a quiet one — which is why there is a single
+/// state rather than the pair this had while the scan was scoped to open
+/// terminals.
+pub(crate) fn empty_headline() -> &'static str {
+    "Nothing listening"
 }
 
 /// Second line under [`empty_headline`].
-pub(crate) fn empty_detail(has_terminals: bool) -> &'static str {
-    if has_terminals {
-        "Start a dev server in a terminal and its port appears here."
-    } else {
-        "Ports are found by looking inside the terminals you have open."
-    }
+pub(crate) fn empty_detail() -> &'static str {
+    "No process on this machine is accepting connections."
 }
 
 #[cfg(test)]
@@ -161,8 +191,40 @@ mod tests {
     }
 
     #[test]
-    fn the_two_empty_states_do_not_share_copy() {
-        assert_ne!(empty_headline(true), empty_headline(false));
-        assert_ne!(empty_detail(true), empty_detail(false));
+    fn the_empty_state_never_promises_a_terminal_is_needed() {
+        // The scan is machine-wide: telling a user to open a terminal would be
+        // instructing them to do something that is not what finds a port.
+        assert!(!empty_headline().to_lowercase().contains("terminal"));
+        assert!(!empty_detail().to_lowercase().contains("terminal"));
+    }
+
+    #[test]
+    fn nothing_of_yours_is_not_the_same_as_nothing_at_all() {
+        assert_ne!(no_owned_hint(), empty_headline());
+    }
+
+    #[test]
+    fn a_detail_line_carries_both_facts() {
+        assert_eq!(
+            detail_label("node", 21044, true),
+            "node · pid 21044 · local only"
+        );
+        assert_eq!(detail_label("", 7, false), "pid 7 · on your network");
+    }
+
+    #[test]
+    fn every_attribution_explains_itself() {
+        for how in [Attribution::Terminal, Attribution::Cwd, Attribution::Command] {
+            assert!(!attribution_tooltip(how).is_empty());
+        }
+        // Three distinct reasons must read as three distinct sentences.
+        assert_ne!(
+            attribution_tooltip(Attribution::Cwd),
+            attribution_tooltip(Attribution::Command)
+        );
+        assert_ne!(
+            attribution_tooltip(Attribution::Terminal),
+            attribution_tooltip(Attribution::Cwd)
+        );
     }
 }

--- a/apps/desktop/src/shell/ports_panel/mod.rs
+++ b/apps/desktop/src/shell/ports_panel/mod.rs
@@ -689,20 +689,29 @@ impl PortsPanel {
             );
         }
         if owned {
-            actions = actions.child(
-                Button::new(SharedString::from(format!("port-stop-{key}")))
-                    .ghost()
-                    .xsmall()
-                    .icon(
-                        Icon::default()
-                            .path("icons/trash.svg")
-                            .text_color(theme.status_error),
-                    )
-                    .tooltip("Stop this process")
-                    .on_click(
-                        cx.listener(move |this, _: &ClickEvent, _w, cx| this.stop_port(pid, port, cx)),
-                    ),
-            );
+            actions = actions
+                // A gap, not a confirmation step. Stop is one click from Copy
+                // in a cluster of small icons, and an accidental SIGTERM to a
+                // dev server is a real cost — but it is a recoverable one
+                // (restart it), so the proportionate answer is to stop the
+                // destructive verb sitting flush against the harmless ones
+                // rather than to put a dialog in front of every deliberate
+                // use.
+                .child(div().flex_none().w(px(density.gap_inline)))
+                .child(
+                    Button::new(SharedString::from(format!("port-stop-{key}")))
+                        .ghost()
+                        .xsmall()
+                        .icon(
+                            Icon::default()
+                                .path("icons/trash.svg")
+                                .text_color(theme.status_error),
+                        )
+                        .tooltip("Stop this process")
+                        .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+                            this.stop_port(pid, port, cx)
+                        })),
+                );
         }
 
         let headline: AnyElement = if editing {

--- a/apps/desktop/src/shell/ports_panel/mod.rs
+++ b/apps/desktop/src/shell/ports_panel/mod.rs
@@ -1,4 +1,5 @@
-//! Ports panel — what the terminals in this window are currently serving.
+//! Ports panel — what this machine is currently serving, and which of it is
+//! yours.
 //!
 //! **Why this is a panel and not a log line.** A dev server prints its URL
 //! once, at the moment it starts, and then a build log buries it. Ten minutes
@@ -8,13 +9,12 @@
 //! panel reading the socket table is always current in a way a transcript
 //! never is.
 //!
-//! **Why it is scoped to your terminals.** The kernel would happily list every
-//! listener on the machine, and that list is mostly the OS talking to itself.
-//! Attribution runs the other way — from the terminals this window owns, down
-//! their process trees, and only then to the socket table — so every row here
-//! is something the user started, under the project they started it in. See
-//! [`oximux_proc_ports`] for why that scoping is also what keeps the Linux
-//! implementation affordable.
+//! **Why it lists more than your terminals.** See [`scan`] for the argument
+//! and the attribution rules. The short version: the panel's job is to answer
+//! "what has 3000", and a list that can only see processes this window started
+//! answers a narrower question than the one being asked. Everything is listed;
+//! what the panel *claims* is what attribution could justify, and only claimed
+//! rows get a destructive action.
 //!
 //! **Why labels are persisted.** Three `node` rows on 3000, 3001 and 9229 are
 //! the API, the docs site and a debugger, and nothing the kernel knows can
@@ -22,36 +22,58 @@
 //! project+port and comes back when the same server does.
 //!
 //! The scan itself is driven by [`crate::workspace_root::WorkspaceRoot`] —
-//! it owns the terminals the walk starts from, and the socket read belongs on
-//! a background thread. This module renders what the scan produced and owns
-//! the actions on a row.
+//! it owns the terminals and the project list the walk starts from, and the
+//! socket read belongs on a background thread. This module renders what the
+//! scan produced and owns the actions on a row.
 
+pub(crate) mod kill;
 pub(crate) mod labels;
 pub(crate) mod scan;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use gpui::{
-    AnyElement, App, AppContext as _, ClipboardItem, Context, FocusHandle, Focusable,
-    InteractiveElement, IntoElement, ParentElement, Render, ScrollHandle, SharedString,
+    AnyElement, App, AppContext as _, ClickEvent, ClipboardItem, Context, FocusHandle, Focusable,
+    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, ScrollHandle, SharedString,
     StatefulInteractiveElement as _, Styled, WeakEntity, Window, div, prelude::FluentBuilder as _,
     px,
 };
-use gpui_component::Sizable as _;
 use gpui_component::input::{Input, InputEvent, InputState};
+use gpui_component::{
+    Disableable as _, Icon, Sizable as _,
+    button::{Button, ButtonVariants as _},
+};
 use oximux_settings::{Density, Theme, Typography};
 use oximux_storage::SettingsRepo;
 
 use crate::app_settings::port_label_settings;
-use crate::shell::settings_modal::controls::value_chip;
 use crate::workspace_root::WorkspaceRoot;
 
 use labels::{
-    empty_detail, empty_headline, origin_label, port_metric_label, project_label, reach_label,
-    row_title, url_for,
+    attribution_tooltip, detail_label, empty_detail, empty_headline, external_section_label,
+    no_owned_hint, project_label, row_title, url_for,
 };
-use scan::PortInventory;
+use scan::{PortInventory, PortRow};
+
+/// Opacity of a row's action cluster at rest.
+///
+/// Not zero, for the reason the stash panel's row actions document: this panel
+/// has no context menu, so a fully hidden cluster would leave Stop reachable
+/// only by a hover a user has no reason to try. Ghosted-at-rest keeps every
+/// verb discoverable while still letting the port number and its process read
+/// as the row's content.
+const ACTION_REST_OPACITY: f32 = 0.35;
+
+/// Height of the panel's header strip.
+///
+/// The file explorer's number, deliberately: these are sibling panels in the
+/// same column, and a header that is four pixels taller than its neighbour
+/// reads as a misalignment rather than as a choice. Notably *not*
+/// `density.h_top_bar`, which is pinned to the macOS traffic lights and
+/// belongs to the window chrome — borrowing it here is what made this header
+/// overflow its own two-line title.
+const HEADER_H: f32 = 28.0;
 
 /// Which row's label is being edited. Project *and* port, because that pair is
 /// the label's identity — a pid would be gone by the next poll and the row
@@ -62,6 +84,15 @@ pub(crate) struct RenameTarget {
     pub port: u16,
 }
 
+/// Which section a row lives in. Sections collapse independently and the
+/// external one starts closed, so the key has to survive a poll that reorders
+/// nothing but rebuilds everything.
+fn project_section_key(project: &std::path::Path) -> String {
+    format!("project:{}", project.display())
+}
+
+const EXTERNAL_SECTION_KEY: &str = "external";
+
 pub struct PortsPanel {
     weak_root: WeakEntity<WorkspaceRoot>,
     focus_handle: FocusHandle,
@@ -69,13 +100,19 @@ pub struct PortsPanel {
     settings_repo: Option<SettingsRepo>,
 
     inventory: PortInventory,
-    /// Whether the window has any terminal at all. Distinguishes "nothing is
-    /// serving" from "there is nothing to look inside", which need different
-    /// empty states — see [`empty_headline`].
-    has_terminals: bool,
     /// Persisted labels by [`port_label_settings::label_key`]. Loaded once and
     /// updated in place on write, so a poll never touches the database.
     port_labels: HashMap<String, String>,
+    /// Sections the user has closed. External is in here from the start: it is
+    /// long, it is mostly the OS talking to itself, and it is reference
+    /// material rather than the thing the panel was opened for.
+    collapsed: HashSet<String>,
+    /// Set while a *manual* refresh is in flight, so the button can say so.
+    ///
+    /// Only manual: the background poll runs every few seconds forever, and a
+    /// spinner driven by it would repaint the window on that cadence for as
+    /// long as the app is open — a battery bug wearing a feature's clothes.
+    refreshing: bool,
 
     rename: Option<RenameTarget>,
     rename_input: gpui::Entity<InputState>,
@@ -101,8 +138,7 @@ impl PortsPanel {
             .as_ref()
             .map(port_label_settings::load_labels)
             .unwrap_or_default();
-        let rename_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Name this port"));
+        let rename_input = cx.new(|cx| InputState::new(window, cx).placeholder("Name this port"));
         // Enter commits. Without this the only way out of an edit is a click,
         // and a text field that ignores Enter reads as broken.
         let subscription = cx.subscribe_in(
@@ -119,8 +155,9 @@ impl PortsPanel {
             focus_handle: cx.focus_handle(),
             settings_repo,
             inventory: PortInventory::default(),
-            has_terminals: false,
             port_labels,
+            collapsed: HashSet::from([EXTERNAL_SECTION_KEY.to_string()]),
+            refreshing: false,
             rename: None,
             rename_input,
             _rename_subscription: subscription,
@@ -135,9 +172,13 @@ impl PortsPanel {
     ///
     /// Repaints only when something actually changed: this is called on a
     /// cadence, and a panel that invalidates the window every few seconds
-    /// forever is a battery bug wearing a feature's clothes.
-    pub fn apply(&mut self, inventory: PortInventory, has_terminals: bool, cx: &mut Context<Self>) {
-        if self.inventory == inventory && self.has_terminals == has_terminals {
+    /// forever is a battery bug wearing a feature's clothes. The one exception
+    /// is a manual refresh landing — clearing that flag *is* a change, and it
+    /// is what makes the button stop saying it is working.
+    pub fn apply(&mut self, inventory: PortInventory, cx: &mut Context<Self>) {
+        let settling = self.refreshing;
+        self.refreshing = false;
+        if self.inventory == inventory && !settling {
             return;
         }
         // An edit whose row has gone is an edit with nowhere to commit to.
@@ -149,11 +190,10 @@ impl PortsPanel {
             self.rename = None;
         }
         self.inventory = inventory;
-        self.has_terminals = has_terminals;
         cx.notify();
     }
 
-    /// Total rows, for the status bar's metric.
+    /// Total project-attributed rows, for the status bar's metric.
     pub fn count(&self) -> usize {
         self.inventory.total()
     }
@@ -162,6 +202,13 @@ impl PortsPanel {
         self.port_labels
             .get(&port_label_settings::label_key(project, port))
             .map(String::as_str)
+    }
+
+    fn toggle_section(&mut self, key: String, cx: &mut Context<Self>) {
+        if !self.collapsed.remove(&key) {
+            self.collapsed.insert(key);
+        }
+        cx.notify();
     }
 
     fn begin_rename(
@@ -229,20 +276,79 @@ impl PortsPanel {
 
     fn copy_url(&mut self, port: u16, cx: &mut Context<Self>) {
         cx.write_to_clipboard(ClipboardItem::new_string(url_for(port)));
+        self.toast(
+            crate::shell::toast::ToastKind::Info,
+            format!("Copied {}", url_for(port)),
+            cx,
+        );
+    }
+
+    /// Stop the process behind a row, then rescan so the row goes away.
+    ///
+    /// Only ever reached from an owned row — see [`kill`] for why external
+    /// rows are not offered this, and for the staleness re-check that makes a
+    /// click on a several-seconds-old row safe.
+    fn stop_port(&mut self, pid: u32, port: u16, cx: &mut Context<Self>) {
+        let spawner = {
+            let executor = cx.background_executor().clone();
+            move |delay: std::time::Duration, escalate: Box<dyn FnOnce() + Send>| {
+                let timer = executor.timer(delay);
+                executor
+                    .spawn(async move {
+                        // The grace wait happens here rather than on the UI
+                        // thread; nothing is holding a click open for it.
+                        timer.await;
+                        escalate();
+                    })
+                    .detach();
+            }
+        };
+        match kill::stop_listener(pid, port, spawner) {
+            Ok(()) => {
+                // Deliberately no immediate rescan. The socket does not close
+                // the instant SIGTERM lands, so a scan fired from this click
+                // would redraw the row it was meant to remove and read as a
+                // failed stop; the toast is what acknowledges the click, and
+                // the ordinary poll is what retires the row a moment later.
+                self.toast(
+                    crate::shell::toast::ToastKind::Info,
+                    format!("Stopping the process on {port}"),
+                    cx,
+                );
+            }
+            Err(refusal) => {
+                self.toast(
+                    crate::shell::toast::ToastKind::Error,
+                    refusal.message(port),
+                    cx,
+                );
+            }
+        }
+    }
+
+    fn toast(&self, kind: crate::shell::toast::ToastKind, text: String, cx: &mut Context<Self>) {
         let _ = self.weak_root.update(cx, |root, cx| {
-            root.push_toast(
-                crate::shell::toast::ToastKind::Info,
-                format!("Copied {}", url_for(port)),
-                cx,
-            );
+            root.push_toast(kind, text, cx);
         });
     }
 
     /// Ask the root for an out-of-cadence scan.
+    ///
+    /// The busy flag is set only if the root actually took the request. A
+    /// panel whose root has gone — a closed window's, mid-teardown — would
+    /// otherwise disable its own button forever waiting for a scan nobody is
+    /// running.
     fn refresh(&mut self, cx: &mut Context<Self>) {
-        let _ = self.weak_root.update(cx, |root, cx| {
-            root.run_port_scan(cx);
-        });
+        let asked = self
+            .weak_root
+            .update(cx, |root, cx| {
+                root.run_port_scan(cx);
+            })
+            .is_ok();
+        if asked {
+            self.refreshing = true;
+            cx.notify();
+        }
     }
 }
 
@@ -254,7 +360,12 @@ impl Focusable for PortsPanel {
 
 impl Render for PortsPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        oximux_settings::appearance::sync(&mut self.theme, &mut self.density, &mut self.typography, cx);
+        oximux_settings::appearance::sync(
+            &mut self.theme,
+            &mut self.density,
+            &mut self.typography,
+            cx,
+        );
         let theme = self.theme;
         let density = self.density;
 
@@ -268,12 +379,20 @@ impl Render for PortsPanel {
                 .w_full()
                 .flex_1()
                 .min_h(px(0.))
-                .gap(px(density.gap_inline))
-                .p(px(density.pad_panel))
+                .pb(px(density.pad_panel))
                 .overflow_y_scroll()
                 .track_scroll(&self.scroll);
+            if self.inventory.groups.is_empty() {
+                // Plenty listening, none of it yours — a different fact from
+                // "nothing is listening", and the one that means a dev server
+                // failed to start.
+                col = col.child(self.render_hint(no_owned_hint()));
+            }
             for group in 0..self.inventory.groups.len() {
-                col = col.child(self.render_group(group, cx));
+                col = col.child(self.render_project_section(group, cx));
+            }
+            if !self.inventory.external.is_empty() {
+                col = col.child(self.render_external_section(cx));
             }
             col.into_any_element()
         };
@@ -292,49 +411,52 @@ impl Render for PortsPanel {
 impl PortsPanel {
     fn render_header(&mut self, cx: &mut Context<Self>) -> AnyElement {
         let theme = self.theme;
-        let density = self.density;
         let typography = self.typography.clone();
-        let count = self.count();
+        let refreshing = self.refreshing;
 
         div()
             .flex()
             .flex_row()
             .items_center()
             .justify_between()
+            .gap(px(8.0))
             .w_full()
             .flex_none()
-            .h(px(density.h_top_bar))
-            .px(px(density.pad_panel))
+            .h(px(HEADER_H))
+            .pl(px(10.0))
+            .pr(px(4.0))
+            .bg(theme.bg_panel)
             .border_b_1()
             .border_color(theme.border_inactive)
             .child(
                 div()
-                    .flex()
-                    .flex_col()
-                    .gap(px(2.0))
-                    .child(
-                        div()
-                            .text_size(px(typography.t_body_md))
-                            .font_weight(typography.w_semibold)
-                            .text_color(theme.fg_base)
-                            .child("Ports"),
-                    )
-                    .child(
-                        div()
-                            .text_size(px(typography.t_sub_label))
-                            .text_color(theme.fg_subtle)
-                            .child(port_metric_label(count)),
-                    ),
+                    .flex_1()
+                    .min_w(px(0.))
+                    .overflow_hidden()
+                    .text_size(px(typography.t_label_caps))
+                    .font_weight(typography.w_semibold)
+                    .text_color(theme.fg_muted)
+                    .child("PORTS"),
             )
-            .child(value_chip(
-                "ports-refresh",
-                "Refresh",
-                theme,
-                density,
-                &typography,
-                |this: &mut Self, _w, cx| this.refresh(cx),
-                cx,
-            ))
+            .child(
+                Button::new("ports-refresh")
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/refresh-cw.svg"))
+                    // The tooltip is the only place this control is named; an
+                    // icon button with none is a mystery glyph.
+                    .tooltip(if refreshing {
+                        "Scanning ports…"
+                    } else {
+                        "Rescan ports"
+                    })
+                    // Disabled while a manual scan is in flight, because the
+                    // root refuses an overlapping scan silently — a button
+                    // that accepts a click and does nothing is worse than one
+                    // that says it is busy.
+                    .disabled(refreshing)
+                    .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| this.refresh(cx))),
+            )
             .into_any_element()
     }
 
@@ -356,133 +478,294 @@ impl PortsPanel {
                 div()
                     .text_size(px(typography.t_body_md))
                     .text_color(theme.fg_muted)
-                    .child(empty_headline(self.has_terminals)),
+                    .child(empty_headline()),
             )
             .child(
                 div()
                     .text_size(px(typography.t_sub_label))
                     .text_color(theme.fg_subtle)
                     .text_center()
-                    .child(empty_detail(self.has_terminals)),
+                    .child(empty_detail()),
             )
             .into_any_element()
     }
 
-    fn render_group(&mut self, idx: usize, cx: &mut Context<Self>) -> AnyElement {
+    /// A single recessive line of explanation between the header and a section.
+    fn render_hint(&self, text: &'static str) -> AnyElement {
         let theme = self.theme;
         let density = self.density;
-        let typography = self.typography.clone();
-        let project = self.inventory.groups[idx].project.clone();
-        let heading = project_label(&project);
-        let row_count = self.inventory.groups[idx].rows.len();
-
-        let mut col = div()
-            .flex()
-            .flex_col()
+        div()
             .w_full()
-            .gap(px(density.gap_inline))
-            .child(
-                div()
-                    .text_size(px(typography.t_sub_label))
-                    .font_weight(typography.w_semibold)
-                    .text_color(theme.fg_subtle)
-                    .child(heading.to_uppercase()),
-            );
-        for row in 0..row_count {
-            col = col.child(self.render_row(idx, row, &project, cx));
-        }
-        col.into_any_element()
+            .px(px(density.pad_panel))
+            .pt(px(density.pad_row))
+            .text_size(px(self.typography.t_sub_label))
+            .text_color(theme.fg_subtle)
+            .child(text)
+            .into_any_element()
     }
 
-    fn render_row(
-        &mut self,
-        group: usize,
-        row: usize,
-        project: &std::path::Path,
+    /// A collapsible section heading: chevron, title, and the count of what is
+    /// inside it.
+    ///
+    /// The count is on the heading rather than in the panel header because
+    /// there are now several numbers to report and one summary line cannot
+    /// hold them without becoming the thing that overflowed this header
+    /// before. It also keeps the number next to the thing it counts.
+    fn render_section_header(
+        &self,
+        key: String,
+        title: String,
+        count: usize,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let theme = self.theme;
         let density = self.density;
         let typography = self.typography.clone();
-        let entry = &self.inventory.groups[group].rows[row];
+        let collapsed = self.collapsed.contains(&key);
+        let id = SharedString::from(format!("ports-section-{key}"));
+        let toggle_key = key.clone();
+
+        div()
+            .id(id)
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(4.0))
+            .w_full()
+            .h(px(density.h_row))
+            .px(px(density.pad_panel))
+            .cursor_pointer()
+            .hover(|s| s.bg(theme.hover_overlay))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _window, cx| {
+                    this.toggle_section(toggle_key.clone(), cx)
+                }),
+            )
+            .child(
+                Icon::default()
+                    .path(if collapsed {
+                        "icons/chevron-right.svg"
+                    } else {
+                        "icons/chevron-down.svg"
+                    })
+                    .xsmall()
+                    // An svg paints transparent without one: see
+                    // `oximux-app-svg-icons-need-assets-registration`.
+                    .text_color(theme.fg_subtle),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.))
+                    .overflow_hidden()
+                    .text_size(px(typography.t_label_caps))
+                    .font_weight(typography.w_semibold)
+                    .text_color(theme.fg_muted)
+                    .child(title),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(px(typography.t_sub_label))
+                    .text_color(theme.fg_subtle)
+                    .child(count.to_string()),
+            )
+            .into_any_element()
+    }
+
+    fn render_project_section(&mut self, idx: usize, cx: &mut Context<Self>) -> AnyElement {
+        let project = self.inventory.groups[idx].project.clone();
+        let key = project_section_key(&project);
+        let count = self.inventory.groups[idx].rows.len();
+        let mut col = div().flex().flex_col().w_full().child(
+            self.render_section_header(key.clone(), project_label(&project).to_uppercase(), count, cx),
+        );
+        if !self.collapsed.contains(&key) {
+            for row in 0..count {
+                col = col.child(self.render_row(Some((idx, project.clone())), row, cx));
+            }
+        }
+        col.into_any_element()
+    }
+
+    fn render_external_section(&mut self, cx: &mut Context<Self>) -> AnyElement {
+        let key = EXTERNAL_SECTION_KEY.to_string();
+        let count = self.inventory.external.len();
+        let mut col = div().flex().flex_col().w_full().child(self.render_section_header(
+            key.clone(),
+            external_section_label().to_string(),
+            count,
+            cx,
+        ));
+        if !self.collapsed.contains(&key) {
+            for row in 0..count {
+                col = col.child(self.render_row(None, row, cx));
+            }
+        }
+        col.into_any_element()
+    }
+
+    /// One port. `owner` is `Some((group index, project))` for an attributed
+    /// row and `None` for an external one — the two differ in which actions
+    /// they carry, not in how they look.
+    fn render_row(
+        &mut self,
+        owner: Option<(usize, PathBuf)>,
+        row: usize,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let theme = self.theme;
+        let density = self.density;
+        let typography = self.typography.clone();
+        let entry: &PortRow = match &owner {
+            Some((group, _)) => &self.inventory.groups[*group].rows[row],
+            None => &self.inventory.external[row],
+        };
         let port = entry.port;
         let pid = entry.pid;
         let process = entry.process.clone();
         let loopback = entry.loopback;
-        let title = row_title(self.label_for(project, port), &process, port);
-        let editing = self.rename.as_ref().is_some_and(|t| {
-            t.port == port && t.project == project
+        let attribution = entry.attribution;
+        let owned = entry.is_owned();
+        let title = match &owner {
+            Some((_, project)) => row_title(self.label_for(project, port), &process, port),
+            None => row_title(None, &process, port),
+        };
+        let editing = owner.as_ref().is_some_and(|(_, project)| {
+            self.rename
+                .as_ref()
+                .is_some_and(|t| t.port == port && &t.project == project)
         });
-        let owned_project = project.to_path_buf();
 
         // Element ids must be unique across the whole panel, and a port number
         // alone is not: two projects can each serve 3000 only if one of them
-        // has exited, but the panel may render both in the frame between.
-        let key = format!("{group}-{row}");
+        // has exited, but the panel may render both in the frame between. The
+        // external section shares the id space, hence the section prefix.
+        let key = match &owner {
+            Some((group, _)) => format!("g{group}-{row}"),
+            None => format!("x-{row}"),
+        };
+        let group_name = SharedString::from(format!("ports-row-{key}"));
 
-        div()
+        let mut actions = div()
             .flex()
-            .flex_col()
-            .w_full()
-            .gap(px(4.0))
-            .p(px(density.pad_row))
-            .rounded(px(density.r_card))
-            .bg(theme.bg_panel_alt)
-            .border_1()
-            .border_color(theme.border_inactive)
+            .flex_row()
+            .items_center()
+            .flex_none()
+            .gap(px(1.0))
+            .opacity(ACTION_REST_OPACITY)
+            .group_hover(group_name.clone(), |s| s.opacity(1.0))
             .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .justify_between()
-                    .gap(px(density.gap_inline))
-                    .w_full()
-                    .child(if editing {
-                        div()
-                            // `flex_1` claims the free space; `min_w_0` lets
-                            // the field shrink instead of forcing the row
-                            // wider than the sidebar.
-                            .flex_1()
-                            .min_w_0()
-                            .child(Input::new(&self.rename_input).small())
-                            .into_any_element()
-                    } else {
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .text_size(px(typography.t_body_sm))
-                            .font_weight(typography.w_semibold)
-                            .text_color(theme.fg_base)
-                            .child(title)
-                            .into_any_element()
-                    })
-                    .child(
-                        div()
-                            .flex_none()
-                            .px(px(6.0))
-                            .rounded(px(density.r_chip))
-                            .bg(theme.bg_panel)
-                            .border_1()
-                            .border_color(theme.border_inactive)
-                            .text_size(px(typography.t_sub_label))
-                            .text_color(theme.fg_muted)
-                            .child(format!(":{port}")),
+                Button::new(SharedString::from(format!("port-open-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/globe.svg"))
+                    .tooltip(SharedString::from(format!("Open {}", url_for(port))))
+                    .on_click(
+                        cx.listener(move |this, _: &ClickEvent, _w, cx| this.open_port(port, cx)),
                     ),
             )
             .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap(px(density.gap_inline))
-                    .child(
-                        div()
-                            .text_size(px(typography.t_sub_label))
-                            .text_color(theme.fg_subtle)
-                            .child(origin_label(&process, pid)),
+                Button::new(SharedString::from(format!("port-copy-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/copy.svg"))
+                    .tooltip(SharedString::from(format!("Copy {}", url_for(port))))
+                    .on_click(
+                        cx.listener(move |this, _: &ClickEvent, _w, cx| this.copy_url(port, cx)),
+                    ),
+            );
+        if let Some((_, project)) = owner.clone() {
+            actions = actions.child(
+                Button::new(SharedString::from(format!("port-rename-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/pencil.svg"))
+                    .tooltip("Name this port")
+                    .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                        this.begin_rename(project.clone(), port, window, cx)
+                    })),
+            );
+        }
+        if owned {
+            actions = actions.child(
+                Button::new(SharedString::from(format!("port-stop-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(
+                        Icon::default()
+                            .path("icons/trash.svg")
+                            .text_color(theme.status_error),
                     )
-                    .child(
+                    .tooltip("Stop this process")
+                    .on_click(
+                        cx.listener(move |this, _: &ClickEvent, _w, cx| this.stop_port(pid, port, cx)),
+                    ),
+            );
+        }
+
+        let headline: AnyElement = if editing {
+            div()
+                // `flex_1` claims the free space; `min_w_0` lets the field
+                // shrink instead of forcing the row wider than the sidebar.
+                .flex_1()
+                .min_w_0()
+                .child(Input::new(&self.rename_input).small())
+                .into_any_element()
+        } else {
+            div()
+                .flex_1()
+                .min_w_0()
+                .overflow_hidden()
+                .text_size(px(typography.t_body_sm))
+                .text_color(theme.fg_base)
+                .child(title)
+                .into_any_element()
+        };
+
+        div()
+            // Stateful unconditionally: `hover` needs an id to key its state
+            // on, and an id that only appears on some rows would make the
+            // hover highlight arrive and leave with the attribution.
+            .id(SharedString::from(format!("port-row-{key}")))
+            .group(group_name)
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(density.gap_inline))
+            .w_full()
+            .py(px(density.pad_row))
+            .pl(px(density.pad_panel))
+            .pr(px(4.0))
+            .hover(|s| s.bg(theme.hover_overlay))
+            // Why this row is filed here, on the row rather than in a legend.
+            .when_some(attribution, |row, how| {
+                let tip = SharedString::from(attribution_tooltip(how));
+                row.tooltip(move |window, cx| {
+                    gpui_component::tooltip::Tooltip::new(tip.clone()).build(window, cx)
+                })
+            })
+            .child(
+            // The port number leads the row: it is what the user came to read,
+            // it is fixed-width, and it is the only field that is never empty.
+            div()
+                .flex_none()
+                .text_size(px(typography.t_body_sm))
+                .font_weight(typography.w_semibold)
+                .text_color(theme.fg_base)
+                .child(format!(":{port}")),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.))
+                .flex()
+                .flex_col()
+                .gap(px(1.0))
+                .child(headline)
+                .when(!editing, |col| {
+                    col.child(
                         div()
                             .text_size(px(typography.t_sub_label))
                             // A server reachable from the network is the
@@ -493,72 +776,204 @@ impl PortsPanel {
                             } else {
                                 theme.status_warn
                             })
-                            .child(reach_label(loopback)),
-                    ),
+                            .overflow_hidden()
+                            .child(detail_label(&process, pid, loopback)),
+                    )
+                }),
+        )
+        .when(editing, |row| {
+            row.child(
+                Button::new(SharedString::from(format!("port-save-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/check.svg"))
+                    .tooltip("Save name")
+                    .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                        this.commit_rename(window, cx)
+                    })),
             )
             .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .flex_wrap()
-                    .items_center()
-                    .gap(px(density.gap_inline))
-                    .when(!editing, |actions| {
-                        actions
-                            .child(value_chip(
-                                SharedString::from(format!("port-open-{key}")),
-                                "Open",
-                                theme,
-                                density,
-                                &typography,
-                                move |this: &mut Self, _w, cx| this.open_port(port, cx),
-                                cx,
-                            ))
-                            .child(value_chip(
-                                SharedString::from(format!("port-copy-{key}")),
-                                "Copy URL",
-                                theme,
-                                density,
-                                &typography,
-                                move |this: &mut Self, _w, cx| this.copy_url(port, cx),
-                                cx,
-                            ))
-                            .child(value_chip(
-                                SharedString::from(format!("port-rename-{key}")),
-                                "Rename",
-                                theme,
-                                density,
-                                &typography,
-                                move |this: &mut Self, window, cx| {
-                                    this.begin_rename(owned_project.clone(), port, window, cx)
-                                },
-                                cx,
-                            ))
-                    })
-                    .when(editing, |actions| {
-                        actions
-                            .child(value_chip(
-                                SharedString::from(format!("port-save-{key}")),
-                                "Save",
-                                theme,
-                                density,
-                                &typography,
-                                move |this: &mut Self, window, cx| {
-                                    this.commit_rename(window, cx)
-                                },
-                                cx,
-                            ))
-                            .child(value_chip(
-                                SharedString::from(format!("port-cancel-{key}")),
-                                "Cancel",
-                                theme,
-                                density,
-                                &typography,
-                                move |this: &mut Self, _w, cx| this.cancel_rename(cx),
-                                cx,
-                            ))
-                    }),
+                Button::new(SharedString::from(format!("port-cancel-{key}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::default().path("icons/x.svg"))
+                    .tooltip("Cancel")
+                    .on_click(
+                        cx.listener(move |this, _: &ClickEvent, _w, cx| this.cancel_rename(cx)),
+                    ),
             )
-            .into_any_element()
+        })
+        .when(!editing, |row| row.child(actions))
+        .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{TestAppContext, size};
+    use gpui_component::Root;
+    use scan::{Attribution, PortGroup};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn owned_row(port: u16, pid: u32, how: Attribution) -> PortRow {
+        PortRow {
+            port,
+            pid,
+            process: "node".to_string(),
+            loopback: true,
+            attribution: Some(how),
+        }
+    }
+
+    fn external_row(port: u16, pid: u32, process: &str) -> PortRow {
+        PortRow {
+            port,
+            pid,
+            process: process.to_string(),
+            loopback: false,
+            attribution: None,
+        }
+    }
+
+    /// A populated inventory of the shape this machine actually produces: one
+    /// claimed project section, and a long external tail.
+    fn populated() -> PortInventory {
+        PortInventory {
+            groups: vec![PortGroup {
+                project: PathBuf::from("/work/api"),
+                rows: vec![
+                    owned_row(3000, 111, Attribution::Terminal),
+                    owned_row(5173, 222, Attribution::Cwd),
+                ],
+            }],
+            external: (0..40)
+                .map(|i| external_row(5400 + i, 900 + i as u32, "postgres"))
+                .collect(),
+        }
+    }
+
+    /// Mount a panel inside a `Root` and paint it. `Root` is required —
+    /// `InputState` panics in `Root::update` without one, and this panel owns
+    /// an `InputState` for the rename field whether or not a rename is active.
+    fn mount(
+        cx: &mut TestAppContext,
+        inventory: PortInventory,
+    ) -> (gpui::Entity<PortsPanel>, gpui::VisualTestContext) {
+        // gpui-component reads a theme global that nothing in a bare test app
+        // installs; `Input` and `Button` both panic without it.
+        cx.update(gpui_component::init);
+        let sink: Rc<RefCell<Option<gpui::Entity<PortsPanel>>>> = Rc::new(RefCell::new(None));
+        let out = sink.clone();
+        let w = cx.add_window(move |window, cx| {
+            let panel = cx.new(|cx| {
+                PortsPanel::new(
+                    // The panel has to survive a root that is gone: a window
+                    // mid-teardown is exactly that, and so is this test.
+                    gpui::WeakEntity::new_invalid(),
+                    None,
+                    Theme::default(),
+                    Density::default(),
+                    Typography::default(),
+                    window,
+                    cx,
+                )
+            });
+            *out.borrow_mut() = Some(panel.clone());
+            let view: gpui::AnyView = panel.into();
+            Root::new(view, window, cx)
+        });
+        let panel = sink.borrow().clone().expect("the panel was built");
+        let mut vcx = gpui::VisualTestContext::from_window(w.into(), cx);
+        panel.update(&mut vcx, |panel, cx| panel.apply(inventory, cx));
+        // A sidebar's width, not a window's — the panel has to lay out in the
+        // narrow column it actually lives in.
+        vcx.simulate_resize(size(px(300.0), px(800.0)));
+        vcx.run_until_parked();
+        (panel, vcx)
+    }
+
+    #[gpui::test]
+    fn a_populated_panel_paints(cx: &mut TestAppContext) {
+        let (panel, vcx) = mount(cx, populated());
+        assert_eq!(panel.read_with(&vcx, |p, _| p.count()), 2);
+    }
+
+    #[gpui::test]
+    fn an_empty_panel_paints(cx: &mut TestAppContext) {
+        let (panel, vcx) = mount(cx, PortInventory::default());
+        assert_eq!(panel.read_with(&vcx, |p, _| p.count()), 0);
+    }
+
+    /// The external section starts closed and its rows are not built until it
+    /// is opened — the whole reason it is collapsible is that it is long.
+    #[gpui::test]
+    fn the_external_section_starts_collapsed_and_opens(cx: &mut TestAppContext) {
+        let (panel, mut vcx) = mount(cx, populated());
+        assert!(panel.read_with(&vcx, |p, _| p
+            .collapsed
+            .contains(EXTERNAL_SECTION_KEY)));
+        panel.update(&mut vcx, |p, cx| {
+            p.toggle_section(EXTERNAL_SECTION_KEY.to_string(), cx)
+        });
+        vcx.run_until_parked();
+        assert!(!panel.read_with(&vcx, |p, _| p
+            .collapsed
+            .contains(EXTERNAL_SECTION_KEY)));
+    }
+
+    /// A project section, unlike the external one, starts open: it is what the
+    /// panel was opened for.
+    #[gpui::test]
+    fn a_project_section_starts_open(cx: &mut TestAppContext) {
+        let (panel, vcx) = mount(cx, populated());
+        let key = project_section_key(&PathBuf::from("/work/api"));
+        assert!(!panel.read_with(&vcx, |p, _| p.collapsed.contains(&key)));
+    }
+
+    /// Renaming swaps a row's headline for a live text field. This is the path
+    /// that paints an `InputState` inside a row, which is where a layout that
+    /// starves the field shows up.
+    #[gpui::test]
+    fn a_row_being_renamed_still_paints(cx: &mut TestAppContext) {
+        let (panel, mut vcx) = mount(cx, populated());
+        vcx.update(|window, cx| {
+            panel.update(cx, |p, cx| {
+                p.begin_rename(PathBuf::from("/work/api"), 3000, window, cx)
+            })
+        });
+        vcx.run_until_parked();
+        assert_eq!(
+            panel.read_with(&vcx, |p, _| p.rename.clone()),
+            Some(RenameTarget {
+                project: PathBuf::from("/work/api"),
+                port: 3000
+            })
+        );
+    }
+
+    /// An edit whose row vanished between polls has nowhere to commit to, so
+    /// it is dropped rather than left pointing at a gone server.
+    #[gpui::test]
+    fn a_rename_of_a_vanished_row_is_abandoned(cx: &mut TestAppContext) {
+        let (panel, mut vcx) = mount(cx, populated());
+        vcx.update(|window, cx| {
+            panel.update(cx, |p, cx| {
+                p.begin_rename(PathBuf::from("/work/api"), 3000, window, cx)
+            })
+        });
+        panel.update(&mut vcx, |p, cx| p.apply(PortInventory::default(), cx));
+        vcx.run_until_parked();
+        assert_eq!(panel.read_with(&vcx, |p, _| p.rename.clone()), None);
+    }
+
+    /// A refresh whose root has gone must not leave the button disabled
+    /// forever waiting for a scan nobody is running.
+    #[gpui::test]
+    fn a_refresh_with_no_root_does_not_wedge_the_button(cx: &mut TestAppContext) {
+        let (panel, mut vcx) = mount(cx, populated());
+        panel.update(&mut vcx, |p, cx| p.refresh(cx));
+        assert!(!panel.read_with(&vcx, |p, _| p.refreshing));
     }
 }

--- a/apps/desktop/src/shell/ports_panel/scan.rs
+++ b/apps/desktop/src/shell/ports_panel/scan.rs
@@ -636,14 +636,23 @@ mod tests {
     }
 
     /// Against the real kernel: our own process must resolve to something
-    /// nameable with a working directory. Guards the metadata read from
-    /// silently returning blanks, which would make every row unattributable.
+    /// nameable. Guards the metadata read from silently returning blanks,
+    /// which would make every row unattributable.
+    ///
+    /// The name is asserted everywhere because every platform can supply one.
+    /// The working directory is asserted only where `oximux-proc-cwd`
+    /// implements it — macOS via `PROC_PIDVNODEPATHINFO`, Linux via
+    /// `/proc/<pid>/cwd`. It has no Windows implementation and answers `None`
+    /// there, which is a documented gap rather than a failure: attribution on
+    /// Windows falls back to the terminal-tree signal, and demanding a cwd
+    /// here would only assert that the gap has been closed.
     #[test]
     fn our_own_process_resolves_to_real_metadata() {
         let mut cache = PidMetaCache::default();
         let me = std::process::id();
         let meta = cache.resolve(&[me]).get(&me).cloned().expect("our own pid");
         assert!(!meta.name.is_empty(), "the kernel names our own process");
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         assert!(meta.cwd.is_some(), "our own working directory is readable");
     }
 }

--- a/apps/desktop/src/shell/ports_panel/scan.rs
+++ b/apps/desktop/src/shell/ports_panel/scan.rs
@@ -6,12 +6,39 @@
 //! project both contain it — are decided by tests rather than by whatever the
 //! render pass happened to do.
 //!
-//! One function here is not pure: [`gather`], the syscall bridge, which walks
-//! process trees and reads the socket table. It sits beside the rules it feeds
-//! rather than in the view, because what it produces is only meaningful
+//! **Why the scan is machine-wide.** It was not, once: it walked only the
+//! process trees of terminals this window owns, which meant a dev server
+//! started in another terminal app, a database in a container, or a daemon
+//! already holding the port a build is about to want were all invisible. A
+//! panel that can only see the servers you started *here* cannot tell "nothing
+//! is running" apart from "it is running, somewhere else", and those are
+//! different answers to the only question a person opens this list to ask.
+//! So the socket table is read whole and the rows are *attributed* afterwards.
+//!
+//! **Three kinds of evidence, in order.** A port is claimed by a project when:
+//!
+//! 1. its pid is inside the process tree of a terminal this window owns — the
+//!    strongest signal there is, because the user demonstrably started it here;
+//! 2. failing that, the process's working directory is inside a known project
+//!    root — how a server started in an outside terminal is recognised;
+//! 3. failing that, the project's path appears as one of the process's
+//!    arguments — how `node /work/api/server.js` launched from `/` is caught.
+//!
+//! Anything left over is *external*: real, listed, actionable to open and copy,
+//! but not claimed by a project and never offered a stop button. Attribution
+//! evidence is carried on the row rather than discarded, because "why does the
+//! panel think this is mine" is a question with a real answer.
+//!
+//! **Why labels are persisted.** Three `node` rows on 3000, 3001 and 9229 are
+//! the API, the docs site and a debugger, and nothing the kernel knows can
+//! tell them apart. The name is the user's to write, so it is stored against
+//! project+port and comes back when the same server does.
+//!
+//! One thing here is not pure: [`gather`], the syscall bridge, which reads the
+//! socket table and resolves process metadata. It sits beside the rules it
+//! feeds rather than in the view, because what it produces is only meaningful
 //! against them — but it is the *only* thing in this file that touches the
-//! kernel, and it is called from a background thread. Everything else is a
-//! function of its arguments.
+//! kernel, and it is called from a background thread.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -34,15 +61,56 @@ pub struct TreeSnapshot {
     pub procs: Vec<(u32, String)>,
 }
 
+/// What connected a port to the project it is filed under.
+///
+/// Declared strongest-first, matching the order [`attribute`] and
+/// [`claim_by_metadata`] try them in — a port reachable by two routes is filed
+/// by the strongest, and the row carries which one so a surprising grouping
+/// can be explained rather than argued with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Attribution {
+    /// The pid sits inside a terminal this window owns.
+    Terminal,
+    /// The process's working directory is inside the project.
+    Cwd,
+    /// The project's path appears in the process's arguments.
+    Command,
+}
+
+/// What a process was, as far as the kernel would say.
+///
+/// All three fields are best-effort and independently absent: a process can
+/// refuse its working directory (another user's), its arguments (Windows), or
+/// both, and still be a perfectly real listener worth showing.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PidMeta {
+    /// Executable name, or empty when the kernel would not name it.
+    pub name: String,
+    pub cwd: Option<PathBuf>,
+    /// The argument vector, `argv[0]` included.
+    pub argv: Vec<String>,
+}
+
 /// A listening port, attributed.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PortRow {
     pub port: u16,
     pub pid: u32,
-    /// Executable name of the listening process, or empty when the walk saw
-    /// the pid but not a name for it.
+    /// Executable name of the listening process, or empty when neither the
+    /// tree walk nor the metadata read produced one.
     pub process: String,
     pub loopback: bool,
+    /// `None` on an external row — nothing claimed it.
+    pub attribution: Option<Attribution>,
+}
+
+impl PortRow {
+    /// Whether this row belongs to a project, and so may be acted on
+    /// destructively. External rows are read-only by design: the panel will
+    /// not offer to kill a system daemon it merely happened to notice.
+    pub fn is_owned(&self) -> bool {
+        self.attribution.is_some()
+    }
 }
 
 /// Every port found under one project.
@@ -52,44 +120,46 @@ pub struct PortGroup {
     pub rows: Vec<PortRow>,
 }
 
-/// What the panel draws: ports grouped by the project they were started in.
+/// What the panel draws: ports grouped by the project they were started in,
+/// plus everything else the machine is listening on.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct PortInventory {
     pub groups: Vec<PortGroup>,
+    /// Listeners no project claimed. Kept rather than dropped — this is the
+    /// half that answers "what already has 3000".
+    pub external: Vec<PortRow>,
 }
 
 impl PortInventory {
-    /// Total rows across every group — the status bar's metric.
+    /// Project-attributed rows. The status bar's metric, and deliberately not
+    /// the external count: a segment reading "84 ports" because the OS talks
+    /// to itself is a number nobody can act on.
     pub fn total(&self) -> usize {
         self.groups.iter().map(|g| g.rows.len()).sum()
     }
 
+    pub fn external_count(&self) -> usize {
+        self.external.len()
+    }
+
+    /// Nothing at all to draw — no owned rows *and* no external ones.
     pub fn is_empty(&self) -> bool {
-        self.groups.is_empty()
+        self.groups.is_empty() && self.external.is_empty()
     }
 }
 
-/// Every pid in `trees`, deduplicated — the set to ask the kernel about.
-pub fn candidate_pids(trees: &[TreeSnapshot]) -> Vec<u32> {
-    let mut pids: Vec<u32> = trees
-        .iter()
-        .flat_map(|t| t.procs.iter().map(|(pid, _)| *pid))
-        .collect();
-    pids.sort_unstable();
-    pids.dedup();
-    pids
-}
-
-/// Group `ports` by the project whose tree owns each one.
+/// Group `ports` by the project each one can be attributed to.
 ///
-/// A port with no owning tree is dropped rather than shown as unattributed.
-/// The pid set handed to the kernel came *from* these trees, so a port
-/// arriving without one means the process exited mid-scan — and a row that
-/// says "something, somewhere, is listening on 3000" helps nobody.
-///
-/// Projects with nothing listening are omitted entirely: an empty group is a
-/// heading with nothing under it, which reads as a bug.
-pub fn attribute(trees: &[TreeSnapshot], ports: &[ListeningPort]) -> PortInventory {
+/// `trees` supplies the strongest evidence and `roots` the other two; `meta`
+/// is what the kernel said about each listening pid. Projects with nothing
+/// listening are omitted entirely: an empty group is a heading with nothing
+/// under it, which reads as a bug.
+pub fn attribute(
+    trees: &[TreeSnapshot],
+    roots: &[PathBuf],
+    ports: &[ListeningPort],
+    meta: &HashMap<u32, PidMeta>,
+) -> PortInventory {
     // pid → (project, process name). Built once; a port is then a lookup.
     let mut owner: HashMap<u32, (&Path, &str)> = HashMap::new();
     for tree in trees {
@@ -104,20 +174,34 @@ pub fn attribute(trees: &[TreeSnapshot], ports: &[ListeningPort]) -> PortInvento
         }
     }
 
-    let mut by_project: Vec<(&Path, Vec<PortRow>)> = Vec::new();
+    let mut by_project: Vec<(PathBuf, Vec<PortRow>)> = Vec::new();
+    let mut external: Vec<PortRow> = Vec::new();
     for port in ports {
-        let Some(&(project, process)) = owner.get(&port.pid) else {
-            continue;
-        };
+        let meta = meta.get(&port.pid);
+        let tree_owner = owner.get(&port.pid);
+        let process = tree_owner
+            .map(|(_, name)| (*name).to_string())
+            .filter(|name| !name.is_empty())
+            .or_else(|| meta.map(|m| m.name.clone()))
+            .unwrap_or_default();
+
+        let claim = tree_owner
+            .map(|(project, _)| (project.to_path_buf(), Attribution::Terminal))
+            .or_else(|| meta.and_then(|meta| claim_by_metadata(meta, roots)));
+
         let row = PortRow {
             port: port.port,
             pid: port.pid,
-            process: process.to_string(),
+            process,
             loopback: port.loopback,
+            attribution: claim.as_ref().map(|(_, how)| *how),
         };
-        match by_project.iter_mut().find(|(p, _)| *p == project) {
-            Some((_, rows)) => rows.push(row),
-            None => by_project.push((project, vec![row])),
+        match claim {
+            Some((project, _)) => match by_project.iter_mut().find(|(p, _)| *p == project) {
+                Some((_, rows)) => rows.push(row),
+                None => by_project.push((project, vec![row])),
+            },
+            None => external.push(row),
         }
     }
 
@@ -125,31 +209,129 @@ pub fn attribute(trees: &[TreeSnapshot], ports: &[ListeningPort]) -> PortInvento
         .into_iter()
         .map(|(project, mut rows)| {
             rows.sort_by_key(|r| (r.port, r.pid));
-            PortGroup {
-                project: project.to_path_buf(),
-                rows,
-            }
+            PortGroup { project, rows }
         })
         .collect();
     // Stable heading order: the panel is re-rendered every poll, and a list
     // whose sections reshuffle under the cursor is unusable.
     groups.sort_by(|a, b| a.project.cmp(&b.project));
-    PortInventory { groups }
+    external.sort_by_key(|r| (r.port, r.pid));
+    PortInventory { groups, external }
 }
 
-/// Walk `roots` down to their listening ports. **Blocking — background
-/// executor only.**
+/// The strongest claim `roots` can make on a process, by working directory
+/// first and arguments second.
+fn claim_by_metadata(meta: &PidMeta, roots: &[PathBuf]) -> Option<(PathBuf, Attribution)> {
+    if let Some(cwd) = &meta.cwd
+        && let Some(root) = deepest_containing(roots, cwd)
+    {
+        return Some((root, Attribution::Cwd));
+    }
+    // Arguments are weaker evidence on purpose: a path can appear in a command
+    // line for reasons other than being where the server runs (a `--config`
+    // pointing into a sibling checkout, say). It is checked only when the
+    // working directory said nothing, and never overrides it.
+    let claimed = meta
+        .argv
+        .iter()
+        .filter_map(|arg| deepest_containing(roots, Path::new(argument_path(arg))))
+        .max_by_key(|root| root.as_os_str().len())?;
+    Some((claimed, Attribution::Command))
+}
+
+/// The path half of one command-line argument.
 ///
-/// `roots` is `(project working directory, terminal shell pid)`, as
-/// `ProjectPanes::terminal_roots` reports it.
+/// `--prefix=/work/api` carries a path that `Path::new` on the whole argument
+/// would never match, and splitting on the first `=` is the only shape common
+/// enough across CLIs to be worth handling. An argument with no `=` is
+/// returned unchanged.
+fn argument_path(arg: &str) -> &str {
+    match arg.split_once('=') {
+        Some((_, value)) if value.starts_with('/') || value.contains(':') => value,
+        _ => arg,
+    }
+}
+
+/// The longest root that `path` is inside of, or is.
 ///
-/// The root itself is included in its own tree, not just its descendants: a
-/// terminal whose command replaced the shell outright — `oximux run npm start`
-/// rather than a shell that then ran it — has the listener at the root, and
-/// walking only downward would miss exactly the case a user is most likely to
-/// have set up on purpose.
-pub fn gather(roots: Vec<(PathBuf, u32)>) -> PortInventory {
-    let trees: Vec<TreeSnapshot> = roots
+/// Deepest wins because project roots nest: a worktree lives under its
+/// repository, and a server running in the worktree belongs to the worktree.
+/// Compared by [`Path::starts_with`], which is component-wise — `/work/apiv2`
+/// is not inside `/work/api`, and a substring test would say it was.
+fn deepest_containing(roots: &[PathBuf], path: &Path) -> Option<PathBuf> {
+    roots
+        .iter()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.as_os_str().len())
+        .cloned()
+}
+
+/// What the kernel said about each listening pid, remembered between polls.
+///
+/// The socket read is cheap and the metadata behind it is not: resolving a
+/// working directory and an argument vector is two syscalls per process, and
+/// a machine-wide scan sees every listener on the box. On a quiet machine the
+/// same servers keep listening, so re-deriving that every few seconds would be
+/// paying repeatedly for an answer that has not changed.
+///
+/// Entries are dropped as soon as their pid stops listening, which bounds the
+/// map to what is currently on screen and keeps a recycled pid from inheriting
+/// the identity of a process that exited long ago. A pid recycled *while still
+/// listening* would still be mislabelled for one poll — which is why
+/// [`super::kill`] re-checks the process it is about to stop rather than
+/// trusting a rendered row.
+#[derive(Default)]
+pub struct PidMetaCache {
+    by_pid: HashMap<u32, PidMeta>,
+}
+
+impl PidMetaCache {
+    /// Metadata for every pid in `pids`, reading only the ones not already
+    /// known and forgetting every pid not asked about.
+    pub fn resolve(&mut self, pids: &[u32]) -> &HashMap<u32, PidMeta> {
+        self.by_pid.retain(|pid, _| pids.contains(pid));
+        for &pid in pids {
+            self.by_pid.entry(pid).or_insert_with(|| read_meta(pid));
+        }
+        &self.by_pid
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_pid.len()
+    }
+}
+
+/// One process's identity, straight from the kernel. **Blocking.**
+fn read_meta(pid: u32) -> PidMeta {
+    PidMeta {
+        name: oximux_proc_tree::process(pid)
+            .map(|p| p.name)
+            .unwrap_or_default(),
+        cwd: oximux_proc_cwd::cwd_of_pid(pid),
+        argv: oximux_proc_tree::argv_of_pid(pid).unwrap_or_default(),
+    }
+}
+
+/// Read the socket table and attribute it. **Blocking — background executor
+/// only.**
+///
+/// `terminal_roots` is `(project working directory, terminal shell pid)`, as
+/// `ProjectPanes::terminal_roots` reports it; `project_roots` is every project
+/// and worktree path this window knows about, whether or not it has a terminal
+/// open.
+///
+/// Each terminal's root is included in its own tree, not just its descendants:
+/// a terminal whose command replaced the shell outright — `oximux run npm
+/// start` rather than a shell that then ran it — has the listener at the root,
+/// and walking only downward would miss exactly the case a user is most likely
+/// to have set up on purpose.
+pub fn gather(
+    terminal_roots: Vec<(PathBuf, u32)>,
+    project_roots: Vec<PathBuf>,
+    cache: &mut PidMetaCache,
+) -> PortInventory {
+    let trees: Vec<TreeSnapshot> = terminal_roots
         .into_iter()
         .map(|(project, root)| {
             let mut procs: Vec<(u32, String)> = oximux_proc_tree::process(root)
@@ -165,8 +347,14 @@ pub fn gather(roots: Vec<(PathBuf, u32)>) -> PortInventory {
             TreeSnapshot { project, procs }
         })
         .collect();
-    let ports = oximux_proc_ports::listening_ports_of(&candidate_pids(&trees));
-    attribute(&trees, &ports)
+    let ports = oximux_proc_ports::listening_ports();
+    // Only listening pids get metadata read for them. The socket table is the
+    // filter that keeps a machine-wide scan from becoming a process census.
+    let mut pids: Vec<u32> = ports.iter().map(|p| p.pid).collect();
+    pids.sort_unstable();
+    pids.dedup();
+    let meta = cache.resolve(&pids);
+    attribute(&trees, &project_roots, &ports, meta)
 }
 
 #[cfg(test)]
@@ -188,26 +376,148 @@ mod tests {
         }
     }
 
+    fn roots(paths: &[&str]) -> Vec<PathBuf> {
+        paths.iter().map(PathBuf::from).collect()
+    }
+
+    fn meta_of(entries: &[(u32, &str, Option<&str>, &[&str])]) -> HashMap<u32, PidMeta> {
+        entries
+            .iter()
+            .map(|(pid, name, cwd, argv)| {
+                (
+                    *pid,
+                    PidMeta {
+                        name: (*name).to_string(),
+                        cwd: cwd.map(PathBuf::from),
+                        argv: argv.iter().map(|a| (*a).to_string()).collect(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn no_meta() -> HashMap<u32, PidMeta> {
+        HashMap::new()
+    }
+
     #[test]
     fn a_port_lands_under_the_project_whose_tree_holds_it() {
         let trees = vec![
             tree("/work/api", &[(10, "bash"), (11, "node")]),
             tree("/work/web", &[(20, "bash"), (21, "vite")]),
         ];
-        let inv = attribute(&trees, &[port(21, 5173), port(11, 3000)]);
+        let inv = attribute(&trees, &[], &[port(21, 5173), port(11, 3000)], &no_meta());
         assert_eq!(inv.groups.len(), 2);
         assert_eq!(inv.groups[0].project, PathBuf::from("/work/api"));
         assert_eq!(inv.groups[0].rows[0].port, 3000);
         assert_eq!(inv.groups[0].rows[0].process, "node");
+        assert_eq!(
+            inv.groups[0].rows[0].attribution,
+            Some(Attribution::Terminal)
+        );
         assert_eq!(inv.groups[1].project, PathBuf::from("/work/web"));
         assert_eq!(inv.groups[1].rows[0].port, 5173);
     }
 
     #[test]
-    fn a_port_nobody_owns_is_not_shown() {
+    fn a_port_nobody_owns_is_external_rather_than_dropped() {
         let trees = vec![tree("/work/api", &[(10, "bash")])];
-        // pid 99 exited between the walk and the socket read.
-        assert!(attribute(&trees, &[port(99, 3000)]).is_empty());
+        // The whole point of the machine-wide scan: a listener the window did
+        // not start is still worth seeing.
+        let inv = attribute(&trees, &[], &[port(99, 3000)], &no_meta());
+        assert!(inv.groups.is_empty());
+        assert_eq!(inv.external.len(), 1);
+        assert_eq!(inv.external[0].port, 3000);
+        assert_eq!(inv.external[0].attribution, None);
+        assert!(!inv.external[0].is_owned());
+        assert!(!inv.is_empty(), "an external row is still something to draw");
+    }
+
+    #[test]
+    fn a_working_directory_inside_a_project_claims_the_port() {
+        // Started in another terminal app entirely: no tree contains it.
+        let meta = meta_of(&[(50, "node", Some("/work/api/src"), &[])]);
+        let inv = attribute(&[], &roots(&["/work/api"]), &[port(50, 3000)], &meta);
+        assert_eq!(inv.groups.len(), 1);
+        assert_eq!(inv.groups[0].project, PathBuf::from("/work/api"));
+        assert_eq!(inv.groups[0].rows[0].attribution, Some(Attribution::Cwd));
+        assert_eq!(inv.groups[0].rows[0].process, "node");
+    }
+
+    #[test]
+    fn a_sibling_directory_with_a_shared_prefix_is_not_inside_the_project() {
+        // `/work/apiv2` starts with the string `/work/api` and is not under it.
+        let meta = meta_of(&[(50, "node", Some("/work/apiv2"), &[])]);
+        let inv = attribute(&[], &roots(&["/work/api"]), &[port(50, 3000)], &meta);
+        assert!(inv.groups.is_empty(), "path containment is by component");
+        assert_eq!(inv.external.len(), 1);
+    }
+
+    #[test]
+    fn the_deepest_matching_root_wins() {
+        // A worktree lives under its repository; the server is the worktree's.
+        let meta = meta_of(&[(50, "node", Some("/work/api/wt/feature/src"), &[])]);
+        let inv = attribute(
+            &[],
+            &roots(&["/work/api", "/work/api/wt/feature"]),
+            &[port(50, 3000)],
+            &meta,
+        );
+        assert_eq!(inv.groups[0].project, PathBuf::from("/work/api/wt/feature"));
+    }
+
+    #[test]
+    fn a_project_path_in_the_arguments_claims_a_port_the_cwd_did_not() {
+        let meta = meta_of(&[(
+            50,
+            "node",
+            Some("/"),
+            &["node", "/work/api/server.js"],
+        )]);
+        let inv = attribute(&[], &roots(&["/work/api"]), &[port(50, 3000)], &meta);
+        assert_eq!(inv.groups[0].project, PathBuf::from("/work/api"));
+        assert_eq!(inv.groups[0].rows[0].attribution, Some(Attribution::Command));
+    }
+
+    #[test]
+    fn a_path_behind_a_flag_is_still_a_path() {
+        let meta = meta_of(&[(50, "npm", Some("/"), &["npm", "--prefix=/work/api", "start"])]);
+        let inv = attribute(&[], &roots(&["/work/api"]), &[port(50, 3000)], &meta);
+        assert_eq!(inv.groups[0].rows[0].attribution, Some(Attribution::Command));
+    }
+
+    #[test]
+    fn the_working_directory_outranks_the_arguments() {
+        // Running in /work/web with a config path pointing into /work/api: the
+        // server is the web one, and the argument must not move it.
+        let meta = meta_of(&[(
+            50,
+            "node",
+            Some("/work/web"),
+            &["node", "--config", "/work/api/shared.json"],
+        )]);
+        let inv = attribute(
+            &[],
+            &roots(&["/work/api", "/work/web"]),
+            &[port(50, 3000)],
+            &meta,
+        );
+        assert_eq!(inv.groups[0].project, PathBuf::from("/work/web"));
+        assert_eq!(inv.groups[0].rows[0].attribution, Some(Attribution::Cwd));
+    }
+
+    #[test]
+    fn a_terminal_tree_outranks_a_working_directory() {
+        // The user started it here, in a terminal whose group cwd is the
+        // worktree; a stale-looking cwd elsewhere must not relocate the row.
+        let trees = vec![tree("/work/api", &[(50, "node")])];
+        let meta = meta_of(&[(50, "node", Some("/work/web"), &[])]);
+        let inv = attribute(&trees, &roots(&["/work/web"]), &[port(50, 3000)], &meta);
+        assert_eq!(inv.groups[0].project, PathBuf::from("/work/api"));
+        assert_eq!(
+            inv.groups[0].rows[0].attribution,
+            Some(Attribution::Terminal)
+        );
     }
 
     #[test]
@@ -216,7 +526,7 @@ mod tests {
             tree("/work/api", &[(10, "bash"), (11, "node")]),
             tree("/work/quiet", &[(20, "bash")]),
         ];
-        let inv = attribute(&trees, &[port(11, 3000)]);
+        let inv = attribute(&trees, &[], &[port(11, 3000)], &no_meta());
         assert_eq!(inv.groups.len(), 1, "an empty section reads as a bug");
         assert_eq!(inv.groups[0].project, PathBuf::from("/work/api"));
     }
@@ -227,7 +537,7 @@ mod tests {
             tree("/work/api", &[(10, "bash"), (11, "node")]),
             tree("/work/api", &[(20, "bash"), (21, "node")]),
         ];
-        let inv = attribute(&trees, &[port(11, 3000), port(21, 3001)]);
+        let inv = attribute(&trees, &[], &[port(11, 3000), port(21, 3001)], &no_meta());
         assert_eq!(inv.groups.len(), 1);
         assert_eq!(
             inv.groups[0].rows.iter().map(|r| r.port).collect::<Vec<_>>(),
@@ -238,9 +548,28 @@ mod tests {
     #[test]
     fn rows_are_ordered_by_port_not_by_discovery() {
         let trees = vec![tree("/work/api", &[(10, "a"), (11, "b"), (12, "c")])];
-        let inv = attribute(&trees, &[port(12, 9229), port(10, 3000), port(11, 5173)]);
+        let inv = attribute(
+            &trees,
+            &[],
+            &[port(12, 9229), port(10, 3000), port(11, 5173)],
+            &no_meta(),
+        );
         assert_eq!(
             inv.groups[0].rows.iter().map(|r| r.port).collect::<Vec<_>>(),
+            vec![3000, 5173, 9229]
+        );
+    }
+
+    #[test]
+    fn external_rows_are_ordered_by_port_too() {
+        let inv = attribute(
+            &[],
+            &[],
+            &[port(12, 9229), port(10, 3000), port(11, 5173)],
+            &no_meta(),
+        );
+        assert_eq!(
+            inv.external.iter().map(|r| r.port).collect::<Vec<_>>(),
             vec![3000, 5173, 9229]
         );
     }
@@ -251,8 +580,8 @@ mod tests {
         let a = tree("/work/api", &[(10, "node")]);
         let b = tree("/work/web", &[(20, "vite")]);
         let ports = [port(10, 3000), port(20, 5173)];
-        let forward = attribute(&[a.clone(), b.clone()], &ports);
-        let backward = attribute(&[b, a], &ports);
+        let forward = attribute(&[a.clone(), b.clone()], &[], &ports, &no_meta());
+        let backward = attribute(&[b, a], &[], &ports, &no_meta());
         assert_eq!(forward, backward);
     }
 
@@ -264,33 +593,57 @@ mod tests {
             tree("/work/outer", &[(10, "bash"), (11, "node")]),
             tree("/work/inner", &[(11, "node")]),
         ];
-        let inv = attribute(&trees, &[port(11, 3000)]);
+        let inv = attribute(&trees, &[], &[port(11, 3000)], &no_meta());
         assert_eq!(inv.total(), 1);
         assert_eq!(inv.groups[0].project, PathBuf::from("/work/outer"));
     }
 
     #[test]
-    fn the_pid_set_is_every_tree_deduplicated() {
-        let trees = vec![
-            tree("/work/api", &[(10, "bash"), (11, "node")]),
-            tree("/work/web", &[(11, "node"), (20, "bash")]),
-        ];
-        assert_eq!(candidate_pids(&trees), vec![10, 11, 20]);
+    fn the_metric_counts_owned_rows_and_the_external_count_is_separate() {
+        let trees = vec![tree("/work/api", &[(10, "node"), (11, "node")])];
+        let inv = attribute(
+            &trees,
+            &[],
+            &[port(10, 3000), port(11, 3001), port(99, 5432)],
+            &no_meta(),
+        );
+        assert_eq!(inv.total(), 2, "the status bar counts what the user started");
+        assert_eq!(inv.external_count(), 1);
     }
 
     #[test]
-    fn no_trees_means_nothing_to_ask_about() {
-        assert!(candidate_pids(&[]).is_empty());
-        assert!(attribute(&[], &[port(10, 3000)]).is_empty());
+    fn nothing_listening_anywhere_is_the_only_empty_inventory() {
+        assert!(attribute(&[], &[], &[], &no_meta()).is_empty());
     }
 
     #[test]
-    fn the_total_counts_rows_across_every_group() {
-        let trees = vec![
-            tree("/work/api", &[(10, "node"), (11, "node")]),
-            tree("/work/web", &[(20, "vite")]),
-        ];
-        let inv = attribute(&trees, &[port(10, 3000), port(11, 3001), port(20, 5173)]);
-        assert_eq!(inv.total(), 3);
+    fn a_row_takes_its_name_from_the_metadata_when_no_tree_named_it() {
+        let meta = meta_of(&[(50, "postgres", None, &[])]);
+        let inv = attribute(&[], &[], &[port(50, 5432)], &meta);
+        assert_eq!(inv.external[0].process, "postgres");
+    }
+
+    #[test]
+    fn a_pid_that_stopped_listening_is_forgotten() {
+        // Otherwise the map grows for the life of the window, and a recycled
+        // pid inherits the identity of something that exited long ago.
+        let mut cache = PidMetaCache::default();
+        let me = std::process::id();
+        cache.resolve(&[me]);
+        assert_eq!(cache.len(), 1);
+        cache.resolve(&[]);
+        assert_eq!(cache.len(), 0);
+    }
+
+    /// Against the real kernel: our own process must resolve to something
+    /// nameable with a working directory. Guards the metadata read from
+    /// silently returning blanks, which would make every row unattributable.
+    #[test]
+    fn our_own_process_resolves_to_real_metadata() {
+        let mut cache = PidMetaCache::default();
+        let me = std::process::id();
+        let meta = cache.resolve(&[me]).get(&me).cloned().expect("our own pid");
+        assert!(!meta.name.is_empty(), "the kernel names our own process");
+        assert!(meta.cwd.is_some(), "our own working directory is readable");
     }
 }

--- a/apps/desktop/src/workspace_root/mod.rs
+++ b/apps/desktop/src/workspace_root/mod.rs
@@ -58,14 +58,23 @@ const LAYOUT_AUTOSAVE_TICK: Duration = Duration::from_secs(15);
 /// ~2 s" without measurable IO churn.
 const AGENT_ACTIVITY_TICK: Duration = Duration::from_secs(2);
 
-/// Cadence of the listening-ports scan. Set by how long it is tolerable to
-/// wait after `npm run dev` prints its URL — a couple of seconds reads as
-/// "immediately", ten does not — rather than by cost: the socket read is one
-/// kernel call on Windows and one small `/proc` read on Linux. Like the diff
-/// refresh, it pauses while the window is unfocused and is kicked once on
-/// focus regain, so a server started while you were away is listed by the
-/// time you have looked back.
-const PORT_SCAN_TICK: Duration = Duration::from_secs(3);
+/// Cadence of the listening-ports scan.
+///
+/// Set by how long it is tolerable to wait after `npm run dev` prints its URL
+/// — a few seconds reads as "immediately", ten does not — traded against a
+/// cost that is no longer negligible. The scan reads the whole machine's
+/// socket table now rather than a handful of pids (see
+/// [`crate::shell::ports_panel::scan`] for why), which is a `lsof` spawn on
+/// macOS and a `/proc` pass on Linux: measured at ~50ms on a laptop with
+/// eighty listeners. At this cadence that is well under a percent of one core,
+/// and the per-pid metadata behind it is cached across polls so a steady state
+/// costs only the socket read.
+///
+/// Like the diff refresh, it pauses while the window is unfocused and is
+/// kicked once on focus regain, so a server started while you were away is
+/// listed by the time you have looked back. The panel's Rescan button is the
+/// out-of-cadence escape hatch for the seconds in between.
+const PORT_SCAN_TICK: Duration = Duration::from_secs(5);
 
 /// Cadence of the usage-meter sample. The probe re-parses only logs whose
 /// (mtime, len) changed since the previous sample, so a steady-state tick
@@ -498,6 +507,14 @@ pub struct WorkspaceRoot {
     /// background executor, and a slow one must not have a second stacked
     /// behind it.
     pub(crate) port_scan_in_flight: bool,
+    /// What the kernel said about each listening pid, kept between polls.
+    ///
+    /// Lives on the root rather than in a `static` because the scan runs on
+    /// the background executor and has to carry the map with it; an `Arc` that
+    /// one place owns is testable in a way a process-wide global is not.
+    port_meta_cache: std::sync::Arc<
+        std::sync::Mutex<crate::shell::ports_panel::scan::PidMetaCache>,
+    >,
     /// Periodic listening-ports scan (focus-gated). Dropping cancels.
     _port_scan_task: Task<()>,
 }
@@ -1332,6 +1349,9 @@ impl WorkspaceRoot {
             _usage_meter_task: usage_meter_task,
             ports_panel,
             port_scan_in_flight: false,
+            port_meta_cache: std::sync::Arc::new(std::sync::Mutex::new(
+                crate::shell::ports_panel::scan::PidMetaCache::default(),
+            )),
             _port_scan_task: port_scan_task,
         };
         // Seed the sidebar's DB-backed caches (workspace rows + agent

--- a/apps/desktop/src/workspace_root/ops.rs
+++ b/apps/desktop/src/workspace_root/ops.rs
@@ -251,27 +251,63 @@ impl WorkspaceRoot {
         if self.port_scan_in_flight {
             return;
         }
-        let mut roots: Vec<(std::path::PathBuf, u32)> = Vec::new();
+        let mut terminal_roots: Vec<(std::path::PathBuf, u32)> = Vec::new();
         for panes in self.project_panes_by_project.values() {
-            roots.extend(panes.read(cx).terminal_roots(cx));
+            terminal_roots.extend(panes.read(cx).terminal_roots(cx));
         }
-        let has_terminals = !roots.is_empty();
+        let project_roots = self.port_attribution_roots();
+        let cache = self.port_meta_cache.clone();
         self.port_scan_in_flight = true;
         cx.spawn(async move |weak, cx| {
             let inventory = cx
                 .background_executor()
                 .spawn(async move {
-                    crate::shell::ports_panel::scan::gather(roots)
+                    // The cache is held across the await only by this closure,
+                    // and `port_scan_in_flight` guarantees one scan at a time,
+                    // so the lock is never contended — it is here to move the
+                    // map to the background thread, not to arbitrate.
+                    let mut cache = cache.lock().expect("port metadata cache");
+                    crate::shell::ports_panel::scan::gather(
+                        terminal_roots,
+                        project_roots,
+                        &mut cache,
+                    )
                 })
                 .await;
             let _ = weak.update(cx, |this, cx| {
                 this.port_scan_in_flight = false;
                 this.ports_panel.update(cx, |panel, cx| {
-                    panel.apply(inventory, has_terminals, cx);
+                    panel.apply(inventory, cx);
                 });
             });
         })
         .detach();
+    }
+
+    /// Every path a listening process could be running under and still count as
+    /// "one of mine": each known project root, and each of its worktrees.
+    ///
+    /// Both, not just the worktrees: a server started in the repository itself
+    /// — the common shape before anyone makes a worktree — has to land
+    /// somewhere, and the deepest-match rule in
+    /// [`crate::shell::ports_panel::scan`] means listing the parent cannot
+    /// steal a row from the worktree underneath it.
+    fn port_attribution_roots(&self) -> Vec<std::path::PathBuf> {
+        let mut roots: Vec<std::path::PathBuf> = Vec::new();
+        for project in &self.app_state.recent_projects {
+            roots.push(std::path::PathBuf::from(&project.root_path));
+            for workspace in self
+                .rail_workspaces_by_project
+                .get(&project.id)
+                .into_iter()
+                .flatten()
+            {
+                roots.push(std::path::PathBuf::from(&workspace.worktree_path));
+            }
+        }
+        roots.sort();
+        roots.dedup();
+        roots
     }
 
     /// Open Settings at the About pane — version, install paths, and every

--- a/crates/proc-ports/src/lib.rs
+++ b/crates/proc-ports/src/lib.rs
@@ -13,19 +13,27 @@
 //! both of those are: dependency-light kernel introspection whose consumers
 //! share nothing else with each other.
 //!
-//! ## Why the query takes a pid set
+//! ## Two queries, and why both exist
 //!
-//! [`listening_ports_of`] answers for pids the caller names rather than
-//! returning every listener on the machine. Two reasons, the second decisive:
+//! [`listening_ports_of`] answers for pids the caller names;
+//! [`listening_ports`] answers for the whole machine. They are the same read
+//! with and without a filter, and the choice is a real trade:
 //!
-//! * A caller only wants ports it can attribute to a terminal it owns. A panel
-//!   that also listed the OS's own listeners would be a security dashboard
-//!   nobody asked for, and it would bury the one row that matters.
-//! * On Linux the owning pid is *not in the socket table*. `/proc/net/tcp`
-//!   names an inode, and turning an inode into a pid means reading
-//!   `/proc/<pid>/fd` for every process on the system. Scoped to a handful of
-//!   candidates that is a few dozen `readlink` calls; unscoped it is thousands
-//!   of them, on a cadence, forever.
+//! * The scoped query is cheap and self-limiting. On Linux especially: the
+//!   owning pid is *not in the socket table*, so `/proc/net/tcp` names an
+//!   inode and turning an inode into a pid means reading `/proc/<pid>/fd`.
+//!   Scoped to a handful of candidates that is a few dozen `readlink` calls;
+//!   unscoped it is one pass over every process on the system.
+//! * The unscoped query is the only one that can see a server the caller did
+//!   not start — a dev server launched from another terminal app, a database
+//!   in a container, a daemon holding the port a build is about to want. A
+//!   caller that only ever asks about its own children cannot tell "nothing is
+//!   running" apart from "it is running, somewhere else", and those are
+//!   different answers to the only question a person opens a ports list to ask.
+//!
+//! Attribution — deciding which of those rows belongs to which of the caller's
+//! projects — is the caller's job, not this crate's. This crate reports what
+//! the kernel says and stops there.
 //!
 //! ## Per platform
 //!
@@ -99,7 +107,23 @@ pub fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
     wanted.sort_unstable();
     wanted.dedup();
     wanted.truncate(MAX_PIDS);
-    collapse(imp::listening_ports_of(&wanted))
+    collapse(imp::listening_ports(Some(&wanted)))
+}
+
+/// Every local TCP port anything on this machine is listening on.
+///
+/// The unscoped sibling of [`listening_ports_of`], with the same guarantees
+/// about the result — one row per pid+port, sorted, empty rather than an error
+/// — and the same silence about failure.
+///
+/// Costs more than the scoped query, and how much more is platform-shaped:
+/// on macOS and Windows it is the identical single call with the filter left
+/// off, while on Linux it adds a pass over every readable `/proc/<pid>/fd`.
+/// Callers polling this on a cadence should cache what they derive *from* each
+/// pid (name, working directory, argument vector) rather than re-deriving it,
+/// because that — not this call — is where an unscoped scan gets expensive.
+pub fn listening_ports() -> Vec<ListeningPort> {
+    collapse(imp::listening_ports(None))
 }
 
 /// Fold per-socket rows into one row per pid+port.

--- a/crates/proc-ports/src/linux.rs
+++ b/crates/proc-ports/src/linux.rs
@@ -1,17 +1,24 @@
 //! Linux listening sockets via `/proc/net/tcp` and the candidates' fd links.
 //!
-//! Linux is the platform that makes this crate's scoped API necessary. The
-//! socket table names an *inode*, never an owner, so the pid has to be found
-//! by asking which process holds a file descriptor pointing at that inode —
-//! and the only way to ask is to read the fd directory of a process and see.
-//! Doing that for every process on the machine, every poll, is the design this
-//! crate exists to avoid; doing it for the caller's handful of candidates is a
-//! few dozen `readlink` calls.
+//! Linux is the platform where the scoped and unscoped queries genuinely
+//! differ. The socket table names an *inode*, never an owner, so the pid has
+//! to be found by asking which process holds a file descriptor pointing at
+//! that inode — and the only way to ask is to read the fd directory of a
+//! process and see. For the caller's handful of candidates that is a few dozen
+//! `readlink` calls; for the whole machine it is one pass over `/proc`.
 //!
-//! The order matters: the socket table is read *first*, so the inode set is
-//! small and the fd walk is a hash lookup per descriptor rather than a scan.
+//! The order matters, and it is what keeps the unscoped pass affordable: the
+//! socket table is read *first*, so the inode set is small and every
+//! descriptor examined is a hash lookup rather than a scan. The walk also
+//! stops as soon as every listening inode has an owner — on a normal machine
+//! that is long before `/proc` runs out of processes.
+//!
+//! Processes owned by another user answer `EACCES` and are skipped. Their
+//! ports are still reported by [`crate::listening_ports`] where the socket
+//! table lists them, they simply arrive without an owning pid to name — so
+//! nothing is invented, and the row is dropped rather than misattributed.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ListeningPort;
 use crate::parse;
@@ -24,7 +31,7 @@ use crate::parse;
 /// matter.
 const MAX_FDS: usize = 4096;
 
-pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
+pub(crate) fn listening_ports(pids: Option<&[u32]>) -> Vec<ListeningPort> {
     let mut sockets: HashMap<u64, (u16, bool)> = HashMap::new();
     for table in ["/proc/net/tcp", "/proc/net/tcp6"] {
         // A missing table is an IPv6-less kernel, not a failure.
@@ -39,10 +46,26 @@ pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
         return Vec::new();
     }
 
+    let candidates: Vec<u32> = match pids {
+        Some(pids) => pids.to_vec(),
+        None => all_pids(),
+    };
+
     let mut out = Vec::new();
-    for &pid in pids {
+    // Inodes that have found an owner. An unscoped walk can stop once every
+    // listening inode is in here — the inodes are the question, and the
+    // remaining processes have nothing left to answer. A set rather than a
+    // countdown because one process can hold the same socket on two
+    // descriptors (a server that `dup`ed its listener), and counting those
+    // twice would end the walk with sockets still unattributed.
+    let mut claimed: HashSet<u64> = HashSet::with_capacity(sockets.len());
+    for pid in candidates {
+        if claimed.len() == sockets.len() {
+            break;
+        }
         // A process that exited between the caller's tree walk and this read
-        // is the common case, not an error.
+        // is the common case, not an error. So is another user's process,
+        // which answers `EACCES`.
         let Ok(dir) = std::fs::read_dir(format!("/proc/{pid}/fd")) else {
             continue;
         };
@@ -55,10 +78,31 @@ pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
             };
             if let Some(&(port, loopback)) = sockets.get(&inode) {
                 out.push(ListeningPort { pid, port, loopback });
+                claimed.insert(inode);
             }
         }
     }
     out
+}
+
+/// Every pid `/proc` currently names.
+///
+/// Sorted, because the walk stops early once every listening inode has an
+/// owner and directory order is not stable across reads — an unsorted walk
+/// would attribute a socket shared by a parent and a forked worker to
+/// whichever of them the filesystem happened to list first, and that answer
+/// would change between polls. Ascending pid means the parent, which is the
+/// older process, is found first.
+fn all_pids() -> Vec<u32> {
+    let Ok(dir) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut pids: Vec<u32> = dir
+        .flatten()
+        .filter_map(|entry| entry.file_name().to_string_lossy().parse().ok())
+        .collect();
+    pids.sort_unstable();
+    pids
 }
 
 #[cfg(test)]
@@ -74,7 +118,7 @@ mod tests {
         let port = listener.local_addr().expect("local addr").port();
         let me = std::process::id();
 
-        let found = listening_ports_of(&[me]);
+        let found = listening_ports(Some(&[me]));
         let ours = found
             .iter()
             .find(|p| p.port == port)
@@ -88,8 +132,22 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
         let port = listener.local_addr().expect("local addr").port();
         assert!(
-            !listening_ports_of(&[u32::MAX]).iter().any(|p| p.port == port),
+            !listening_ports(Some(&[u32::MAX])).iter().any(|p| p.port == port),
             "the fd walk is scoped to the pids asked for"
+        );
+    }
+
+    /// The unscoped query must find the same socket without being told whose
+    /// it is — the half that makes a port started outside the app visible.
+    #[test]
+    fn an_unscoped_query_finds_a_listener_it_was_not_told_about() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        assert!(
+            listening_ports(None)
+                .iter()
+                .any(|p| p.port == port && p.pid == std::process::id()),
+            "a full /proc walk must reach our own fd table"
         );
     }
 }

--- a/crates/proc-ports/src/linux.rs
+++ b/crates/proc-ports/src/linux.rs
@@ -52,15 +52,25 @@ pub(crate) fn listening_ports(pids: Option<&[u32]>) -> Vec<ListeningPort> {
     };
 
     let mut out = Vec::new();
-    // Inodes that have found an owner. An unscoped walk can stop once every
-    // listening inode is in here — the inodes are the question, and the
-    // remaining processes have nothing left to answer. A set rather than a
-    // countdown because one process can hold the same socket on two
-    // descriptors (a server that `dup`ed its listener), and counting those
-    // twice would end the walk with sockets still unattributed.
+    // Inodes that have found an owner. A set rather than a countdown because
+    // one process can hold the same socket on two descriptors (a server that
+    // `dup`ed its listener), and counting those twice would end the walk with
+    // sockets still unattributed.
     let mut claimed: HashSet<u64> = HashSet::with_capacity(sockets.len());
+    // Only an *unscoped* walk may stop once every listening inode has an
+    // owner. It is walking the whole process table to answer a question about
+    // inodes, so once none are left there is nothing further to learn — and
+    // that early exit is the entire reason the unscoped pass is affordable.
+    //
+    // A scoped walk must not take that shortcut. Its candidate list is a
+    // handful of pids, so the exit saves nothing, and it can lose a row: a
+    // parent and a forked child share one *inode* for an inherited listener,
+    // so the first of them claims it and the second would never be examined.
+    // `collapse` deliberately keeps both of those as separate rows, and this
+    // is the only place that could quietly drop one.
+    let may_stop_early = pids.is_none();
     for pid in candidates {
-        if claimed.len() == sockets.len() {
+        if may_stop_early && claimed.len() == sockets.len() {
             break;
         }
         // A process that exited between the caller's tree walk and this read

--- a/crates/proc-ports/src/macos.rs
+++ b/crates/proc-ports/src/macos.rs
@@ -13,6 +13,10 @@
 //! this slow and lossy, `-iTCP -sTCP:LISTEN` narrows to listeners, `-a`
 //! combines that with `-p` rather than unioning with it, and `-F pn` selects
 //! the two fields the parser reads.
+//!
+//! The unscoped query is the same command with `-a -p <list>` left off. It is
+//! not meaningfully more expensive here — `lsof` walks every process either
+//! way to answer `-iTCP`, and the filter only decides what it prints.
 
 use std::process::{Command, Stdio};
 
@@ -27,14 +31,20 @@ use crate::parse;
 /// is the worst of both.
 const LSOF: &str = "/usr/sbin/lsof";
 
-pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
-    let list = pids
-        .iter()
-        .map(u32::to_string)
-        .collect::<Vec<_>>()
-        .join(",");
+pub(crate) fn listening_ports(pids: Option<&[u32]>) -> Vec<ListeningPort> {
+    let list = pids.map(|pids| {
+        pids.iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    });
+    let mut args: Vec<&str> = vec!["-nP", "-iTCP", "-sTCP:LISTEN"];
+    if let Some(list) = list.as_deref() {
+        args.extend(["-a", "-p", list]);
+    }
+    args.extend(["-F", "pn"]);
     let output = Command::new(LSOF)
-        .args(["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", &list, "-F", "pn"])
+        .args(&args)
         .stdin(Stdio::null())
         .stderr(Stdio::null())
         .output();
@@ -47,8 +57,8 @@ pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
     parse::lsof(&text)
         .into_iter()
         // `-p` is a filter, not a promise: re-check rather than trust it, so a
-        // future flag change cannot quietly widen what this crate reports.
-        .filter(|row| pids.contains(&row.pid))
+        // future flag change cannot quietly widen what a scoped query reports.
+        .filter(|row| pids.is_none_or(|pids| pids.contains(&row.pid)))
         .map(|row| ListeningPort {
             pid: row.pid,
             port: row.port,
@@ -70,7 +80,7 @@ mod tests {
         let port = listener.local_addr().expect("local addr").port();
         let me = std::process::id();
 
-        let found = listening_ports_of(&[me]);
+        let found = listening_ports(Some(&[me]));
         let ours = found
             .iter()
             .find(|p| p.port == port)
@@ -84,8 +94,22 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
         let port = listener.local_addr().expect("local addr").port();
         assert!(
-            !listening_ports_of(&[u32::MAX]).iter().any(|p| p.port == port),
+            !listening_ports(Some(&[u32::MAX])).iter().any(|p| p.port == port),
             "the query is scoped to the pids asked for"
+        );
+    }
+
+    /// The unscoped query must find the same socket without being told whose
+    /// it is — the half that makes a port started outside the app visible.
+    #[test]
+    fn an_unscoped_query_finds_a_listener_it_was_not_told_about() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        assert!(
+            listening_ports(None)
+                .iter()
+                .any(|p| p.port == port && p.pid == std::process::id()),
+            "an unfiltered lsof must report every listener, ours included"
         );
     }
 }

--- a/crates/proc-ports/src/unsupported.rs
+++ b/crates/proc-ports/src/unsupported.rs
@@ -6,6 +6,6 @@
 
 use crate::ListeningPort;
 
-pub(crate) fn listening_ports_of(_pids: &[u32]) -> Vec<ListeningPort> {
+pub(crate) fn listening_ports(_pids: Option<&[u32]>) -> Vec<ListeningPort> {
     Vec::new()
 }

--- a/crates/proc-ports/src/windows.rs
+++ b/crates/proc-ports/src/windows.rs
@@ -26,13 +26,13 @@ use crate::ListeningPort;
 /// slow poll, and a poll that returns nothing is already a supported answer.
 const ATTEMPTS: usize = 3;
 
-pub(crate) fn listening_ports_of(pids: &[u32]) -> Vec<ListeningPort> {
+pub(crate) fn listening_ports(pids: Option<&[u32]>) -> Vec<ListeningPort> {
     let mut out = v4(pids);
     out.extend(v6(pids));
     out
 }
 
-fn v4(pids: &[u32]) -> Vec<ListeningPort> {
+fn v4(pids: Option<&[u32]>) -> Vec<ListeningPort> {
     let buf = table(AF_INET as u32);
     // SAFETY: `table` returns either an empty buffer or one the kernel filled
     // for this family and class, which is `MIB_TCPTABLE_OWNER_PID` by
@@ -43,7 +43,7 @@ fn v4(pids: &[u32]) -> Vec<ListeningPort> {
         return Vec::new();
     };
     rows.iter()
-        .filter(|row| pids.contains(&row.dwOwningPid))
+        .filter(|row| pids.is_none_or(|pids| pids.contains(&row.dwOwningPid)))
         .map(|row| ListeningPort {
             pid: row.dwOwningPid,
             port: port_of(row.dwLocalPort),
@@ -52,7 +52,7 @@ fn v4(pids: &[u32]) -> Vec<ListeningPort> {
         .collect()
 }
 
-fn v6(pids: &[u32]) -> Vec<ListeningPort> {
+fn v6(pids: Option<&[u32]>) -> Vec<ListeningPort> {
     let buf = table(AF_INET6 as u32);
     // SAFETY: as `v4`, for the v6 table class.
     let Some(rows) = (unsafe { rows::<MIB_TCP6TABLE_OWNER_PID, MIB_TCP6ROW_OWNER_PID>(&buf) })
@@ -60,7 +60,7 @@ fn v6(pids: &[u32]) -> Vec<ListeningPort> {
         return Vec::new();
     };
     rows.iter()
-        .filter(|row| pids.contains(&row.dwOwningPid))
+        .filter(|row| pids.is_none_or(|pids| pids.contains(&row.dwOwningPid)))
         .map(|row| ListeningPort {
             pid: row.dwOwningPid,
             port: port_of(row.dwLocalPort),
@@ -206,7 +206,7 @@ mod tests {
         let port = listener.local_addr().expect("local addr").port();
         let me = std::process::id();
 
-        let found = listening_ports_of(&[me]);
+        let found = listening_ports(Some(&[me]));
         let ours = found
             .iter()
             .find(|p| p.port == port)
@@ -220,7 +220,25 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
         let port = listener.local_addr().expect("local addr").port();
         // Scoped to a pid that is not ours, the socket we are holding must not
-        // come back — the filter is the whole contract of this crate.
-        assert!(!listening_ports_of(&[u32::MAX]).iter().any(|p| p.port == port));
+        // come back — an unscoped query is the only one allowed to widen.
+        assert!(
+            !listening_ports(Some(&[u32::MAX]))
+                .iter()
+                .any(|p| p.port == port)
+        );
+    }
+
+    /// The unscoped query must find the same socket without being told whose
+    /// it is — the half that makes a port started outside the app visible.
+    #[test]
+    fn an_unscoped_query_finds_a_listener_it_was_not_told_about() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        assert!(
+            listening_ports(None)
+                .iter()
+                .any(|p| p.port == port && p.pid == std::process::id()),
+            "the listener table is the whole machine's when no filter is given"
+        );
     }
 }


### PR DESCRIPTION
## The problem

The Ports panel walked the process trees of terminals the window owns and asked the kernel only about those pids. Everything else on the machine was invisible by design — a dev server started in another terminal app, a database in a container, the daemon already holding the port a build is about to want.

On my laptop that meant the panel read **`0 ports`** while 79 things were listening. "Nothing is running" and "it's running, somewhere else" are different answers, and this list only gets opened to settle the second one.

## The fix

**Read the socket table whole, attribute afterwards.** `proc-ports` grows an unscoped `listening_ports()` beside the existing scoped query — on macOS and Windows the same call with the filter left off, on Linux a `/proc` pass that stops as soon as every listening inode has an owner.

**Attribution replaces filtering**, strongest evidence first:
1. the pid is inside a terminal this window owns,
2. else the process's working directory is inside a known project root,
3. else the project's path appears in its argument vector.

Containment is component-wise (`/work/apiv2` is not inside `/work/api`), deepest root wins (a worktree beats the repo above it). What nothing claims becomes **External** — listed and openable, never offered a destructive action. The evidence rides on the row as a tooltip, so a surprising grouping can be explained rather than argued with.

**Owned rows gain Stop.** SIGTERM, then SIGKILL after a grace period on a background timer. It re-reads the socket table at click time and refuses unless that pid still holds that port — a rendered row is up to one poll old, and a recycled pid would otherwise get killed by mistake. The app's own pid, its parent, and pids ≤ 1 are refused outright.

**UI.** The header was borrowing `density.h_top_bar` (32px, pinned to the macOS traffic lights, window chrome's) while stacking a two-line title into it, and overflowed. It is now the file explorer's 28px single line with a ghost icon button, since those two panels share a column. Rows lead with the port, carry hover-revealed icon actions, and live in collapsible sections; External starts closed. Refresh now says it is working instead of silently no-op'ing when a scan is already in flight.

**Cost.** Per-pid metadata is cached across polls and evicted when a pid stops listening, so a steady state costs only the socket read. Poll moves 3s → 5s to match a scan that went from a handful of pids to the whole table (~50ms measured).

## Verification

- `cargo check --workspace --all-targets` under `RUSTFLAGS=-D warnings`: clean.
- 1905/1905 desktop lib tests, 21/21 `proc-ports`. New: 24 attribution/label tests, 6 kill-guard tests (one spawns a real listener and stops it through the actual signal path), 7 GPUI render tests that paint the panel at sidebar width including the rename `Input`.
- **Live**: on a machine where the old panel showed `0 ports`, the new one reports 1 owned + 79 external, with a `python3 -m http.server` started entirely outside OxiMux correctly filed by working directory. Confirmed in the running app: owned rows carry a red Stop, external rows carry only open/copy.

## Risk notes

- Linux is the platform where the unscoped query genuinely costs more (a `/proc` fd walk). It is bounded by the early stop and by `MAX_FDS`, and other users' processes are skipped rather than misattributed — but this is the arm least exercised here, and CI is where it actually runs.
- Windows cannot read another process's command line (`argv_of_pid` returns `None` there), so evidence 3 is unavailable and more rows land in External. Working-directory attribution is also macOS/Linux-only in `proc-cwd`. Windows therefore leans on the terminal-tree signal, which is unchanged.

https://claude.ai/code/session_01EVVzbwxcbfVoT1mWBB75BM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Ports panel now shows all listening ports on the machine, grouped by project with a separate collapsed External section.
  - Port ownership includes clearer attribution details and tooltips.
  - Added manual refresh with a busy indicator and automatic background updates.
  - Added controls to stop listening processes, with safeguards against stale or protected processes.
  - Added Open, Copy, Rename, Save, and Cancel actions for port entries.

- **Bug Fixes**
  - Improved port discovery across supported platforms, including listeners not associated with the current terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->