### PR TITLE
feat(worktree): base a worktree on a chosen ref, or adopt an existing branch

### DIFF
--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -715,8 +715,14 @@ pub enum WorktreeCommand {
         /// is NOT run. Use the row's `Run setup` after reading it.
         #[arg(long, value_name = "REF", conflicts_with = "branch")]
         from: Option<String>,
-        /// Check out an EXISTING branch into the new worktree. No branch is
-        /// created and no prefix is applied.
+        /// Check out an existing LOCAL branch into the new worktree. No branch
+        /// is created and no prefix is applied.
+        ///
+        /// A remote-tracking name (`origin/side`) or a tag is refused, because
+        /// neither is a branch to adopt: git would mint a local branch for the
+        /// first and detach HEAD for the second, and the worktree's row would
+        /// then name something that is not checked out. Use `--from` for those
+        /// — it cuts a new branch from any ref.
         #[arg(long, value_name = "NAME")]
         branch: Option<String>,
     },

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -707,8 +707,8 @@ pub enum WorktreeCommand {
         /// project the host knows (see `projects ls`).
         #[arg(long, value_name = "DIR")]
         project: Option<PathBuf>,
-        /// Cut the new branch from this ref instead of the host's current
-        /// checkout — a branch, a tag, or a SHA.
+        /// Cut the new branch from this ref instead of the repository's
+        /// default branch — a branch, a tag, or a SHA.
         ///
         /// A base that is not already part of the default branch is treated as
         /// unreviewed: the worktree is created, and its committed setup script

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -698,12 +698,27 @@ pub enum WorktreeCommand {
     /// Create a worktree (and its branch) under a project. The host derives
     /// the on-disk location; the reply carries it.
     Create {
-        /// The worktree slug (becomes branch `oximux/<slug>`).
-        slug: String,
+        /// The worktree slug (becomes the branch, under the configured prefix).
+        ///
+        /// Not required with `--branch`: adopting an existing branch takes its
+        /// name, and the slug would then name only the directory.
+        slug: Option<String>,
         /// The project's root path (default: the current directory). Must be a
         /// project the host knows (see `projects ls`).
         #[arg(long, value_name = "DIR")]
         project: Option<PathBuf>,
+        /// Cut the new branch from this ref instead of the host's current
+        /// checkout — a branch, a tag, or a SHA.
+        ///
+        /// A base that is not already part of the default branch is treated as
+        /// unreviewed: the worktree is created, and its committed setup script
+        /// is NOT run. Use the row's `Run setup` after reading it.
+        #[arg(long, value_name = "REF", conflicts_with = "branch")]
+        from: Option<String>,
+        /// Check out an EXISTING branch into the new worktree. No branch is
+        /// created and no prefix is applied.
+        #[arg(long, value_name = "NAME")]
+        branch: Option<String>,
     },
     /// List worktrees (all projects unless --project narrows it).
     Ls {

--- a/apps/cli/src/commands/worktree.rs
+++ b/apps/cli/src/commands/worktree.rs
@@ -5,7 +5,7 @@
 use std::path::{Path, PathBuf};
 
 use oximux_core::WorkPhase;
-use oximux_remote_proto::messages::{WorktreeProgressWire, WorktreeWire};
+use oximux_remote_proto::messages::{CreateBaseWire, WorktreeProgressWire, WorktreeWire};
 use oximux_remote_proto::proto::{Request, Response};
 use serde_json::{Value, json};
 
@@ -75,15 +75,73 @@ fn wire_json(row: &WorktreeWire) -> Value {
     })
 }
 
+/// The base the flags add up to, and the slug that names the directory.
+///
+/// `--branch` makes the positional slug optional: adopting a branch takes its
+/// name, so the only thing left for a slug to name is the directory. **The
+/// derivation is the host's**, not this side's — `derive_slug` lives in
+/// `oximux-git`, which is deliberately not on the CLI's dependency path (the
+/// same edge `oximux-worktree-ops` was extracted to keep the git process layer
+/// off `oximux-cli`). Reimplementing it here would put two copies of a naming
+/// rule in the tree and let them disagree, so an omitted slug travels as an
+/// empty string and the host fills it in. An explicit slug still wins: a user
+/// may want the directory named something other than the branch.
+///
+/// Clap already enforces `conflicts_with = "branch"` on `--from`; the arm below
+/// is what makes that a property of this function rather than of its caller, so
+/// the unit tests can state the rule directly.
+pub(crate) fn base_and_slug(
+    slug: Option<&str>,
+    from: Option<&str>,
+    branch: Option<&str>,
+) -> Result<(String, CreateBaseWire), Failure> {
+    let usage = |msg: &str| Failure::new("usage", exit::USAGE, msg.to_string());
+    match (from, branch) {
+        (Some(_), Some(_)) => Err(usage(
+            "`--from` and `--branch` are mutually exclusive: --from cuts a NEW branch \
+             from a ref, --branch adopts one that already exists",
+        )),
+        (from, None) => {
+            let Some(slug) = slug else {
+                return Err(usage(
+                    "`worktree create` wants a slug, or `--branch <NAME>` to adopt an \
+                     existing branch",
+                ));
+            };
+            let base = match from {
+                Some(r) => CreateBaseWire::From(r.to_string()),
+                None => CreateBaseWire::Default,
+            };
+            Ok((slug.to_string(), base))
+        }
+        (None, Some(branch)) => Ok((
+            slug.unwrap_or_default().to_string(),
+            CreateBaseWire::Existing(branch.to_string()),
+        )),
+    }
+}
+
 pub async fn create(
     client: &Client,
-    slug: &str,
+    slug: Option<&str>,
     project: Option<PathBuf>,
+    from: Option<&str>,
+    branch: Option<&str>,
 ) -> Result<(Value, String), Failure> {
+    let (slug, base) = base_and_slug(slug, from, branch)?;
     let project_path = resolve_project(client, project).await?;
-    let reply = client
-        .call(Request::CreateWorktree { project_path, slug: slug.into() })
-        .await?;
+    // **V2 only when the base needs it.** A plain create keeps taking the v16
+    // verb even against a v24 host, so every invocation that worked before this
+    // phase encodes byte-for-byte as it did. `--from`/`--branch` are separately
+    // refused against an older host by `required_version`, so a non-default
+    // base reaching here already implies a v24 host — the base *is* the
+    // decision, which is why this reads no version.
+    let request = if base.is_default() {
+        Request::CreateWorktree { project_path, slug }
+    } else {
+        Request::CreateWorktreeV2 { project_path, slug, base }
+    };
+    let reply = client.call(request).await?;
     match reply {
         Response::WorktreeCreated(row) => {
             let human = format!(
@@ -287,5 +345,64 @@ mod tests {
                 "the CLI must not send a spelling the host cannot parse"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod base_tests {
+    use super::*;
+
+    #[test]
+    fn a_plain_create_asks_for_the_default_base() {
+        let (slug, base) = base_and_slug(Some("feat-x"), None, None).expect("valid");
+        assert_eq!(slug, "feat-x");
+        assert_eq!(base, CreateBaseWire::Default);
+        // The property the version gate rests on: a plain create still encodes
+        // as the v16 verb, so it keeps working against a v16-v23 host.
+        assert!(base.is_default());
+    }
+
+    #[test]
+    fn from_cuts_a_new_branch_and_needs_the_v2_verb() {
+        let (slug, base) = base_and_slug(Some("feat-x"), Some("release/1.4"), None).expect("valid");
+        assert_eq!(slug, "feat-x");
+        assert_eq!(base, CreateBaseWire::From("release/1.4".into()));
+        assert!(!base.is_default());
+    }
+
+    #[test]
+    fn branch_adopts_and_leaves_the_slug_for_the_host_to_derive() {
+        let (slug, base) = base_and_slug(None, None, Some("feature/api/retry")).expect("valid");
+        assert_eq!(
+            slug, "",
+            "the CLI must not derive the slug — `derive_slug` lives on the host side"
+        );
+        assert_eq!(base, CreateBaseWire::Existing("feature/api/retry".into()));
+        assert!(!base.is_default());
+    }
+
+    #[test]
+    fn an_explicit_slug_still_names_the_directory_when_adopting() {
+        let (slug, base) = base_and_slug(Some("retry"), None, Some("feature/api/retry")).unwrap();
+        assert_eq!(slug, "retry");
+        assert_eq!(base, CreateBaseWire::Existing("feature/api/retry".into()));
+    }
+
+    #[test]
+    fn from_and_branch_are_mutually_exclusive_and_say_so() {
+        let err = base_and_slug(Some("x"), Some("main"), Some("side")).expect_err("refused");
+        assert_eq!(err.code, "usage");
+        assert!(
+            err.message.contains("mutually exclusive"),
+            "the refusal must name the rule: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_create_with_neither_a_slug_nor_a_branch_is_a_usage_error() {
+        let err = base_and_slug(None, None, None).expect_err("refused");
+        assert_eq!(err.code, "usage");
+        assert!(err.message.contains("wants a slug"), "{}", err.message);
     }
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -25,7 +25,7 @@ use cli::{
     TermCommand, WorktreeCommand,
 };
 use client::Client;
-use oximux_remote_proto::proto::{SCHEDULE_CRON_MIN_VERSION, TEAM_PER_ROLE_MIN_VERSION};
+use oximux_remote_proto::proto::{CREATE_WORKTREE_BASE_MIN_VERSION, SCHEDULE_CRON_MIN_VERSION, TEAM_PER_ROLE_MIN_VERSION};
 use output::render;
 
 /// Leaf verbs that erase something. A typo is never nudged toward one of
@@ -266,6 +266,17 @@ fn required_version(command: &Command) -> Option<(u32, &'static str)> {
         Command::Schedule { command: ScheduleCommand::Create { cron: Some(_), .. } } => {
             Some((SCHEDULE_CRON_MIN_VERSION, "schedule create --cron"))
         }
+        // v24: a worktree base ref. Gated on the flags, not the family — a
+        // plain `worktree create` still speaks v16 to a v16 host, and only
+        // `--from`/`--branch` needs one that can decode `CreateWorktreeV2`.
+        // Must stay ABOVE the catch-all `Worktree` arm below, which would
+        // otherwise match first and claim v16.
+        Command::Worktree {
+            command: WorktreeCommand::Create { from: Some(_), .. },
+        } => Some((CREATE_WORKTREE_BASE_MIN_VERSION, "worktree create --from")),
+        Command::Worktree {
+            command: WorktreeCommand::Create { branch: Some(_), .. },
+        } => Some((CREATE_WORKTREE_BASE_MIN_VERSION, "worktree create --branch")),
         // v18: the automation surface.
         Command::Heartbeat { .. } => Some((18, "heartbeat")),
         Command::Team { .. } => Some((18, "team")),
@@ -321,6 +332,16 @@ fn precheck(command: &mut Command, json_mode: bool) -> Result<(), output::Failur
     // avoid.
     if let Command::Permit { command: PermitCommand::Allow { input: Some(raw), .. } } = command {
         commands::permit::parse_input_override(raw)?;
+    }
+    // `worktree create` with neither a slug nor `--branch` is the same class of
+    // mistake, and was the same defect: the check lives inside the verb, which
+    // runs past `resolve_and_connect`, so a missing argument was reported as an
+    // unreachable host. Validated here against the argv alone; the verb still
+    // owns the rule and is still what builds the request from it.
+    if let Command::Worktree { command: WorktreeCommand::Create { slug, from, branch, .. } } =
+        command
+    {
+        commands::worktree::base_and_slug(slug.as_deref(), from.as_deref(), branch.as_deref())?;
     }
     match command {
         Command::Run { prompt, .. } | Command::Send { prompt, .. } => {
@@ -545,8 +566,15 @@ fn host_verb(mut args: Cli) -> u8 {
                     TermCommand::Attach { pty } => commands::term::attach(&client, &pty).await,
                 },
                 Command::Worktree { command } => match command {
-                    WorktreeCommand::Create { slug, project } => {
-                        commands::worktree::create(&client, &slug, project).await
+                    WorktreeCommand::Create { slug, project, from, branch } => {
+                        commands::worktree::create(
+                            &client,
+                            slug.as_deref(),
+                            project,
+                            from.as_deref(),
+                            branch.as_deref(),
+                        )
+                        .await
                     }
                     WorktreeCommand::Ls { project } => {
                         commands::worktree::ls(&client, project).await

--- a/apps/cli/tests/cli_e2e.rs
+++ b/apps/cli/tests/cli_e2e.rs
@@ -16,7 +16,7 @@ use oximux_remote_host::{
 use oximux_remote_local::{
     LocalClaim, LocalControlListener, generate_token, token_path, write_token_file,
 };
-use oximux_remote_proto::messages::{WorktreeProgressWire, WorktreeWire};
+use oximux_remote_proto::messages::{CreateBaseWire, WorktreeProgressWire, WorktreeWire};
 
 fn bin(runtime_dir: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_oximux-cli"));
@@ -72,15 +72,34 @@ struct StubWorktrees;
 
 #[async_trait::async_trait]
 impl WorktreeService for StubWorktrees {
-    async fn create(&self, project_path: &str, slug: &str)
-    -> Result<WorktreeWire, WorktreeError> {
+    async fn create(
+        &self,
+        project_path: &str,
+        slug: &str,
+        base: &CreateBaseWire,
+    ) -> Result<WorktreeWire, WorktreeError> {
+        // The stub reflects the base back into the row so the CLI tests can
+        // assert what actually crossed the wire. Without this the two modes are
+        // indistinguishable from the client side, and a `--from` that silently
+        // sent `Default` would pass every test.
+        let (branch, path) = match base {
+            CreateBaseWire::Default => {
+                (format!("oximux/{slug}"), format!("/stub/worktrees/{slug}"))
+            }
+            CreateBaseWire::From(r) => {
+                (format!("oximux/{slug}"), format!("/stub/worktrees/{slug}@{r}"))
+            }
+            CreateBaseWire::Existing(name) => {
+                (name.clone(), format!("/stub/worktrees/{slug}"))
+            }
+        };
         Ok(WorktreeWire {
             id: format!("wt-{slug}"),
             project_path: project_path.into(),
             name: slug.into(),
             slug: slug.into(),
-            branch: format!("oximux/{slug}"),
-            path: format!("/stub/worktrees/{slug}"),
+            branch,
+            path,
         })
     }
     async fn list(&self, _project_path: Option<&str>) -> Result<Vec<WorktreeWire>, WorktreeError> {

--- a/apps/cli/tests/wire_skew_e2e.rs
+++ b/apps/cli/tests/wire_skew_e2e.rs
@@ -478,3 +478,92 @@ fn a_new_client_schedules_on_an_old_host() {
     let _ = child.wait();
 }
 
+
+/// The v24 twin of [`a_new_client_schedules_on_an_old_host`]: a plain
+/// `worktree create` keeps speaking v16 to a pre-v24 host, and only a base ref
+/// is refused — by version, never by blaming the frame.
+///
+/// **What "keeps speaking v16" is proven by.** The CLI has no `projects add`,
+/// so a released `serve` in a tempdir knows no project and cannot actually cut
+/// a worktree. That makes a successful create untestable here — but it also
+/// makes the available assertion the more precise one: an old host that
+/// answers *about the project* has decoded ordinal 43 and run its own
+/// validation, where a host that could not decode the frame answers
+/// `BadRequest("undecodable request frame")` and never reaches a project at
+/// all. Those two outcomes are exactly the two sides of the append-only claim,
+/// and they are distinguishable in the error text.
+#[test]
+fn a_new_client_creates_worktrees_on_an_old_host() {
+    let Some(old) = old_cli() else {
+        eprintln!("skipped: OXIMUX_SKEW_CLI is unset");
+        return;
+    };
+    let host_version = protocol_of(&old);
+    if host_version >= oximux_remote_proto::proto::CREATE_WORKTREE_BASE_MIN_VERSION {
+        eprintln!("skipped: the released peer already speaks v{host_version}");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data = tmp.path().join("data");
+    let shim = tmp.path().join("bin");
+    let cwd = tmp.path().join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+    common::install_claude_shim(&shim);
+    let (mut child, dir) = boot_released_serve(&old, &data, &shim, tmp.path());
+
+    // A plain create IS the v16 request. It must reach the host's own project
+    // validation — which is what "the frame decoded" looks like from here.
+    let out = common::bin()
+        .args([
+            "--dir", &dir, "worktree", "create", "feat", "--project", cwd.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("undecodable"),
+        "a plain create must still decode on a v{host_version} host: {stderr}"
+    );
+    assert!(
+        !stderr.contains("protocol v"),
+        "and must not be version-gated — only a base ref is: {stderr}"
+    );
+
+    // `worktree ls` is a v16 read and must be untouched by the bump.
+    let out = common::bin().args(["--dir", &dir, "--json", "worktree", "ls"]).output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "worktree ls must keep working: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Only a base ref is refused, and the refusal names the version.
+    for (flag, value) in [("--from", "main"), ("--branch", "side")] {
+        let out = common::bin()
+            .args([
+                "--dir", &dir, "worktree", "create", "feat", "--project",
+                cwd.to_str().unwrap(), flag, value,
+            ])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_eq!(
+            out.status.code(),
+            Some(3),
+            "{flag} must be unreachable-class, not a crash: {stderr}"
+        );
+        assert!(
+            stderr.contains("protocol v24"),
+            "{flag} must name the version needed: {stderr}"
+        );
+        assert!(
+            !stderr.contains("undecodable"),
+            "{flag} must never blame the frame for a version problem: {stderr}"
+        );
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/apps/desktop/src/shell/agents_dashboard/filter.rs
+++ b/apps/desktop/src/shell/agents_dashboard/filter.rs
@@ -132,6 +132,9 @@ mod tests {
         Workspace {
             id: "ws".into(),
             project_id: "p".into(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: "ws".into(),
             slug: slug.into(),
             branch: branch.into(),

--- a/apps/desktop/src/shell/agents_dashboard/model.rs
+++ b/apps/desktop/src/shell/agents_dashboard/model.rs
@@ -121,6 +121,9 @@ mod tests {
         Workspace {
             id: id.to_string(),
             project_id: project_id.to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: format!("ws-{id}"),
             slug: id.to_string(),
             branch: format!("oximux/{id}"),

--- a/apps/desktop/src/shell/agents_dashboard/row_builder.rs
+++ b/apps/desktop/src/shell/agents_dashboard/row_builder.rs
@@ -115,6 +115,9 @@ mod tests {
         Workspace {
             id: id.to_string(),
             project_id: project_id.to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: format!("ws-{id}"),
             slug: id.to_string(),
             branch: format!("oximux/{id}"),

--- a/apps/desktop/src/shell/agents_dashboard/sections.rs
+++ b/apps/desktop/src/shell/agents_dashboard/sections.rs
@@ -115,6 +115,9 @@ mod tests {
         Workspace {
             id: "ws".into(),
             project_id: "p".into(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: "ws".into(),
             slug: "ws".into(),
             branch: "main".into(),

--- a/apps/desktop/src/shell/left_rail/mod.rs
+++ b/apps/desktop/src/shell/left_rail/mod.rs
@@ -1686,6 +1686,9 @@ mod tests {
         Workspace {
             id: id.to_string(),
             project_id: "p".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: id.to_string(),
             slug: id.to_string(),
             branch: format!("oximux/{id}"),

--- a/apps/desktop/src/shell/left_rail/project_group.rs
+++ b/apps/desktop/src/shell/left_rail/project_group.rs
@@ -908,6 +908,9 @@ mod tests {
         Workspace {
             id: id.to_string(),
             project_id: project_id.to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: id.to_string(),
             slug: id.to_string(),
             branch: format!("oximux/{id}"),

--- a/apps/desktop/src/shell/left_rail/workspace_list_render.rs
+++ b/apps/desktop/src/shell/left_rail/workspace_list_render.rs
@@ -395,6 +395,9 @@ mod tests {
         Workspace {
             id: id.to_string(),
             project_id: "p1".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: id.to_string(),
             slug: id.to_string(),
             branch: format!("oximux/{id}"),

--- a/apps/desktop/src/shell/left_rail/workspace_row.rs
+++ b/apps/desktop/src/shell/left_rail/workspace_row.rs
@@ -418,6 +418,9 @@ mod tests {
         Workspace {
             id: format!("id-{slug}"),
             project_id: "proj".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: name.to_string(),
             slug: slug.to_string(),
             branch: format!("oximux/{slug}"),
@@ -615,6 +618,9 @@ mod tests {
         Workspace {
             id: format!("id-{slug}"),
             project_id: "proj".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: name.to_string(),
             slug: slug.to_string(),
             branch: branch.to_string(),

--- a/apps/desktop/src/shell/tasks_view/row.rs
+++ b/apps/desktop/src/shell/tasks_view/row.rs
@@ -429,6 +429,10 @@ pub(super) fn create_action(
                         // No setup picker on a task row — the project's
                         // `auto_setup` decides, same as before this existed.
                         oximux_settings::SetupDecision::Inherit,
+                        // No base picker on a task row either: a new branch off
+                        // the project's default branch, which is what this path
+                        // meant all along and did not previously get.
+                        crate::shell::workspace::base_choice::BaseChoice::default(),
                         true,
                         window,
                         cx,

--- a/apps/desktop/src/shell/workspace/add_project_dialog.rs
+++ b/apps/desktop/src/shell/workspace/add_project_dialog.rs
@@ -29,6 +29,7 @@ use gpui_component::{
 use oximux_core::Project;
 use oximux_settings::{Density, Theme, Typography};
 
+use crate::shell::workspace::project_picker::detect_default_branch;
 use crate::ui::FloatingSurface;
 use oximux_storage::ProjectRepo;
 use tokio::sync::oneshot;
@@ -41,8 +42,6 @@ const MODAL_TOP_OFFSET: f32 = 120.0;
 const CARD_HEIGHT: f32 = 120.0;
 /// Fallback name when `path.file_name()` returns None.
 const FALLBACK_PROJECT_NAME: &str = "untitled";
-/// Branch stored at insert time; real HEAD detection lands later.
-pub(crate) const DEFAULT_BRANCH_PLACEHOLDER: &str = "main";
 
 /// Owner callback fired after a project is added (Browse or Clone).
 pub type OnPick = Box<dyn Fn(Project, &mut Window, &mut App) + Send + 'static>;
@@ -176,8 +175,15 @@ impl AddProjectDialog {
         cx.spawn_in(window, async move |this, cx| {
             let folder = rfd::AsyncFileDialog::new().pick_folder().await;
             let path = folder.map(|h| h.path().to_path_buf());
+            // Detected in the spawn — `register_and_open` runs on the
+            // foreground executor, where a git subprocess would stall the
+            // window. See `project_picker::detect_default_branch`.
+            let default_branch = match &path {
+                Some(p) => detect_default_branch(p).await,
+                None => String::new(),
+            };
             let _ = this.update_in(cx, |this, window, cx| match path {
-                Some(p) => this.handle_folder_pick(p, window, cx),
+                Some(p) => this.handle_folder_pick(p, default_branch, window, cx),
                 None => {
                     this.pending_folder_pick = false;
                     cx.notify();
@@ -187,13 +193,19 @@ impl AddProjectDialog {
         .detach();
     }
 
-    fn handle_folder_pick(&mut self, path: PathBuf, window: &mut Window, cx: &mut Context<Self>) {
+    fn handle_folder_pick(
+        &mut self,
+        path: PathBuf,
+        default_branch: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // NSOpenPanel races against close(); discard stale results.
         if !self.open {
             return;
         }
         self.pending_folder_pick = false;
-        self.register_and_open(path, window, cx);
+        self.register_and_open(path, default_branch, window, cx);
     }
 
     /// Kick off a clone: validate the URL, derive a folder name, pick a
@@ -252,10 +264,17 @@ impl AddProjectDialog {
                 );
             });
             let outcome = rx.await;
+            // A fresh clone has the truest default branch of all — it is
+            // whatever the remote just told git — so read it before the
+            // foreground handler registers the project.
+            let default_branch = match &outcome {
+                Ok(Ok(path)) => detect_default_branch(path).await,
+                _ => String::new(),
+            };
             let _ = this.update_in(cx, |this, window, cx| {
                 this.cloning = false;
                 match outcome {
-                    Ok(Ok(path)) => this.register_and_open(path, window, cx),
+                    Ok(Ok(path)) => this.register_and_open(path, default_branch, window, cx),
                     Ok(Err(msg)) => {
                         this.clone_error = Some(msg);
                         cx.notify();
@@ -274,7 +293,13 @@ impl AddProjectDialog {
     /// Shared by Browse and Clone. Closes the dialog before firing
     /// `on_pick` so a modal the callback opens isn't wiped by a trailing
     /// close.
-    fn register_and_open(&mut self, path: PathBuf, window: &mut Window, cx: &mut Context<Self>) {
+    fn register_and_open(
+        &mut self,
+        path: PathBuf,
+        default_branch: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if !self.open {
             return;
         }
@@ -282,7 +307,7 @@ impl AddProjectDialog {
         let name = name_from_path(&path);
         match self
             .project_repo
-            .insert_or_touch(&name, &path_str, DEFAULT_BRANCH_PLACEHOLDER)
+            .insert_or_touch(&name, &path_str, &default_branch)
         {
             Ok(project) => {
                 self.close(cx);

--- a/apps/desktop/src/shell/workspace/base_choice.rs
+++ b/apps/desktop/src/shell/workspace/base_choice.rs
@@ -1,0 +1,146 @@
+//! What the create dialog's **From** control means, as data.
+//!
+//! Split from the dialog for the reason `workspace_list_render` is split from
+//! its painter: the interesting part is a decision — which of three
+//! [`CreateBase`] shapes a user's two dropdowns add up to — and a decision is
+//! testable where a GPUI render is not.
+
+use oximux_worktree_ops::CreateBase;
+
+/// Which of the two creation modes the segmented control is on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum BaseMode {
+    /// Cut a new branch, named by the configured prefix and the slug.
+    #[default]
+    NewBranch,
+    /// Adopt a branch that already exists. No branch is created and no prefix
+    /// applies — the name is the user's, not ours.
+    ExistingBranch,
+}
+
+/// The dialog's base selection, before it knows the branch name it will mint.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BaseChoice {
+    pub mode: BaseMode,
+    /// The chosen start point. `None` means "the project's default branch" —
+    /// the default the control opens on, kept as `None` rather than eagerly
+    /// resolved so a project switch re-reads it instead of carrying the
+    /// previous project's answer.
+    pub from: Option<String>,
+    /// The chosen existing branch. `None` in `ExistingBranch` mode means the
+    /// user has not picked one yet, which is why [`Self::resolve`] can fail.
+    pub existing: Option<String>,
+}
+
+impl BaseChoice {
+    /// The label the **From** control shows: the explicit choice, else the
+    /// project's default branch, else a plain statement of the fallback rather
+    /// than a branch name we cannot name.
+    pub fn from_label<'a>(&'a self, default_branch: &'a str) -> &'a str {
+        match self.from.as_deref() {
+            Some(chosen) => chosen,
+            None if !default_branch.is_empty() => default_branch,
+            None => "current checkout",
+        }
+    }
+
+    /// Whether this choice is complete enough to submit.
+    ///
+    /// Only `ExistingBranch` can be incomplete: adopting a branch requires
+    /// naming one, where a new branch always has a name (the slug) and always
+    /// has a base (the default, or the checkout behind it).
+    pub fn is_complete(&self) -> bool {
+        match self.mode {
+            BaseMode::NewBranch => true,
+            BaseMode::ExistingBranch => self.existing.is_some(),
+        }
+    }
+
+    /// Fold the choice and the branch name the resolver minted into the base
+    /// the create path takes.
+    ///
+    /// `minted_branch` is ignored in `ExistingBranch` mode — deliberately, and
+    /// this is the whole reason the modes are one enum rather than a pair of
+    /// fields. Adopting a branch and *also* naming a new one is not a state a
+    /// caller should be able to build.
+    ///
+    /// **"Default branch" stays unresolved here.** `CreateBase::new_branch`
+    /// already means "the repository's default branch, or HEAD if it does not
+    /// resolve", and answering that question needs `git`. Resolving it in this
+    /// pure function would mean either a stale stored value or a second
+    /// resolution free to disagree with the create path's own.
+    ///
+    /// `None` when the choice is incomplete; the caller has already disabled
+    /// submit, so reaching this is a bug rather than a user error.
+    pub fn resolve(&self, minted_branch: String) -> Option<CreateBase> {
+        match self.mode {
+            BaseMode::ExistingBranch => self.existing.clone().map(CreateBase::existing),
+            BaseMode::NewBranch => Some(match self.from.as_deref() {
+                Some(from) => CreateBase::new_branch_from(minted_branch, from),
+                None => CreateBase::new_branch(minted_branch),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_new_branch_defers_the_default_to_the_create_path() {
+        let choice = BaseChoice::default();
+        assert_eq!(
+            choice.resolve("oximux/x".into()),
+            Some(CreateBase::new_branch("oximux/x")),
+            "the default branch is resolved with git at create time, not here"
+        );
+    }
+
+    #[test]
+    fn an_explicit_from_wins_over_the_default() {
+        let choice = BaseChoice {
+            from: Some("release/1.4".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            choice.resolve("oximux/x".into()),
+            Some(CreateBase::new_branch_from("oximux/x", "release/1.4"))
+        );
+    }
+
+    #[test]
+    fn existing_mode_adopts_the_branch_and_discards_the_minted_name() {
+        let choice = BaseChoice {
+            mode: BaseMode::ExistingBranch,
+            existing: Some("feature/api/retry".into()),
+            // Left set on purpose: switching modes must not carry the other
+            // mode's answer into the result.
+            from: Some("release/1.4".into()),
+        };
+        assert_eq!(
+            choice.resolve("oximux/x".into()),
+            Some(CreateBase::existing("feature/api/retry"))
+        );
+    }
+
+    #[test]
+    fn existing_mode_without_a_branch_is_incomplete() {
+        let choice = BaseChoice {
+            mode: BaseMode::ExistingBranch,
+            ..Default::default()
+        };
+        assert!(!choice.is_complete());
+        assert_eq!(choice.resolve("oximux/x".into()), None);
+        assert!(BaseChoice::default().is_complete());
+    }
+
+    #[test]
+    fn the_from_label_names_what_the_create_will_actually_do() {
+        let mut choice = BaseChoice::default();
+        assert_eq!(choice.from_label("main"), "main");
+        assert_eq!(choice.from_label(""), "current checkout");
+        choice.from = Some("dev".into());
+        assert_eq!(choice.from_label("main"), "dev");
+    }
+}

--- a/apps/desktop/src/shell/workspace/mod.rs
+++ b/apps/desktop/src/shell/workspace/mod.rs
@@ -2,6 +2,7 @@
 //! and the project-management dialogs (add-project, project picker).
 
 pub mod add_project_dialog;
+pub mod base_choice;
 pub mod merge_notices;
 pub mod merge_ops;
 pub mod project_picker;

--- a/apps/desktop/src/shell/workspace/project_picker.rs
+++ b/apps/desktop/src/shell/workspace/project_picker.rs
@@ -43,9 +43,37 @@ const EMPTY_STATE_HEIGHT: f32 = 80.0;
 const MAX_VISIBLE_ROWS: usize = 20;
 /// Fallback name when `path.file_name()` returns None (root paths).
 const FALLBACK_PROJECT_NAME: &str = "untitled";
-/// Default branch stored at insert time; step 6's workspace dialog
-/// detects the real HEAD branch via `oximux_git`.
-const DEFAULT_BRANCH_PLACEHOLDER: &str = "main";
+/// What a project's default branch falls back to when the folder is not a
+/// repository, or is one whose HEAD says nothing useful.
+///
+/// A fallback, no longer a placeholder: [`detect_default_branch`] runs before
+/// every insert now. This matters more than it used to — the stored value is
+/// what a new worktree is based on, and what decides whether a chosen base
+/// counts as reviewed, so a repo that renamed `master` to `main` (or never had
+/// either) must not silently carry a branch that does not exist.
+pub(crate) const DEFAULT_BRANCH_FALLBACK: &str = "main";
+
+/// The default branch of the repository at `path`, or
+/// [`DEFAULT_BRANCH_FALLBACK`] when there is nothing to read.
+///
+/// Async because it shells out to git, and called from the folder-pick spawn
+/// rather than from the handler it feeds: the handler runs inside
+/// `update_in` on the foreground executor, where a subprocess would stall the
+/// window on every project add.
+///
+/// Every failure resolves to the fallback. Adding a project must not be
+/// refusable because a folder is not a repository — plain folders are a
+/// supported kind of project.
+pub async fn detect_default_branch(path: &Path) -> String {
+    let Ok(repo) = oximux_git::Repository::open(path).await else {
+        return DEFAULT_BRANCH_FALLBACK.to_string();
+    };
+    repo.default_branch()
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| DEFAULT_BRANCH_FALLBACK.to_string())
+}
 
 /// Handler the owner registers to receive the picked `Project`. Boxed so
 /// the picker is constructed without a `Context<WorkspaceRoot>`.
@@ -171,8 +199,13 @@ impl ProjectPickerModal {
         cx.spawn(async move |this, cx| {
             let folder = rfd::AsyncFileDialog::new().pick_folder().await;
             let path = folder.map(|h| h.path().to_path_buf());
+            // Detected HERE, in the spawn, before the foreground handler runs.
+            let default_branch = match &path {
+                Some(p) => detect_default_branch(p).await,
+                None => String::new(),
+            };
             let _ = this.update_in(cx, |this, window, cx| match path {
-                Some(p) => this.handle_folder_pick(p, window, cx),
+                Some(p) => this.handle_folder_pick(p, default_branch, window, cx),
                 None => {
                     this.pending_folder_pick = false;
                     cx.notify();
@@ -182,7 +215,13 @@ impl ProjectPickerModal {
         .detach();
     }
 
-    fn handle_folder_pick(&mut self, path: PathBuf, window: &mut Window, cx: &mut Context<Self>) {
+    fn handle_folder_pick(
+        &mut self,
+        path: PathBuf,
+        default_branch: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // User may have dismissed the picker via Escape (or another
         // Cmd+O toggle) while NSOpenPanel was still open. NSOpenPanel
         // is a separate macOS window, so its resolution races against
@@ -193,11 +232,10 @@ impl ProjectPickerModal {
         }
         self.pending_folder_pick = false;
         let path_str = path.to_string_lossy().to_string();
-        // TODO(step-6): detect HEAD branch via `oximux_git` before insert.
         let name = name_from_path(&path);
         match self
             .project_repo
-            .insert_or_touch(&name, &path_str, DEFAULT_BRANCH_PLACEHOLDER)
+            .insert_or_touch(&name, &path_str, &default_branch)
         {
             Ok(project) => {
                 // Close before invoking the callback so any modal the
@@ -483,7 +521,7 @@ mod tests {
         let db = oximux_storage::open_memory().expect("memory");
         let repo = ProjectRepo::new(db);
         let project = repo
-            .insert_or_touch("Acme", "/p/acme", DEFAULT_BRANCH_PLACEHOLDER)
+            .insert_or_touch("Acme", "/p/acme", DEFAULT_BRANCH_FALLBACK)
             .expect("resolve");
         assert_eq!(project.name, "Acme");
         assert_eq!(project.root_path, "/p/acme");
@@ -497,7 +535,7 @@ mod tests {
             .insert("Acme", "/p/acme", "main")
             .expect("first insert");
         let resolved = repo
-            .insert_or_touch("Acme-renamed", "/p/acme", DEFAULT_BRANCH_PLACEHOLDER)
+            .insert_or_touch("Acme-renamed", "/p/acme", DEFAULT_BRANCH_FALLBACK)
             .expect("resolve");
         assert_eq!(resolved.id, first.id);
         let fetched = repo.get_by_id(&first.id).expect("get").expect("present");

--- a/apps/desktop/src/shell/workspace/session_merge.rs
+++ b/apps/desktop/src/shell/workspace/session_merge.rs
@@ -379,6 +379,9 @@ mod tests {
         Workspace {
             id: id.into(),
             project_id: "proj-1".into(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: id.into(),
             slug: id.into(),
             branch: "main".into(),

--- a/apps/desktop/src/shell/workspace/workspace_dialog.rs
+++ b/apps/desktop/src/shell/workspace/workspace_dialog.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use gpui::{
     App, AppContext, ClickEvent, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, ParentElement, Render, Styled,
-    Subscription, Task, Window, div, px,
+    IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, ParentElement, Render,
+    StatefulInteractiveElement, Styled, Subscription, Task, Window, div, px,
 };
 use gpui_component::{
     Disableable,
@@ -26,6 +26,7 @@ use oximux_core::{AgentAdapter, Project, Workspace};
 use oximux_git::derive_slug;
 use oximux_settings::{Density, SetupDecision, Theme, Typography};
 
+use crate::shell::workspace::base_choice::{BaseChoice, BaseMode};
 use crate::shell::forge::ref_parse::parse_forge_ref;
 use crate::shell::forge::{Forge, fetch_ref_title};
 use crate::ui::FloatingSurface;
@@ -83,6 +84,10 @@ pub struct WorkspaceDialogSubmit {
     /// ten-minute install, and a one-off can opt in, without editing a file
     /// the whole team shares.
     pub setup: SetupDecision,
+    /// What the worktree is cut from. Defaults to a new branch based on the
+    /// project's default branch — the answer that used to be "wherever the
+    /// main checkout's HEAD happened to be".
+    pub base: BaseChoice,
 }
 
 pub type OnSubmit = Box<dyn Fn(WorkspaceDialogSubmit, &mut Window, &mut App) + Send + 'static>;
@@ -102,6 +107,29 @@ pub struct WorkspaceDialog {
     agent_dropdown_open: bool,
     selected_setup: SetupDecision,
     setup_dropdown_open: bool,
+    /// The **From** control's state. See [`BaseChoice`].
+    base: BaseChoice,
+    /// Local branches, most-recent-first, as `list_branches` already sorts
+    /// them. Capped at [`MAX_BRANCH_CHOICES`]: a repo with thousands of refs
+    /// makes an uncapped dropdown useless, and the ones a person wants to base
+    /// work on are the ones they touched recently.
+    branches: Vec<String>,
+    from_dropdown_open: bool,
+    existing_dropdown_open: bool,
+    /// The setup-skip notice for the current base, shown BEFORE the user
+    /// commits — the same sentence provisioning would write afterwards.
+    base_warning: Option<String>,
+    /// Cancel-on-change token for the base-warning lookup, mirroring
+    /// `fetch_epoch`: a completed lookup only applies if its epoch is current.
+    ///
+    /// The branch list has **no** epoch and its own task slot. The two are
+    /// independent — the list depends on the project, the warning on the
+    /// selection — and sharing either would make choosing a base cancel the
+    /// fetch of the list you chose it from, leaving the dropdown empty for the
+    /// rest of the dialog's life.
+    base_epoch: u64,
+    _warning_load: Option<Task<()>>,
+    _branch_load: Option<Task<()>>,
     /// Forge reference the current name was prefilled from (`"#42"`).
     /// Cleared the moment the user edits the name again — their text wins.
     linked_issue: Option<String>,
@@ -158,6 +186,14 @@ impl WorkspaceDialog {
             agent_dropdown_open: false,
             selected_setup: SetupDecision::Inherit,
             setup_dropdown_open: false,
+            base: BaseChoice::default(),
+            branches: Vec::new(),
+            from_dropdown_open: false,
+            existing_dropdown_open: false,
+            base_warning: None,
+            base_epoch: 0,
+            _warning_load: None,
+            _branch_load: None,
             linked_issue: None,
             fetch_epoch: 0,
             fetching_title: false,
@@ -265,6 +301,8 @@ impl WorkspaceDialog {
         self.agent_dropdown_open = false;
         self.selected_setup = SetupDecision::Inherit;
         self.setup_dropdown_open = false;
+        self.reset_base();
+        self.reload_branches(cx);
         self.linked_issue = None;
         self.fetch_epoch += 1;
         self.fetching_title = false;
@@ -291,6 +329,7 @@ impl WorkspaceDialog {
         self.project_dropdown_open = false;
         self.agent_dropdown_open = false;
         self.setup_dropdown_open = false;
+        self.reset_base();
         let input_focus = self.name_input.read(cx).focus_handle(cx);
         window.focus(&input_focus, cx);
         cx.notify();
@@ -308,7 +347,23 @@ impl WorkspaceDialog {
         self.project_dropdown_open = false;
         self.agent_dropdown_open = false;
         self.setup_dropdown_open = false;
+        self.reset_base();
         cx.notify();
+    }
+
+    /// Clear the base selection and cancel anything in flight for it.
+    ///
+    /// The epoch bump is what makes this a cancel rather than a hope: a lookup
+    /// that lands after a close (or into a later open) finds its epoch stale
+    /// and applies nothing. Same contract as `fetch_epoch`.
+    fn reset_base(&mut self) {
+        self.base = BaseChoice::default();
+        self.from_dropdown_open = false;
+        self.existing_dropdown_open = false;
+        self.base_warning = None;
+        self.base_epoch += 1;
+        self._warning_load = None;
+        self._branch_load = None;
     }
 
     fn current_name(&self, cx: &App) -> String {
@@ -326,7 +381,11 @@ impl WorkspaceDialog {
             return false;
         }
         match &self.mode {
-            Some(WorkspaceDialogMode::Create) => self.selected_project.is_some(),
+            // Adopting a branch requires naming one — `is_complete` is the
+            // only state that can be half-made.
+            Some(WorkspaceDialogMode::Create) => {
+                self.selected_project.is_some() && self.base.is_complete()
+            }
             Some(WorkspaceDialogMode::Rename(_)) => true,
             None => false,
         }
@@ -346,6 +405,7 @@ impl WorkspaceDialog {
         };
         let agent = self.selected_agent;
         let setup = self.selected_setup;
+        let base = self.base.clone();
         let linked_issue = self.linked_issue.clone();
         self.close(cx);
         (self.on_submit)(
@@ -355,6 +415,7 @@ impl WorkspaceDialog {
                 project,
                 agent,
                 setup,
+                base,
                 linked_issue,
             },
             window,
@@ -404,6 +465,14 @@ impl Render for WorkspaceDialog {
         // derivation of the same rule.
         let project_root = self.selected_project.as_ref().map(|p| std::path::PathBuf::from(&p.root_path));
         let branch = crate::git_settings::branch_for_slug(&slug, project_root.as_deref(), cx);
+        // In existing-branch mode the name field no longer names the branch —
+        // the worktree adopts one. Previewing the minted `<prefix>/<slug>`
+        // there would promise a branch the create will never make.
+        let branch = match (&self.base.mode, self.base.existing.as_deref()) {
+            (BaseMode::ExistingBranch, Some(existing)) => existing.to_string(),
+            (BaseMode::ExistingBranch, None) => "—".to_string(),
+            (BaseMode::NewBranch, _) => branch,
+        };
         let slug_line = if self.fetching_title {
             format!("Branch: {branch} · fetching title…")
         } else if let Some(issue) = &self.linked_issue {
@@ -423,10 +492,8 @@ impl Render for WorkspaceDialog {
                 cx.stop_propagation();
                 // First Escape collapses an open dropdown; only a bare
                 // Escape dismisses the whole dialog.
-                if this.project_dropdown_open || this.agent_dropdown_open || this.setup_dropdown_open {
-                    this.project_dropdown_open = false;
-                    this.agent_dropdown_open = false;
-                    this.setup_dropdown_open = false;
+                if this.any_dropdown_open() {
+                    this.close_dropdowns();
                     cx.notify();
                 } else {
                     this.close(cx);
@@ -484,6 +551,7 @@ impl Render for WorkspaceDialog {
             );
 
         if is_create {
+            card = card.child(self.render_base_section(cx));
             card = card.child(self.render_agent_section(cx));
             card = card.child(self.render_setup_section(cx));
         }
@@ -605,8 +673,22 @@ impl WorkspaceDialog {
                         .on_mouse_down(
                             MouseButton::Left,
                             cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                                let changed = this.selected_project.as_ref().map(|p| &p.id)
+                                    != Some(&p_clone.id);
                                 this.selected_project = Some(p_clone.clone());
                                 this.project_dropdown_open = false;
+                                // Everything under the Name field is keyed to a
+                                // project: the branch list, the chosen base, and
+                                // the ancestry notice. Carrying any of them across
+                                // a switch offers refs the new project does not
+                                // have — and in existing-branch mode it would submit
+                                // a branch name from the OLD repository, which fails
+                                // the create at best. `open_create` runs exactly
+                                // these two; a project change is the same event.
+                                if changed {
+                                    this.reset_base();
+                                    this.reload_branches(cx);
+                                }
                                 cx.notify();
                             }),
                         ),
@@ -683,6 +765,267 @@ impl WorkspaceDialog {
         col
     }
 
+
+    /// Whether any dropdown in the card is expanded. Escape collapses one
+    /// before it dismisses the dialog, so this has to know about all of them —
+    /// a new dropdown that forgets to register here makes Escape close the
+    /// whole dialog out from under an open list.
+    fn any_dropdown_open(&self) -> bool {
+        self.project_dropdown_open
+            || self.agent_dropdown_open
+            || self.setup_dropdown_open
+            || self.from_dropdown_open
+            || self.existing_dropdown_open
+    }
+
+    fn close_dropdowns(&mut self) {
+        self.project_dropdown_open = false;
+        self.agent_dropdown_open = false;
+        self.setup_dropdown_open = false;
+        self.from_dropdown_open = false;
+        self.existing_dropdown_open = false;
+    }
+
+    /// The selected project's default branch, or `""` when there is none to
+    /// read. Empty is a real answer here — see [`BaseChoice::resolve`].
+    fn default_branch(&self) -> &str {
+        self.selected_project
+            .as_ref()
+            .map(|p| p.default_branch.as_str())
+            .unwrap_or_default()
+    }
+
+    /// Reload the branch list for the selected project.
+    ///
+    /// On the background executor because `git branch --list` is a subprocess
+    /// and this is called from `open_create` — a synchronous read there would
+    /// stall the window on every ⌘N in a cold repository.
+    fn reload_branches(&mut self, cx: &mut Context<Self>) {
+        self.branches.clear();
+        let Some(project) = self.selected_project.clone() else {
+            return;
+        };
+        let project_id = project.id.clone();
+        let root = std::path::PathBuf::from(&project.root_path);
+        self._branch_load = Some(cx.spawn(async move |this, cx| {
+            let names = match oximux_git::Repository::open(&root).await {
+                Ok(repo) => repo
+                    .list_branches()
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|b| b.name)
+                    .take(MAX_BRANCH_CHOICES)
+                    .collect::<Vec<_>>(),
+                // A project that is not a repository has no branches to offer.
+                // The From control still works: it falls back to the default
+                // branch, which is what an empty list means here.
+                Err(_) => Vec::new(),
+            };
+            let _ = this.update(cx, |d, cx| {
+                // Keyed on the project rather than an epoch: the only thing
+                // that invalidates a branch list is asking about a different
+                // project, and holding the slot means a later reload replaces
+                // this task rather than racing it.
+                if d.selected_project.as_ref().map(|p| p.id.as_str()) != Some(&project_id) {
+                    return;
+                }
+                d.branches = names;
+                cx.notify();
+            });
+        }));
+    }
+
+    /// Recompute the setup-skip notice for the current base.
+    ///
+    /// Runs on every base change rather than once at submit, because the whole
+    /// point is to say so **before** the user commits. One `merge-base` per
+    /// change is acceptable on a user-driven control; it is not a polling path.
+    ///
+    /// **This asks the create path's own function.** An earlier draft
+    /// reimplemented the ancestry rule here, which is precisely how a preview
+    /// comes to promise one thing while the create does another — the same
+    /// failure `branch_name` was extracted to end. `setup_decision` returns the
+    /// decision *and* the sentence, so the dialog renders the string
+    /// provisioning would have written, not a paraphrase of it.
+    fn refresh_base_warning(&mut self, cx: &mut Context<Self>) {
+        self.base_warning = None;
+        self.base_epoch += 1;
+        let epoch = self.base_epoch;
+        let Some(project) = self.selected_project.clone() else {
+            return;
+        };
+        // No named base means nothing to warn about, and no subprocess to
+        // spend finding that out.
+        let Some(base) = self.base.resolve(String::new()) else {
+            return;
+        };
+        if base.named_base().is_none() {
+            return;
+        }
+        let default = project.default_branch.clone();
+        let root = std::path::PathBuf::from(&project.root_path);
+        self._warning_load = Some(cx.spawn(async move |this, cx| {
+            let Ok(repo) = oximux_git::Repository::open(&root).await else {
+                return;
+            };
+            let default = (!default.is_empty()).then_some(default);
+            let (_, reason) = oximux_worktree_ops::setup_decision(
+                &repo,
+                &base,
+                oximux_settings::SetupDecision::Inherit,
+                default.as_deref(),
+            )
+            .await;
+            let Some(reason) = reason else {
+                return;
+            };
+            let _ = this.update(cx, |d, cx| {
+                if d.base_epoch != epoch {
+                    return;
+                }
+                // Future tense here, past tense in the transcript — same rule,
+                // same refs, read at the moment each is true.
+                d.base_warning = Some(reason.replacen("Setup skipped:", "Setup will be skipped:", 1));
+                cx.notify();
+            });
+        }));
+    }
+
+    /// The **From** / **Existing branch** control, and the setup-skip notice
+    /// the current base implies.
+    ///
+    /// Sits directly under Name because it changes what the branch line above
+    /// it means: in existing-branch mode the name no longer names the branch.
+    fn render_base_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = self.theme;
+        let density = self.density;
+        let typography = self.typography.clone();
+        let adopting = self.base.mode == BaseMode::ExistingBranch;
+
+        let segmented = div()
+            .flex()
+            .flex_row()
+            .gap(px(4.0))
+            .child(base_mode_tab(BaseMode::NewBranch, "New branch", adopting, theme, density, &typography, cx))
+            .child(base_mode_tab(BaseMode::ExistingBranch, "Existing branch", adopting, theme, density, &typography, cx));
+
+        let (label, trigger_id, open) = if adopting {
+            (
+                self.base
+                    .existing
+                    .as_deref()
+                    .unwrap_or("Choose a branch…")
+                    .to_string(),
+                "ws-dialog-existing-trigger",
+                self.existing_dropdown_open,
+            )
+        } else {
+            (
+                self.base.from_label(self.default_branch()).to_string(),
+                "ws-dialog-from-trigger",
+                self.from_dropdown_open,
+            )
+        };
+
+        let mut col = div()
+            .flex()
+            .flex_col()
+            .gap(px(2.0))
+            .child(
+                div()
+                    .text_size(px(typography.t_label_caps))
+                    .text_color(theme.fg_subtle)
+                    .child(if adopting { "Branch" } else { "From" }),
+            )
+            .child(segmented)
+            .child(
+                div()
+                    .id(trigger_id)
+                    .flex()
+                    .items_center()
+                    .h(px(FIELD_HEIGHT))
+                    .px(px(8.0))
+                    .bg(theme.bg_panel)
+                    .border_1()
+                    .border_color(theme.border_inactive)
+                    .rounded(px(density.r_xs))
+                    .cursor_pointer()
+                    .text_size(px(typography.t_body_sm))
+                    .text_color(theme.fg_base)
+                    .child(label)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                            let was = if adopting {
+                                this.existing_dropdown_open
+                            } else {
+                                this.from_dropdown_open
+                            };
+                            this.close_dropdowns();
+                            if adopting {
+                                this.existing_dropdown_open = !was;
+                            } else {
+                                this.from_dropdown_open = !was;
+                            }
+                            cx.notify();
+                        }),
+                    ),
+            );
+
+        if open {
+            let mut list = div()
+                .id("ws-dialog-branch-list")
+                .flex()
+                .flex_col()
+                .max_h(px(BRANCH_LIST_MAX_HEIGHT))
+                .overflow_y_scroll()
+                .bg(theme.bg_panel)
+                .border_1()
+                .border_color(theme.border_inactive)
+                .rounded(px(density.r_xs));
+            // "Default branch" is offered only when cutting a new branch:
+            // adopting one means naming it, and there is no default to adopt.
+            if !adopting {
+                list = list.child(branch_option_row(
+                    None,
+                    self.default_branch(),
+                    theme,
+                    &typography,
+                    cx,
+                ));
+            }
+            for (i, name) in self.branches.iter().enumerate() {
+                list = list.child(
+                    branch_option_row(Some((i, name.clone())), "", theme, &typography, cx),
+                );
+            }
+            if self.branches.is_empty() {
+                list = list.child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .h(px(FIELD_HEIGHT))
+                        .px(px(8.0))
+                        .text_size(px(typography.t_body_sm))
+                        .text_color(theme.fg_muted)
+                        .child("no local branches"),
+                );
+            }
+            col = col.child(list);
+        }
+
+        if let Some(warning) = &self.base_warning {
+            col = col.child(
+                div()
+                    .text_size(px(typography.t_body_sm))
+                    .text_color(theme.status_warn)
+                    .child(warning.clone()),
+            );
+        }
+        col
+    }
+
     /// The per-request Setup override. Deliberately the last field: the
     /// default answer ("Project default") is right almost always, and putting
     /// it above the agent picker would make every create look like a decision
@@ -743,6 +1086,106 @@ impl WorkspaceDialog {
         }
         col
     }
+}
+
+
+/// Cap on the **From** dropdown. A repo with thousands of refs makes an
+/// uncapped list useless; `list_branches` sorts by `-committerdate`, so the
+/// survivors are the branches someone actually touched.
+const MAX_BRANCH_CHOICES: usize = 50;
+
+/// Keeps the branch list a list rather than a second modal.
+const BRANCH_LIST_MAX_HEIGHT: f32 = 220.0;
+
+/// One half of the New-branch / Existing-branch segmented control.
+fn base_mode_tab(
+    mode: BaseMode,
+    label: &'static str,
+    adopting: bool,
+    theme: Theme,
+    density: Density,
+    typography: &Typography,
+    cx: &mut Context<WorkspaceDialog>,
+) -> impl IntoElement {
+    let selected = (mode == BaseMode::ExistingBranch) == adopting;
+    div()
+        .id(("ws-dialog-base-mode", mode as usize))
+        .flex()
+        .items_center()
+        .h(px(FIELD_HEIGHT))
+        .px(px(10.0))
+        .cursor_pointer()
+        .rounded(px(density.r_xs))
+        .border_1()
+        .border_color(if selected { theme.border_active } else { theme.border_inactive })
+        .bg(if selected { theme.bg_panel } else { theme.bg_base })
+        .hover(|s| s.bg(theme.hover_overlay))
+        .text_size(px(typography.t_body_sm))
+        .text_color(if selected { theme.fg_base } else { theme.fg_muted })
+        .child(label)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                if this.base.mode == mode {
+                    return;
+                }
+                this.base.mode = mode;
+                this.close_dropdowns();
+                // The other mode's answer is deliberately kept, not cleared: a
+                // user toggling to look at the other list and back should find
+                // their choice where they left it. `BaseChoice::resolve` reads
+                // only the field its mode names, so the stale one cannot leak
+                // into the result.
+                this.refresh_base_warning(cx);
+                cx.notify();
+            }),
+        )
+}
+
+/// One row of the branch dropdown. `None` is the "default branch" row, which
+/// exists only in new-branch mode.
+fn branch_option_row(
+    branch: Option<(usize, String)>,
+    default_branch: &str,
+    theme: Theme,
+    typography: &Typography,
+    cx: &mut Context<WorkspaceDialog>,
+) -> impl IntoElement {
+    let (id, label, value) = match &branch {
+        Some((i, name)) => (i + 1, name.clone(), Some(name.clone())),
+        None => (
+            0,
+            if default_branch.is_empty() {
+                "Default branch (current checkout)".to_string()
+            } else {
+                format!("Default branch ({default_branch})")
+            },
+            None,
+        ),
+    };
+    div()
+        .id(("ws-dialog-branch-opt", id))
+        .flex()
+        .items_center()
+        .h(px(FIELD_HEIGHT))
+        .px(px(8.0))
+        .cursor_pointer()
+        .hover(|s| s.bg(theme.hover_overlay))
+        .text_size(px(typography.t_body_sm))
+        .text_color(theme.fg_base)
+        .child(label)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                match this.base.mode {
+                    BaseMode::ExistingBranch => this.base.existing = value.clone(),
+                    BaseMode::NewBranch => this.base.from = value.clone(),
+                }
+                this.close_dropdowns();
+                this.refresh_base_warning(cx);
+                cx.notify();
+            }),
+        )
 }
 
 /// Order matters: `Inherit` first because it is the default and the answer a
@@ -884,6 +1327,7 @@ mod tests {
             project: Some(project("p1", "Acme")),
             agent: Some(AgentAdapter::ClaudeCode),
             setup: SetupDecision::Inherit,
+            base: BaseChoice::default(),
             linked_issue: None,
         };
         assert_eq!(payload.mode, WorkspaceDialogMode::Create);
@@ -917,6 +1361,7 @@ mod tests {
             project: None,
             agent: None,
             setup: SetupDecision::Inherit,
+            base: BaseChoice::default(),
             linked_issue: None,
         };
         assert!(payload.project.is_none());

--- a/apps/desktop/src/shell/workspace/workspace_dialog.rs
+++ b/apps/desktop/src/shell/workspace/workspace_dialog.rs
@@ -1278,6 +1278,9 @@ mod tests {
         Workspace {
             id: "id".to_string(),
             project_id: "pid".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: "old".to_string(),
             slug: "old".to_string(),
             branch: "oximux/old".to_string(),

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -290,6 +290,9 @@ fn workspaces_with_primary_for(repo: &WorkspaceRepo, project: &Project) -> Vec<W
             Workspace {
                 id: format!("primary:{}", project.id),
                 project_id: project.id.clone(),
+                // Not a branch OxiMux minted: a synthesized row or a
+                // fixture. `false` is the reading that never deletes.
+                branch_minted: false,
                 name,
                 slug,
                 branch,
@@ -1370,6 +1373,9 @@ impl WorkspaceRoot {
         let workspace = Workspace {
             id: workspace_id,
             project_id,
+            // A stub built to name a row by id and path — it carries no branch,
+            // so nothing can act on this field. `false` never deletes.
+            branch_minted: false,
             name: String::new(),
             slug: String::new(),
             branch: String::new(),
@@ -2464,11 +2470,27 @@ impl WorkspaceRoot {
                     tracing::warn!(?err, slug = %workspace.slug, "force delete: remove_worktree still failed");
                     leftovers.push(format!("worktree at {}", workspace.worktree_path));
                 }
-                if let Err(err) = repo.delete_branch(&branch, force).await {
-                    tracing::warn!(?err, branch = %branch, "delete_branch failed");
-                    // Don't bail — DB cleanup still wanted to keep
-                    // state in sync.
-                    leftovers.push(format!("branch {branch}"));
+                // ONLY a branch this workspace's create minted.
+                //
+                // `delete_branch(_, force)` is `git branch -D` on the force
+                // path, which is correct for a branch created by the same call
+                // that made the worktree and is a week of somebody's work for
+                // one the worktree merely adopted. The create path recorded
+                // which it did (`Workspace::branch_minted`); this is the guard
+                // that create-time rollback has always had, on the door the
+                // user actually walks through.
+                if workspace.branch_minted {
+                    if let Err(err) = repo.delete_branch(&branch, force).await {
+                        tracing::warn!(?err, branch = %branch, "delete_branch failed");
+                        // Don't bail — DB cleanup still wanted to keep
+                        // state in sync.
+                        leftovers.push(format!("branch {branch}"));
+                    }
+                } else {
+                    tracing::info!(
+                        branch = %branch,
+                        "keeping an adopted branch: this worktree checked it out, it did not create it"
+                    );
                 }
                 let row_deleted = match workspace_repo.delete(&workspace.id) {
                     Ok(()) => true,
@@ -2750,6 +2772,9 @@ mod nav_history_tests {
         Workspace {
             id: id.to_string(),
             project_id: "p".to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: id.to_string(),
             slug: id.to_string(),
             branch: "main".to_string(),
@@ -2782,6 +2807,9 @@ mod nav_history_tests {
         Workspace {
             id: format!("ws-{project_id}"),
             project_id: project_id.to_string(),
+            // Not a branch OxiMux minted: a synthesized row or a
+            // fixture. `false` is the reading that never deletes.
+            branch_minted: false,
             name: "w".to_string(),
             slug: "w".to_string(),
             branch: branch.to_string(),

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -144,9 +144,10 @@ pub(crate) fn build_add_project_dialog(
 // `oximux serve` creates the same worktree this flow does rather than a
 // second implementation of the same rollback ladder. Re-exported here
 // because this module is the desktop's door to it.
+use crate::shell::workspace::base_choice::BaseChoice;
 pub use oximux_worktree_ops::{
-    CreateOutcome, Provision, ProvisionEvent, SetupTranscript, create_workspace_with_rollback,
-    run_cleanup_before_remove,
+    CreateBase, CreateOutcome, Provision, ProvisionEvent, SetupTranscript,
+    create_workspace_with_rollback, run_cleanup_before_remove,
 };
 
 /// Upper bound on `default_tabs`. The list is repo-controlled and needs no
@@ -248,6 +249,7 @@ pub(crate) async fn stream_provisioning(
             ProvisionEvent::IncludeSkipped(skip) => format!("include: skipped {skip}"),
             ProvisionEvent::FreshenStarted(branch) => format!("fetching {branch}…"),
             ProvisionEvent::FreshenFinished(summary) => format!("== {summary}"),
+            ProvisionEvent::SetupSkipped(reason) => format!("== {reason}"),
             ProvisionEvent::SetupStarted(script) => format!("$ {script}"),
             ProvisionEvent::SetupLine(line) => line,
             ProvisionEvent::SetupFinished(outcome) => format!("== {}", outcome.summary()),
@@ -659,21 +661,38 @@ impl WorkspaceRoot {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let path_str = path.to_string_lossy().to_string();
-        let name = crate::shell::add_project_dialog::name_from_path(&path);
-        match self.app_state.project_repo.insert_or_touch(
-            &name,
-            &path_str,
-            crate::shell::add_project_dialog::DEFAULT_BRANCH_PLACEHOLDER,
-        ) {
-            Ok(project) => {
-                self.refresh_recent_projects();
-                self.set_active_project(project, window, cx);
-            }
-            Err(err) => {
-                tracing::warn!(?err, path = %path_str, "dropped-folder registration failed");
-            }
-        }
+        // Detected in a spawn, like both add-project paths: `default_branch`
+        // is what a new worktree gets based on, so a dropped folder must not
+        // register with a guess — and reading it is a git subprocess, which
+        // has no business on the foreground executor.
+        // Two folders dropped in quick succession would otherwise activate
+        // whichever `detect_default_branch` returned first rather than the one
+        // dropped last. The token makes the last drop win, the same way the
+        // dialog's `base_epoch` does.
+        self.drop_epoch = self.drop_epoch.wrapping_add(1);
+        let epoch = self.drop_epoch;
+        cx.spawn_in(window, async move |this, cx| {
+            let default_branch =
+                crate::shell::workspace::project_picker::detect_default_branch(&path).await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                if this.drop_epoch != epoch {
+                    tracing::debug!("dropped-folder registration superseded by a later drop");
+                    return;
+                }
+                let path_str = path.to_string_lossy().to_string();
+                let name = crate::shell::add_project_dialog::name_from_path(&path);
+                match this.app_state.project_repo.insert_or_touch(&name, &path_str, &default_branch) {
+                    Ok(project) => {
+                        this.refresh_recent_projects();
+                        this.set_active_project(project, window, cx);
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, path = %path_str, "dropped-folder registration failed");
+                    }
+                }
+            });
+        })
+        .detach();
     }
 
     /// Push hidden-state to every project's terminals except `active_id`, so a
@@ -1899,6 +1918,7 @@ impl WorkspaceRoot {
                     None,
                     submit.linked_issue,
                     submit.setup,
+                    submit.base,
                     false,
                     window,
                     cx,
@@ -1925,6 +1945,10 @@ impl WorkspaceRoot {
         // every caller but the create dialog — defers to the project's
         // committed `auto_setup`.
         setup_decision: oximux_settings::SetupDecision,
+        // What the worktree is cut from. The create dialog passes the user's
+        // **From** selection; every other caller passes the default, which is
+        // a new branch based on the project's default branch.
+        base: BaseChoice,
         activate_after: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -1979,6 +2003,15 @@ impl WorkspaceRoot {
         // gap this phase closed.
         let branch = crate::git_settings::branch_for_slug(&slug, Some(&project_root), cx);
         let freshen_default = crate::git_settings::settings(cx).keep_default_up_to_date;
+        // Folded HERE, beside the branch resolution, for the same reason: the
+        // dialog showed the user a base, and re-deriving it inside the spawn
+        // would let the preview and the create disagree.
+        let Some(base) = base.resolve(branch) else {
+            // Submit is disabled on an incomplete choice, so this is a bug
+            // rather than a user error — log it instead of failing silently.
+            tracing::warn!(slug = %slug, "workspace create: incomplete base choice");
+            return;
+        };
 
         cx.spawn(async move |weak, cx| {
             if let Some(parent) = worktree_path.parent()
@@ -2009,7 +2042,7 @@ impl WorkspaceRoot {
                 &project_id,
                 &name_trimmed,
                 &slug,
-                &branch,
+                &base,
                 &worktree_path,
                 linked_issue.as_deref(),
                 &workspace_repo,

--- a/apps/desktop/src/state.rs
+++ b/apps/desktop/src/state.rs
@@ -243,7 +243,7 @@ mod tests {
 
         let project = project_repo.insert("p", "/p", "main").expect("project");
         let workspace = workspace_repo
-            .insert(&project.id, "ws", "ws", "oximux/ws", "/p/ws")
+            .insert(&project.id, "ws", "ws", "oximux/ws", "/p/ws", true)
             .expect("workspace");
         let alive_1 = agent_repo
             .insert(&workspace.id, "claude", None, None)
@@ -334,13 +334,13 @@ mod tests {
         let a = project_repo.insert("a", "/a", "main").expect("a");
         let b = project_repo.insert("b", "/b", "main").expect("b");
         workspace_repo
-            .insert(&a.id, "wa", "wa", "oximux/wa", "/a/wa")
+            .insert(&a.id, "wa", "wa", "oximux/wa", "/a/wa", true)
             .expect("wa");
         workspace_repo
-            .insert(&b.id, "wb1", "wb1", "oximux/wb1", "/b/wb1")
+            .insert(&b.id, "wb1", "wb1", "oximux/wb1", "/b/wb1", true)
             .expect("wb1");
         workspace_repo
-            .insert(&b.id, "wb2", "wb2", "oximux/wb2", "/b/wb2")
+            .insert(&b.id, "wb2", "wb2", "oximux/wb2", "/b/wb2", true)
             .expect("wb2");
 
         let state = hydrate(db).expect("hydrate");
@@ -357,7 +357,7 @@ mod tests {
         let agent_repo = AgentSessionRepo::new(db.clone());
         let project = project_repo.insert("p", "/p", "main").expect("project");
         let workspace = workspace_repo
-            .insert(&project.id, "ws", "ws", "oximux/ws", "/p/ws")
+            .insert(&project.id, "ws", "ws", "oximux/ws", "/p/ws", true)
             .expect("workspace");
         let session = agent_repo
             .insert(&workspace.id, "claude", None, None)

--- a/apps/desktop/src/workspace_root/mod.rs
+++ b/apps/desktop/src/workspace_root/mod.rs
@@ -203,6 +203,11 @@ pub(crate) fn chat_backend_for_profile(
 }
 
 pub struct WorkspaceRoot {
+    /// Cancel-on-supersede token for `add_project_from_drop`, which reads a
+    /// project's default branch in a spawn before registering it. Without this,
+    /// two folders dropped in quick succession activate whichever git call
+    /// returned first rather than the one dropped last.
+    pub(crate) drop_epoch: u64,
     pub(crate) theme: Theme,
     pub(crate) density: Density,
     pub(crate) typography: Typography,
@@ -1265,6 +1270,7 @@ impl WorkspaceRoot {
         // entities the original subscriptions would otherwise orphan.
 
         let mut this = Self {
+            drop_epoch: 0,
             theme,
             density,
             typography,

--- a/apps/desktop/src/workspace_root/render.rs
+++ b/apps/desktop/src/workspace_root/render.rs
@@ -580,7 +580,7 @@ impl Render for WorkspaceRoot {
                         crate::git_settings::settings(cx).keep_default_up_to_date;
                     cx.spawn(async move |weak_root, cx| {
                         use crate::shell::workspace_ops::{
-                            ChatWorktreeOutcome, CreateOutcome, Provision,
+                            ChatWorktreeOutcome, CreateBase, CreateOutcome, Provision,
                             create_workspace_with_rollback, provisioning_transcript_path,
                             stream_provisioning,
                         };
@@ -591,12 +591,19 @@ impl Render for WorkspaceRoot {
                         });
                         // `name` = slug: the human label derived from the branch
                         // slug (collision handled inside `insert`).
+                        // The project's default branch, not "wherever HEAD is" —
+                        // `new_branch` means exactly that, resolved with git at
+                        // create time. This path runs UNATTENDED (a chat pill
+                        // the user clicked once), so inheriting a half-finished
+                        // feature branch here is the defect with the fewest
+                        // ways for anyone to notice.
+                        let base = CreateBase::new_branch(branch);
                         let outcome = create_workspace_with_rollback(
                             &project_root,
                             &project_id,
                             &slug,
                             &slug,
-                            &branch,
+                            &base,
                             &worktree_path,
                             None,
                             &workspace_repo,

--- a/apps/desktop/tests/workspace_create_rollback.rs
+++ b/apps/desktop/tests/workspace_create_rollback.rs
@@ -74,13 +74,7 @@ async fn rollback_on_insert_conflict_removes_worktree_and_branch() {
     // orchestration tries to insert after the git step.
     let slug = "fix-login";
     workspace_repo
-        .insert(
-            &project.id,
-            "Pre-existing",
-            slug,
-            "oximux/fix-login",
-            "/dummy",
-        )
+        .insert(&project.id, "Pre-existing", slug, "oximux/fix-login", "/dummy", true)
         .expect("pre-insert");
 
     let worktree_path = tmp.path().join("worktrees").join(slug);
@@ -805,7 +799,7 @@ async fn a_failed_create_never_deletes_the_branch_it_adopted() {
     // AFTER the git step — the exact window the rollback ladder exists for.
     let slug = "adopted-conflict";
     workspace_repo
-        .insert(&project.id, "Pre-existing", slug, "side", "/dummy")
+        .insert(&project.id, "Pre-existing", slug, "side", "/dummy", false)
         .expect("pre-insert");
 
     let worktree_path = tmp.path().join("worktrees").join(slug);
@@ -977,4 +971,80 @@ async fn a_default_branch_that_exists_only_on_the_remote_still_creates_the_named
         .output()
         .expect("git");
     assert_eq!(String::from_utf8(out.stdout).unwrap().trim(), branch_of(slug));
+}
+
+/// **H3, closed end to end.** Create-time rollback already refused to delete an
+/// adopted branch, but *deleting the workspace later* went through a different
+/// door and ran `git branch -D` unconditionally — the same data loss, reached
+/// by the gesture a user actually performs.
+///
+/// The fix is that the create records which it did. This asserts the record is
+/// what a delete path would read, in both directions: an adopted branch is
+/// marked so the branch survives, and a minted one is marked so cleanup still
+/// happens. Without the second half the guard would leak a dangling branch on
+/// every ordinary delete, forever.
+#[tokio::test]
+async fn the_row_records_whether_the_branch_was_minted_or_adopted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    // Adopted: `side` existed before OxiMux ever saw it.
+    let adopted = match create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Adopted",
+        "adopted",
+        &CreateBase::existing("side"),
+        &tmp.path().join("worktrees").join("adopted"),
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await
+    {
+        CreateOutcome::Created(row) => row,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert_eq!(adopted.branch, "side");
+    assert!(
+        !adopted.branch_minted,
+        "adopting a branch must record that we did NOT create it — otherwise \
+         deleting the workspace force-deletes the user's branch"
+    );
+
+    // Minted: ours, and cleanup must still remove it.
+    let minted = match create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Minted",
+        "minted",
+        &base_of("minted"),
+        &tmp.path().join("worktrees").join("minted"),
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await
+    {
+        CreateOutcome::Created(row) => row,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert!(
+        minted.branch_minted,
+        "an ordinary create must stay cleanable, or every delete leaks a branch"
+    );
+
+    // And both survive the trip through storage, which is where the delete
+    // paths read them from.
+    let reread = |id: &str| {
+        workspace_repo
+            .get_by_id(id)
+            .expect("get")
+            .expect("row")
+            .branch_minted
+    };
+    assert!(!reread(&adopted.id));
+    assert!(reread(&minted.id));
 }

--- a/apps/desktop/tests/workspace_create_rollback.rs
+++ b/apps/desktop/tests/workspace_create_rollback.rs
@@ -8,7 +8,9 @@
 use std::path::Path;
 use std::process::Command;
 
-use oximux_app::shell::workspace_ops::{CreateOutcome, Provision, create_workspace_with_rollback};
+use oximux_app::shell::workspace_ops::{
+    CreateBase, CreateOutcome, Provision, create_workspace_with_rollback,
+};
 use oximux_git::Repository;
 use oximux_storage::{ProjectRepo, WorkspaceRepo, open_memory};
 
@@ -42,6 +44,15 @@ fn init_repo(cwd: &Path) {
 /// than resolving settings that no headless test has.
 fn branch_of(slug: &str) -> String {
     format!("{}/{slug}", oximux_settings::git::DEFAULT_PREFIX)
+}
+
+/// The base every pre-existing test in this file means: a new branch named the
+/// shipped way, cut where `git worktree add -b` used to cut it. Keeping these
+/// on `new_branch` rather than `new_branch_from` is deliberate — it is the
+/// no-start-point argv, so the guards these tests pin stay pinned against the
+/// same git invocation they were written for.
+fn base_of(slug: &str) -> CreateBase {
+    CreateBase::new_branch(branch_of(slug))
 }
 
 #[tokio::test]
@@ -79,7 +90,7 @@ async fn rollback_on_insert_conflict_removes_worktree_and_branch() {
         &project.id,
         "Fix Login",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -133,7 +144,7 @@ async fn create_workspace_happy_path_inserts_row_and_keeps_worktree() {
         &project.id,
         "New Feat",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -208,7 +219,7 @@ async fn a_failing_setup_script_rolls_back_worktree_branch_and_row() {
         &project.id,
         "Bad Setup",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -280,7 +291,7 @@ async fn a_failing_setup_script_is_not_run_when_the_project_did_not_opt_in() {
         &project.id,
         "Opted Out",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -326,7 +337,7 @@ async fn included_files_are_present_before_the_setup_script_runs() {
         &project.id,
         "With Env",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -369,7 +380,7 @@ async fn an_include_pattern_matching_nothing_does_not_fail_creation() {
         &project.id,
         "No Match",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -410,7 +421,7 @@ async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry()
         &project.id,
         "Interrupted",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -432,7 +443,7 @@ async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry()
         &project.id,
         "Interrupted",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -475,7 +486,7 @@ async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
         &project.id,
         "Live Work",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -493,7 +504,7 @@ async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
         &project.id,
         "Live Work",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -540,7 +551,7 @@ async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
         &project.id,
         "Mine",
         slug,
-        &branch_of(slug),
+        &base_of(slug),
         &worktree_path,
         None,
         &workspace_repo,
@@ -557,4 +568,413 @@ async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
         "not yours\n",
         "a non-opted-in create deleted a directory it did not own"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Base ref + existing branch (phase 2)
+// ---------------------------------------------------------------------------
+
+/// A repo whose committed setup script writes a marker file, plus a `side`
+/// branch that carries the same script but is NOT an ancestor of `main`.
+///
+/// The marker is the whole point: "did setup run" has to be a fact on disk,
+/// not an absence in a log. `create_workspace_with_rollback` reports a setup
+/// failure loudly and a setup *skip* quietly, so a test that only checked the
+/// outcome would pass whether or not the guard did anything.
+fn repo_with_a_marker_script_and_a_side_branch(root: &Path) {
+    init_repo(root);
+    commit_scripts(
+        root,
+        "auto_setup = true\nsetup = \"touch setup-ran.marker\"\n",
+    );
+    // `side` diverges: it commits something `main` does not have, so it is not
+    // an ancestor of `main` and reads as an unreviewed base.
+    run_git(root, &["checkout", "-q", "-b", "side"]);
+    std::fs::write(root.join("theirs.txt"), "contributed\n").expect("write");
+    run_git(root, &["add", "theirs.txt"]);
+    run_git(root, &["commit", "-m", "their work"]);
+    run_git(root, &["checkout", "-q", "main"]);
+}
+
+fn seed_project(root: &Path) -> (WorkspaceRepo, oximux_core::Project) {
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let project = project_repo
+        .insert("Acme", root.to_str().unwrap(), "main")
+        .expect("project");
+    (workspace_repo, project)
+}
+
+/// The guard: provisioning runs the *worktree's own committed* setup script,
+/// which is safe only while every worktree branches off the user's own HEAD.
+/// A base the user has not reviewed must not run its author's script.
+#[tokio::test]
+async fn a_base_that_is_not_an_ancestor_of_the_default_skips_the_setup_script() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let slug = "review-theirs";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Review Theirs",
+        slug,
+        &CreateBase::new_branch_from(branch_of(slug), "side"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::Created(_)),
+        "the guard skips setup; it does not fail the create: {outcome:?}"
+    );
+    assert!(
+        !worktree_path.join("setup-ran.marker").exists(),
+        "an unreviewed base ran its own committed setup script"
+    );
+    // The worktree is real and based where it was asked to be — skipping setup
+    // must not have skipped the create.
+    assert!(worktree_path.join("theirs.txt").exists());
+}
+
+/// The other arm, and the one that proves the guard is not simply "never run
+/// setup any more": a base already contained in the default branch is one the
+/// user lives on, and provisioning is unchanged for it.
+#[tokio::test]
+async fn a_base_that_is_an_ancestor_of_the_default_still_runs_setup() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let slug = "ordinary";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Ordinary",
+        slug,
+        &CreateBase::new_branch_from(branch_of(slug), "main"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(matches!(outcome, CreateOutcome::Created(_)), "{outcome:?}");
+    assert!(
+        worktree_path.join("setup-ran.marker").exists(),
+        "a reviewed base must provision exactly as before"
+    );
+}
+
+/// The skip is a default, not a prohibition — `Run setup` from the row menu is
+/// how a user opts in after reading the script, and it has to actually win.
+#[tokio::test]
+async fn an_explicit_run_setup_overrides_the_unreviewed_base_guard() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let slug = "opted-in";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Opted In",
+        slug,
+        &CreateBase::new_branch_from(branch_of(slug), "side"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision {
+            setup: oximux_settings::SetupDecision::Run,
+            ..Provision::default()
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, CreateOutcome::Created(_)), "{outcome:?}");
+    assert!(
+        worktree_path.join("setup-ran.marker").exists(),
+        "an explicit Run must override the guard"
+    );
+}
+
+/// The reason reaches whoever is watching. A silent skip is indistinguishable
+/// from a project with no setup script, which is exactly the confusion the
+/// event exists to prevent.
+#[tokio::test]
+async fn the_skip_reason_reaches_the_provisioning_transcript() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let slug = "watched";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Watched",
+        slug,
+        &CreateBase::new_branch_from(branch_of(slug), "side"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::new(oximux_settings::SetupDecision::Inherit, tx),
+    )
+    .await;
+    assert!(matches!(outcome, CreateOutcome::Created(_)), "{outcome:?}");
+
+    let mut reason = None;
+    while let Ok(event) = rx.try_recv() {
+        if let oximux_app::shell::workspace_ops::ProvisionEvent::SetupSkipped(text) = event {
+            reason = Some(text);
+        }
+    }
+    let reason = reason.expect("no SetupSkipped event was emitted");
+    assert!(
+        reason.contains("side") && reason.contains("main"),
+        "the reason must name both refs so the user can judge it: {reason}"
+    );
+    assert!(
+        reason.contains("Run setup"),
+        "the reason must name the way out: {reason}"
+    );
+}
+
+/// An adopted branch is the row's branch. No `oximux/`-prefixed branch is
+/// minted, because the user named the branch and we did not.
+#[tokio::test]
+async fn an_adopted_branch_becomes_the_rows_branch_with_no_prefix_applied() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let slug = "adopted";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Adopted",
+        slug,
+        &CreateBase::existing("side"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    match outcome {
+        CreateOutcome::Created(row) => assert_eq!(row.branch, "side"),
+        other => panic!("expected Created, got {other:?}"),
+    }
+    let repo = Repository::open(project_root).await.expect("open");
+    let branches = repo.list_branches().await.expect("branches");
+    assert!(
+        !branches.iter().any(|b| b.name.starts_with("oximux/")),
+        "adopting a branch minted one anyway: {branches:?}"
+    );
+}
+
+/// **The data-loss guard.** Rollback force-deletes the branch — correct for one
+/// this create minted a moment ago, and a week of someone's work for one it
+/// merely adopted. A failed create must leave an adopted branch exactly as it
+/// found it.
+#[tokio::test]
+async fn a_failed_create_never_deletes_the_branch_it_adopted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    // Force the UNIQUE conflict on `(project_id, slug)` so the insert fails
+    // AFTER the git step — the exact window the rollback ladder exists for.
+    let slug = "adopted-conflict";
+    workspace_repo
+        .insert(&project.id, "Pre-existing", slug, "side", "/dummy")
+        .expect("pre-insert");
+
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Adopted Conflict",
+        slug,
+        &CreateBase::existing("side"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, CreateOutcome::StorageFailedRollbackClean(_)),
+        "expected a clean rollback, got {outcome:?}"
+    );
+    // The worktree is gone — the rollback did run.
+    assert!(!worktree_path.exists(), "rollback left the worktree behind");
+    // And the branch survived it.
+    let repo = Repository::open(project_root).await.expect("open");
+    let branches = repo.list_branches().await.expect("branches");
+    assert!(
+        branches.iter().any(|b| b.name == "side"),
+        "rollback deleted the adopted branch: {branches:?}"
+    );
+    // Its commit is still reachable, which is the thing that actually matters.
+    run_git(project_root, &["rev-parse", "--verify", "side"]);
+}
+
+/// **The unattended path.** The chat pill creates a worktree from a draft the
+/// user clicked once; it runs with no dialog, no preview, and nobody watching.
+/// Basing it on "wherever the main checkout's HEAD happened to be" is the
+/// defect with the fewest ways for anyone to notice — the work looks fine
+/// until review, when it turns out to carry somebody's half-finished feature
+/// branch underneath.
+///
+/// `workspace_root/render.rs` passes `project.default_branch` explicitly for
+/// exactly this reason. This pins the property that choice buys, at the layer
+/// where it can be asserted: the render-path listener itself is a GPUI closure
+/// with no seam to call.
+#[tokio::test]
+async fn an_unattended_create_does_not_inherit_a_feature_branch_head() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    init_repo(project_root);
+    let main_tip = {
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(project_root)
+            .output()
+            .expect("git");
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    };
+    // The main checkout wanders off onto a feature branch, as it does all day.
+    run_git(project_root, &["checkout", "-q", "-b", "wip"]);
+    std::fs::write(project_root.join("half-done.txt"), "wip\n").expect("write");
+    run_git(project_root, &["add", "half-done.txt"]);
+    run_git(project_root, &["commit", "-m", "half done"]);
+
+    let (workspace_repo, project) = seed_project(project_root);
+    let slug = "from-chat";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "From Chat",
+        slug,
+        // What the chat pill passes.
+        &CreateBase::new_branch_from(branch_of(slug), &project.default_branch),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(matches!(outcome, CreateOutcome::Created(_)), "{outcome:?}");
+
+    // The new branch sits on `main`'s tip, not on `wip`'s.
+    let out = Command::new("git")
+        .args(["rev-parse", &branch_of(slug)])
+        .current_dir(project_root)
+        .output()
+        .expect("git");
+    let tip = String::from_utf8(out.stdout).unwrap().trim().to_string();
+    assert_eq!(tip, main_tip, "an unattended create inherited the wip HEAD");
+    assert!(
+        !worktree_path.join("half-done.txt").exists(),
+        "the feature branch's work leaked into a worktree that never asked for it"
+    );
+}
+
+/// **The end-to-end C1 regression.** A project whose default branch exists only
+/// as `origin/main` — the ordinary state of a worktree-centric checkout after
+/// the user deletes the local `main` they never sit on.
+///
+/// `git worktree add` DWIMs such a name into `--track -b <name>`, overriding an
+/// explicit `-b`, so an unguarded create landed the worktree on `main`, never
+/// made `oximux/<slug>`, and inserted a row naming a branch that did not exist.
+///
+/// The create path must still produce a working worktree on the branch it
+/// promised: an unresolvable default degrades to HEAD rather than failing, per
+/// the plan's own risk note ("fall back … rather than failing creation").
+#[tokio::test]
+async fn a_default_branch_that_exists_only_on_the_remote_still_creates_the_named_branch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let origin = tmp.path().join("origin");
+    std::fs::create_dir_all(&origin).unwrap();
+    run_git(&origin, &["init", "-q", "--bare"]);
+
+    let project_root = tmp.path().join("work");
+    std::fs::create_dir_all(&project_root).unwrap();
+    init_repo(&project_root);
+    run_git(&project_root, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    run_git(&project_root, &["push", "-q", "origin", "main"]);
+    run_git(&project_root, &["checkout", "-q", "-b", "dev"]);
+    run_git(&project_root, &["branch", "-D", "main"]);
+    run_git(&project_root, &["remote", "set-head", "origin", "main"]);
+
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    // The stored default is `main` — captured when the local branch still
+    // existed, which is exactly how this goes stale in the field.
+    let project = project_repo
+        .insert("Acme", project_root.to_str().unwrap(), "main")
+        .expect("project");
+
+    let slug = "feat";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        &project_root,
+        &project.id,
+        "Feat",
+        slug,
+        // What ⌘N with every control left alone produces.
+        &base_of(slug),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+
+    let row = match outcome {
+        CreateOutcome::Created(row) => row,
+        other => panic!("a stale default branch must not fail the create: {other:?}"),
+    };
+    // The row names the branch we minted — not the one git's DWIM wanted.
+    assert_eq!(row.branch, branch_of(slug));
+    // And that branch actually exists, which is the half the DWIM used to break.
+    let repo = Repository::open(&project_root).await.expect("open");
+    let branches = repo.list_branches().await.expect("branches");
+    assert!(
+        branches.iter().any(|b| b.name == branch_of(slug)),
+        "the row names a branch that was never created: {branches:?}"
+    );
+    assert!(
+        !branches.iter().any(|b| b.name == "main"),
+        "git minted a local `main` behind our back: {branches:?}"
+    );
+    // The worktree is on our branch, not on `main`.
+    let out = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(&worktree_path)
+        .output()
+        .expect("git");
+    assert_eq!(String::from_utf8(out.stdout).unwrap().trim(), branch_of(slug));
 }

--- a/apps/desktop/tests/workspace_create_rollback.rs
+++ b/apps/desktop/tests/workspace_create_rollback.rs
@@ -1048,3 +1048,68 @@ async fn the_row_records_whether_the_branch_was_minted_or_adopted() {
     assert!(!reread(&adopted.id));
     assert!(reread(&minted.id));
 }
+
+/// **Adopting a branch must be judged against the real default branch.**
+///
+/// `default_branch` was briefly not read at all in existing-branch mode — it
+/// looked like a saved subprocess. But `named_base()` is `Some` for an adopted
+/// branch, so the guard hit its "no default branch" arm every time and told the
+/// user *"could not verify `behind` against the default branch (this repository
+/// has no default branch)"* on a repo that plainly had one. Two things followed
+/// from the same line: an adopted branch that IS an ancestor could never
+/// provision, and `freshen_default` became a no-op for adopts.
+///
+/// `behind` here points at an earlier commit of `main`, so it is contained in
+/// the default branch's history — reviewed by definition, and setup must run.
+#[tokio::test]
+async fn adopting_a_branch_contained_in_the_default_still_runs_setup() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path();
+    repo_with_a_marker_script_and_a_side_branch(project_root);
+    // Move `main` on by one, then point `behind` at the commit before it: an
+    // ancestor of `main`, unlike `side`, and — critically — one that already
+    // carries `.oximux/scripts.toml`, or there would be no setup script to run
+    // and the assertion below would pass for the wrong reason.
+    let scripts_commit = {
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(project_root)
+            .output()
+            .expect("git");
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    };
+    std::fs::write(project_root.join("later.txt"), "later\n").expect("write");
+    run_git(project_root, &["add", "later.txt"]);
+    run_git(project_root, &["commit", "-m", "later"]);
+    run_git(project_root, &["branch", "behind", &scripts_commit]);
+    let (workspace_repo, project) = seed_project(project_root);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let slug = "adopt-behind";
+    let worktree_path = tmp.path().join("worktrees").join(slug);
+    let outcome = create_workspace_with_rollback(
+        project_root,
+        &project.id,
+        "Adopt Behind",
+        slug,
+        &CreateBase::existing("behind"),
+        &worktree_path,
+        None,
+        &workspace_repo,
+        &Provision::new(oximux_settings::SetupDecision::Inherit, tx),
+    )
+    .await;
+    assert!(matches!(outcome, CreateOutcome::Created(_)), "{outcome:?}");
+
+    assert!(
+        worktree_path.join("setup-ran.marker").exists(),
+        "an adopted branch already contained in the default branch is reviewed \
+         by definition; setup must run"
+    );
+    // And nothing claimed the repository has no default branch.
+    while let Ok(event) = rx.try_recv() {
+        if let oximux_app::shell::workspace_ops::ProvisionEvent::SetupSkipped(text) = event {
+            panic!("setup was skipped for a reviewed base: {text}");
+        }
+    }
+}

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -59,6 +59,31 @@ pub struct Workspace {
     /// anything unrecognised.
     #[serde(default)]
     pub phase: String,
+    /// Whether OxiMux **minted** this worktree's branch, as opposed to
+    /// adopting one that already existed.
+    ///
+    /// **A data-loss guard, and the only durable record of the distinction.**
+    /// Every lifecycle path that removes a worktree also removes its branch —
+    /// correct for a branch created by the same call that made the worktree,
+    /// and destructive for one the user has had for a week. The create path is
+    /// the only place that knows which happened, and nothing downstream can
+    /// work it out afterwards: inferring from the configured prefix is wrong
+    /// for a user who turned the prefix off, and wrong again for an adopted
+    /// branch that happens to match it.
+    ///
+    /// `#[serde(default = "default_true")]` because every workspace that
+    /// predates this field was necessarily minted — adopting a branch shipped
+    /// with the field itself — so `true` is the correct reading of an old
+    /// snapshot, not merely a safe one.
+    #[serde(default = "default_true")]
+    pub branch_minted: bool,
+}
+
+/// `true`, for [`Workspace::branch_minted`]'s serde default. A bare `default`
+/// would give `false` — "adopted" — which is the destructive reading of every
+/// pre-field snapshot.
+fn default_true() -> bool {
+    true
 }
 
 /// The closed vocabulary a worktree's [`Workspace::phase`] is written with.

--- a/crates/git/src/branch.rs
+++ b/crates/git/src/branch.rs
@@ -171,6 +171,15 @@ impl Repository {
             let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
             if let Some(name) = text.strip_prefix("origin/")
                 && !name.is_empty()
+                // `origin/HEAD` names the REMOTE's default, which need not
+                // exist locally at all — a worktree-centric user routinely
+                // deletes the `main` they never sit on. Reporting a name with
+                // no `refs/heads/` entry used to be harmless (it only labelled
+                // a menu); it is now an argument to `git worktree add`, where
+                // git DWIMs it into `--track -b <name>` and silently overrides
+                // an explicit `-b`. Fall through to the conventional names
+                // rather than hand back something that does not resolve.
+                && self.sha_of(&format!("refs/heads/{name}")).await.ok().flatten().is_some()
             {
                 return Ok(Some(name.to_string()));
             }

--- a/crates/git/src/branch.rs
+++ b/crates/git/src/branch.rs
@@ -162,6 +162,20 @@ impl Repository {
     /// Not `current_branch`: where HEAD happens to be is what a merge
     /// pre-flight *compares against*, so using it as the target would make that
     /// comparison vacuous.
+    /// **The returned name may have no local ref.** `origin/HEAD` names the
+    /// *remote's* default, and a worktree-centric checkout routinely has no
+    /// local `main` at all — the user deleted the branch they never sit on.
+    /// This still reports `main`, because that IS the project's default branch
+    /// and the name is what a merge target, a menu label, and an ancestry
+    /// comparison all want.
+    ///
+    /// A caller that needs something it can *check out* must resolve the name
+    /// first; `oximux_worktree_ops::resolvable_default` is that resolution, and
+    /// it tries the remote-tracking spelling before giving up. An earlier
+    /// attempt to verify `refs/heads/<name>` here instead was worse: it turned
+    /// "the default is main, held at origin/main" into `None`, and the create
+    /// path then based new work on whatever the checkout was parked on — the
+    /// exact defect base refs exist to close. Caught by live verification.
     pub async fn default_branch(&self) -> Result<Option<String>> {
         if let Ok(out) = GitCmd::new(self.workdir())
             .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
@@ -171,15 +185,6 @@ impl Repository {
             let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
             if let Some(name) = text.strip_prefix("origin/")
                 && !name.is_empty()
-                // `origin/HEAD` names the REMOTE's default, which need not
-                // exist locally at all — a worktree-centric user routinely
-                // deletes the `main` they never sit on. Reporting a name with
-                // no `refs/heads/` entry used to be harmless (it only labelled
-                // a menu); it is now an argument to `git worktree add`, where
-                // git DWIMs it into `--track -b <name>` and silently overrides
-                // an explicit `-b`. Fall through to the conventional names
-                // rather than hand back something that does not resolve.
-                && self.sha_of(&format!("refs/heads/{name}")).await.ok().flatten().is_some()
             {
                 return Ok(Some(name.to_string()));
             }

--- a/crates/git/src/merge.rs
+++ b/crates/git/src/merge.rs
@@ -137,7 +137,10 @@ impl Repository {
             return Err(GitError::invalid_input("revision is empty"));
         }
         let raw = GitCmd::new(self.workdir())
-            .args(["merge-base", "--is-ancestor", ancestor, descendant])
+            // `--` before the revisions: both are caller-supplied, and this is
+            // the one comparison that runs BEFORE `add_worktree_from`'s own
+            // validation on the create path.
+            .args(["merge-base", "--is-ancestor", "--", ancestor, descendant])
             .run_raw()
             .await?;
         if raw.status.success() {

--- a/crates/git/src/worktree.rs
+++ b/crates/git/src/worktree.rs
@@ -64,13 +64,124 @@ impl Repository {
     /// `path` must not already exist; `branch` must pass
     /// [`validate_branch_name`]. The branch must not already exist (git
     /// refuses with `NonZero` if it does).
+    ///
+    /// **Branches from whatever HEAD happens to be.** The desktop and the CLI
+    /// no longer call this — they name a base explicitly through
+    /// [`add_worktree_from`](Self::add_worktree_from), because "wherever HEAD
+    /// was" silently bases a new worktree on a half-finished feature branch.
+    /// This form stays for callers that genuinely mean the current HEAD.
     pub async fn add_worktree(&self, path: &Path, branch: &str) -> Result<WorktreeInfo> {
         validate_branch_name(branch)?;
         GitCmd::new(self.workdir())
-            .args(["worktree", "add", "-b", branch])
+            .args(["worktree", "add", "-b", branch, "--"])
             .arg(path.as_os_str())
             .run()
             .await?;
+        self.worktree_at(path).await
+    }
+
+    /// Create a linked worktree at `path` on a new `branch` cut from
+    /// `start_point`, rather than from the main checkout's HEAD.
+    ///
+    /// `start_point` is anything git resolves as a commit-ish — a branch, a
+    /// tag, a SHA. It must pass [`validate_ref_name`]; `branch` must pass
+    /// [`validate_branch_name`] and must not already exist.
+    ///
+    /// Both positionals sit after a `--` terminator. Git would treat a
+    /// flag-shaped ref as a reference name even without it (it fails with
+    /// `invalid reference: --force`), but the terminator is what makes that a
+    /// property of the argv rather than of git's current option parser, and it
+    /// matches `merge.rs` and `branch.rs`.
+    ///
+    /// # The start point is resolved to a SHA first, and that is load-bearing
+    ///
+    /// `git worktree add` DWIMs a commit-ish that names no local branch but
+    /// exactly one remote-tracking branch into `--track -b <that name>` — and
+    /// **that override beats an explicit `-b`**. Verified on git 2.55:
+    ///
+    /// ```text
+    /// $ git worktree add -b oximux/x -- ../wt main   # local `main` deleted,
+    /// Preparing worktree (new branch 'main')          # origin/main present
+    /// branch 'main' set up to track 'origin/main'.
+    /// ```
+    ///
+    /// The worktree lands on `main`, `oximux/x` is never created, and nothing
+    /// reports a problem. The `workspaces` row would then name a branch that
+    /// does not exist, breaking the three-way agreement the crate is built on —
+    /// and a worktree-centric user who deleted their local `main` hits it on an
+    /// ordinary create with no flags at all.
+    ///
+    /// Passing a raw SHA removes the ambiguity DWIM keys on, so `-b` is
+    /// honoured. A start point that does not resolve is refused here rather
+    /// than silently reinterpreted.
+    pub async fn add_worktree_from(
+        &self,
+        path: &Path,
+        branch: &str,
+        start_point: &str,
+    ) -> Result<WorktreeInfo> {
+        validate_branch_name(branch)?;
+        validate_ref_name(start_point)?;
+        let sha = self.sha_of(start_point).await?.ok_or_else(|| {
+            GitError::invalid_input(format!("start point {start_point:?} does not resolve"))
+        })?;
+        GitCmd::new(self.workdir())
+            .args(["worktree", "add", "-b", branch, "--"])
+            .arg(path.as_os_str())
+            .arg(&sha)
+            .run()
+            .await?;
+        self.worktree_at(path).await
+    }
+
+    /// Check an **existing** `branch` out into a new linked worktree at `path`.
+    ///
+    /// No `-b`, so no branch is created and no prefix applies: the worktree
+    /// adopts the branch under whatever name it already has. `branch` must pass
+    /// [`validate_ref_name`] rather than [`validate_branch_name`] — an adopted
+    /// branch is somebody else's name and may carry more than one prefix
+    /// segment (`feature/api/retry`), which the one-segment branch rule exists
+    /// to forbid only for names OxiMux itself mints.
+    ///
+    /// Git refuses when the branch is already checked out in another worktree,
+    /// and its message names that worktree; the error carries git's own text so
+    /// the caller can surface the reason verbatim.
+    ///
+    /// # Why this insists the local branch already exists
+    ///
+    /// "Adopt" has to mean adopt. Handed a name git resolves some other way,
+    /// `git worktree add <path> <name>` quietly does something else — and both
+    /// alternatives break a caller that has already decided this branch was not
+    /// minted here:
+    ///
+    /// - a name that exists only as `origin/<name>` **creates** a local branch
+    ///   (`Preparing worktree (new branch 'main')`), which the create path then
+    ///   declines to clean up on rollback, because it believes it adopted one;
+    /// - a **tag** or a raw SHA produces a detached HEAD, leaving the
+    ///   `workspaces` row naming a branch the worktree is not on.
+    ///
+    /// So the check is `refs/heads/<branch>`, not "does this resolve".
+    /// Rejecting here costs the user an explicit `--from` for the cases they
+    /// probably meant; accepting silently costs them the invariant.
+    pub async fn add_worktree_existing(&self, path: &Path, branch: &str) -> Result<WorktreeInfo> {
+        validate_ref_name(branch)?;
+        if self.sha_of(&format!("refs/heads/{branch}")).await?.is_none() {
+            return Err(GitError::invalid_input(format!(
+                "no local branch named {branch:?} \
+                 (a remote-only branch or a tag needs `--from` instead)"
+            )));
+        }
+        GitCmd::new(self.workdir())
+            .args(["worktree", "add", "--"])
+            .arg(path.as_os_str())
+            .arg(branch)
+            .run()
+            .await?;
+        self.worktree_at(path).await
+    }
+
+    /// The freshly-added worktree at `path`, looked up in `git worktree list`.
+    async fn worktree_at(&self, path: &Path) -> Result<WorktreeInfo> {
         // Look up the newly-added worktree by path. BOTH sides are
         // canonicalized: the caller may have passed a relative or symlinked
         // path, and git's `--porcelain` output is not `fs::canonicalize`'s
@@ -243,6 +354,82 @@ pub fn validate_branch_name(branch: &str) -> Result<()> {
         }
         None => validate_slug(first),
     }
+}
+
+/// Reject ref names OxiMux would not be able to hand to git safely.
+///
+/// A *ref* is not a branch OxiMux minted, so neither of the existing validators
+/// fits. [`validate_slug`] rejects `/`, which every remote-tracking ref and most
+/// real branch names contain. [`validate_branch_name`] allows exactly one `/`,
+/// because that is the shape of `<prefix>/<slug>` — but a base ref the user
+/// chose (`feature/api/retry`, `origin/main`, `v1.2.0`) legitimately carries
+/// more, and refusing it would refuse the feature.
+///
+/// So this validates the whole name at once against the subset of
+/// `check-ref-format` that is actually dangerous rather than merely unusual,
+/// plus the shapes that are ambiguous as *arguments*:
+/// - Non-empty, and no empty segment (`a//b`, `/a`, `a/`)
+/// - No leading `-` — an argument git's option parser could claim. The `--`
+///   terminator on every call site already covers this; the check makes it a
+///   property of the value, so a future call site that forgets the terminator
+///   is not a force-reset waiting to happen.
+/// - No whitespace, no ASCII control characters
+/// - No `..` (relative-ref-path injection), no `@{` (reflog selector)
+/// - No `~` `^` `:` `?` `*` `[` `\` (revision-modifier and glob syntax git's
+///   own `check-ref-format` forbids)
+/// - No segment starting or ending with `.`, and no `.lock` suffix
+/// - Not a bare `@`
+///
+/// This is deliberately a front-load, not a replacement: git's own
+/// `check-ref-format` remains the authority, and anything that slips through
+/// here is refused by git with its own message rather than misinterpreted.
+pub fn validate_ref_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(GitError::invalid_input("ref name is empty"));
+    }
+    if name.starts_with('-') {
+        return Err(GitError::invalid_input(format!(
+            "ref name {name:?} starts with '-' (would be parsed as a flag)"
+        )));
+    }
+    if name == "@" {
+        return Err(GitError::invalid_input("ref name is a bare '@'"));
+    }
+    if name.chars().any(|c| c.is_whitespace() || c.is_ascii_control()) {
+        return Err(GitError::invalid_input(format!(
+            "ref name {name:?} contains whitespace or a control character"
+        )));
+    }
+    for bad in ["..", "@{", "~", "^", ":", "?", "*", "[", "\\"] {
+        if name.contains(bad) {
+            return Err(GitError::invalid_input(format!(
+                "ref name {name:?} contains forbidden sequence {bad:?}"
+            )));
+        }
+    }
+    if name.ends_with(".lock") {
+        return Err(GitError::invalid_input(format!(
+            "ref name {name:?} ends with '.lock' (collides with git lockfile naming)"
+        )));
+    }
+    for segment in name.split('/') {
+        if segment.is_empty() {
+            return Err(GitError::invalid_input(format!(
+                "ref name {name:?} has an empty path segment"
+            )));
+        }
+        if segment.starts_with('.') || segment.ends_with('.') {
+            return Err(GitError::invalid_input(format!(
+                "ref name {name:?} has a segment starting or ending with '.'"
+            )));
+        }
+        if segment.ends_with(".lock") {
+            return Err(GitError::invalid_input(format!(
+                "ref name {name:?} has a segment ending with '.lock'"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Derive a slug from a human-readable workspace name.

--- a/crates/git/tests/worktree_ops.rs
+++ b/crates/git/tests/worktree_ops.rs
@@ -505,3 +505,381 @@ async fn default_branch_is_none_when_nothing_conventional_resolves() {
     let repo = Repository::open(root).await.expect("open");
     assert_eq!(repo.default_branch().await.expect("detect"), None);
 }
+
+// ---------------------------------------------------------------------------
+// Base ref + existing branch (phase 2)
+// ---------------------------------------------------------------------------
+
+/// `git <args>` with its stdout captured and trimmed. `common::run_git` only
+/// asserts the exit status, and these tests assert on *values* — a merge-base,
+/// a branch tip — so they need the output rather than the status.
+fn git_out(cwd: &std::path::Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git not on PATH");
+    assert!(out.status.success(), "git {args:?} failed in {cwd:?}");
+    String::from_utf8(out.stdout).expect("git printed non-utf8").trim().to_string()
+}
+
+/// A repo whose `main` has two commits and whose `side` branch points at the
+/// FIRST of them. Basing a worktree on `side` is therefore observably different
+/// from basing it on HEAD, which is what makes the merge-base assertions below
+/// mean something.
+fn repo_with_a_divergent_base(p: &std::path::Path) -> String {
+    init_repo(p);
+    write(&p.join("a.txt"), "v1\n");
+    run_git(p, &["add", "a.txt"]);
+    run_git(p, &["commit", "-m", "first"]);
+    let first = git_out(p, &["rev-parse", "HEAD"]);
+    run_git(p, &["branch", "side"]);
+    write(&p.join("b.txt"), "v2\n");
+    run_git(p, &["add", "b.txt"]);
+    run_git(p, &["commit", "-m", "second"]);
+    first
+}
+
+#[tokio::test]
+async fn add_worktree_from_bases_the_new_branch_on_the_named_ref() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    let first = repo_with_a_divergent_base(p);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("feat-x");
+
+    let repo = Repository::open(p).await.unwrap();
+    let info = repo
+        .add_worktree_from(&wt_path, "oximux/feat-x", "side")
+        .await
+        .unwrap();
+    assert_eq!(info.branch.as_deref(), Some("oximux/feat-x"));
+
+    // The new branch's tip IS the first commit — it was cut from `side`, not
+    // from the main checkout's HEAD two commits along.
+    let tip = git_out(p, &["rev-parse", "oximux/feat-x"]);
+    assert_eq!(tip, first, "worktree did not branch from `side`");
+
+    // And the merge-base with HEAD is that same commit, which is the property
+    // a reviewer actually reads: the work starts where the user asked.
+    let base = git_out(p, &["merge-base", "oximux/feat-x", "main"]);
+    assert_eq!(base, first);
+}
+
+#[tokio::test]
+async fn add_worktree_from_defaults_are_unaffected_by_a_feature_branch_head() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    let first = repo_with_a_divergent_base(p);
+
+    // The main checkout sits on a feature branch — the exact state that used to
+    // leak into every new worktree.
+    run_git(p, &["checkout", "-q", "-b", "wip"]);
+    write(&p.join("c.txt"), "wip\n");
+    run_git(p, &["add", "c.txt"]);
+    run_git(p, &["commit", "-m", "wip work"]);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("feat-y");
+    let repo = Repository::open(p).await.unwrap();
+    repo.add_worktree_from(&wt_path, "oximux/feat-y", "side")
+        .await
+        .unwrap();
+
+    let tip = git_out(p, &["rev-parse", "oximux/feat-y"]);
+    assert_eq!(tip, first, "new worktree inherited the wip HEAD");
+}
+
+#[tokio::test]
+async fn add_worktree_existing_checks_out_without_creating_a_prefixed_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("adopted");
+
+    let repo = Repository::open(p).await.unwrap();
+    let info = repo.add_worktree_existing(&wt_path, "side").await.unwrap();
+    assert_eq!(info.branch.as_deref(), Some("side"));
+
+    // No `oximux/`-prefixed branch was minted anywhere: the worktree adopted
+    // the branch under the name it already had.
+    let branches = repo.list_branches().await.unwrap();
+    assert!(
+        !branches.iter().any(|b| b.name.starts_with("oximux/")),
+        "existing-branch mode minted a prefixed branch: {branches:?}"
+    );
+}
+
+#[tokio::test]
+async fn add_worktree_existing_surfaces_gits_own_already_checked_out_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let repo = Repository::open(p).await.unwrap();
+    repo.add_worktree_existing(&wt_root.path().join("first"), "side")
+        .await
+        .unwrap();
+
+    // `side` is now live in another worktree. Git refuses, and its refusal
+    // names the worktree holding it — the detail the user needs to act.
+    let err = repo
+        .add_worktree_existing(&wt_root.path().join("second"), "side")
+        .await
+        .unwrap_err();
+    let text = err.to_string();
+    assert!(
+        text.contains("already used by worktree") || text.contains("already checked out"),
+        "git's own reason did not survive: {text}"
+    );
+}
+
+#[tokio::test]
+async fn base_ref_arguments_shaped_like_flags_are_refused_before_git_runs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+    let wt_root = tempfile::tempdir().unwrap();
+    let repo = Repository::open(p).await.unwrap();
+
+    // Every one of these is refused by `validate_ref_name`, not by git — the
+    // worktree directory is never created, which is the observable difference
+    // between "rejected" and "git happened to fail".
+    for (i, bad) in [
+        "-B main",
+        "--force",
+        "-f",
+        "main..side",
+        "main@{1}",
+        "side~1",
+        "side^",
+        "refs/heads/side:x",
+        "feature/.hidden",
+        "feature/x.lock",
+        "side branch",
+        "a//b",
+        "",
+        "@",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        // Keyed by index, not by length: `-B main` and `--force` are both 7
+        // characters, and a shared path would make a regression name the wrong
+        // input in the failure message.
+        let wt_path = wt_root.path().join(format!("wt-{i}"));
+        let err = repo
+            .add_worktree_from(&wt_path, "oximux/probe", bad)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitError::InvalidInput { .. }),
+            "start_point {bad:?} reached git instead of being refused: {err}"
+        );
+        assert!(!wt_path.exists(), "start_point {bad:?} created a directory");
+
+        let err = repo.add_worktree_existing(&wt_path, bad).await.unwrap_err();
+        assert!(
+            matches!(err, GitError::InvalidInput { .. }),
+            "branch {bad:?} reached git instead of being refused: {err}"
+        );
+        assert!(!wt_path.exists(), "branch {bad:?} created a directory");
+    }
+}
+
+#[tokio::test]
+async fn a_multi_segment_ref_is_accepted_where_a_minted_branch_name_would_not_be() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+    run_git(p, &["branch", "feature/api/retry", "side"]);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let repo = Repository::open(p).await.unwrap();
+
+    // `validate_branch_name` would refuse this (more than one prefix segment),
+    // and refusing it here would refuse the feature: an adopted branch is
+    // somebody else's name.
+    let info = repo
+        .add_worktree_existing(&wt_root.path().join("adopted"), "feature/api/retry")
+        .await
+        .unwrap();
+    assert_eq!(info.branch.as_deref(), Some("feature/api/retry"));
+}
+
+#[tokio::test]
+async fn add_worktree_from_rejects_a_ref_that_does_not_resolve() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+    let wt_root = tempfile::tempdir().unwrap();
+    let repo = Repository::open(p).await.unwrap();
+
+    // Well-formed, so it passes `validate_ref_name` — and is then refused by
+    // the SHA resolution, before `git worktree add` runs. That ordering is not
+    // incidental: resolving first is what stops git's DWIM from reinterpreting
+    // an unresolvable-looking name as a remote-tracking branch (see the
+    // regression tests below).
+    let err = repo
+        .add_worktree_from(&wt_root.path().join("nope"), "oximux/nope", "no-such-ref")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, GitError::InvalidInput { .. }),
+        "an unresolvable start point must be refused, not handed to git: {err}"
+    );
+    assert!(
+        err.to_string().contains("no-such-ref"),
+        "the refusal must name the ref: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `git worktree add`'s DWIM overrides an explicit `-b` (regression, phase 2)
+// ---------------------------------------------------------------------------
+
+/// A repo whose `main` exists **only** as `origin/main` — the state a
+/// worktree-centric user is in after deleting the local default branch they
+/// never sit on. This is the shape that makes git's DWIM fire.
+fn repo_whose_default_is_remote_only(root: &std::path::Path) -> std::path::PathBuf {
+    let origin = root.join("origin");
+    std::fs::create_dir_all(&origin).unwrap();
+    run_git(&origin, &["init", "-q", "--bare"]);
+
+    let work = root.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    init_repo(&work);
+    write(&work.join("a.txt"), "v1\n");
+    run_git(&work, &["add", "a.txt"]);
+    run_git(&work, &["commit", "-m", "init"]);
+    run_git(&work, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    run_git(&work, &["push", "-q", "origin", "main"]);
+    // Move off `main`, delete it locally, and point `origin/HEAD` at it — so
+    // `default_branch()` reports "main" while `refs/heads/main` is absent.
+    run_git(&work, &["checkout", "-q", "-b", "dev"]);
+    run_git(&work, &["branch", "-D", "main"]);
+    run_git(&work, &["remote", "set-head", "origin", "main"]);
+    work
+}
+
+/// **The regression.** `git worktree add -b <new> -- <path> <start>` DWIMs a
+/// start point that names no local branch but exactly one remote-tracking
+/// branch into `--track -b <that name>` — and the DWIM **beats the explicit
+/// `-b`**. Before the SHA resolution this created `main`, left `oximux/feat`
+/// non-existent, and reported success, so the `workspaces` row named a branch
+/// that was never made.
+///
+/// Resolving the start point first closes it from both sides: a name git can
+/// resolve is passed as a SHA (no ambiguity for the DWIM to key on), and a name
+/// it cannot — which is what a remote-only `main` is to `rev-parse` — is
+/// refused outright instead of being reinterpreted. The create path turns that
+/// refusal into "base on HEAD"; see
+/// `apps/desktop/tests/workspace_create_rollback.rs`.
+#[tokio::test]
+async fn a_remote_only_start_point_cannot_hijack_the_branch_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = repo_whose_default_is_remote_only(tmp.path());
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("feat");
+
+    let repo = Repository::open(&work).await.unwrap();
+    let err = repo
+        .add_worktree_from(&wt_path, "oximux/feat", "main")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, GitError::InvalidInput { .. }),
+        "a remote-only start point must be refused, not DWIMed into a branch name: {err}"
+    );
+    // Nothing was created under either name — in particular git did NOT mint
+    // the `main` its DWIM wanted.
+    assert!(!wt_path.exists());
+    let branches = repo.list_branches().await.unwrap();
+    assert!(
+        !branches.iter().any(|b| b.name == "main" || b.name == "oximux/feat"),
+        "a branch was created behind our back: {branches:?}"
+    );
+}
+
+/// And the way the user actually gets what they meant: name the
+/// remote-tracking ref, which resolves — the new branch is theirs, based on the
+/// remote's tip, with no DWIM in sight.
+#[tokio::test]
+async fn the_remote_tracking_form_bases_correctly_and_keeps_our_branch_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = repo_whose_default_is_remote_only(tmp.path());
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("feat");
+
+    let repo = Repository::open(&work).await.unwrap();
+    let info = repo
+        .add_worktree_from(&wt_path, "oximux/feat", "origin/main")
+        .await
+        .unwrap();
+    assert_eq!(info.branch.as_deref(), Some("oximux/feat"));
+    assert_eq!(
+        git_out(&work, &["rev-parse", "oximux/feat"]),
+        git_out(&work, &["rev-parse", "origin/main"])
+    );
+    let branches = repo.list_branches().await.unwrap();
+    assert!(!branches.iter().any(|b| b.name == "main"), "{branches:?}");
+}
+
+/// The sibling: existing-branch mode handed a remote-only name used to
+/// **create** a local branch — while `CreateBase::ExistingBranch` tells the
+/// rollback "this branch already existed, leave it alone", so every failed
+/// adopt-create left an orphan behind.
+#[tokio::test]
+async fn adopting_refuses_a_branch_that_exists_only_on_the_remote() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = repo_whose_default_is_remote_only(tmp.path());
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("adopted");
+
+    let repo = Repository::open(&work).await.unwrap();
+    let err = repo.add_worktree_existing(&wt_path, "main").await.unwrap_err();
+    assert!(
+        matches!(err, GitError::InvalidInput { .. }),
+        "a remote-only branch must be refused, not silently created: {err}"
+    );
+    assert!(err.to_string().contains("--from"), "the refusal names the way out: {err}");
+    assert!(!wt_path.exists());
+    let branches = repo.list_branches().await.unwrap();
+    assert!(!branches.iter().any(|b| b.name == "main"), "{branches:?}");
+}
+
+/// The other sibling: a tag resolves, so it passed the old check — and
+/// produced a **detached HEAD** whose row claimed a branch the worktree was
+/// not on.
+#[tokio::test]
+async fn adopting_refuses_a_tag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path();
+    repo_with_a_divergent_base(p);
+    run_git(p, &["tag", "v1.0", "side"]);
+
+    let wt_root = tempfile::tempdir().unwrap();
+    let wt_path = wt_root.path().join("tagged");
+    let repo = Repository::open(p).await.unwrap();
+
+    let err = repo.add_worktree_existing(&wt_path, "v1.0").await.unwrap_err();
+    assert!(
+        matches!(err, GitError::InvalidInput { .. }),
+        "a tag must be refused: it detaches HEAD and the row would lie: {err}"
+    );
+    assert!(!wt_path.exists());
+
+    // `--from` is the documented way to do what the user probably meant, and
+    // it still works on the same tag.
+    repo.add_worktree_from(&wt_path, "oximux/from-tag", "v1.0")
+        .await
+        .expect("--from accepts a tag");
+    assert_eq!(
+        git_out(p, &["rev-parse", "oximux/from-tag"]),
+        git_out(p, &["rev-parse", "v1.0^{commit}"])
+    );
+}

--- a/crates/git/tests/worktree_ops.rs
+++ b/crates/git/tests/worktree_ops.rs
@@ -883,3 +883,30 @@ async fn adopting_refuses_a_tag() {
         git_out(p, &["rev-parse", "v1.0^{commit}"])
     );
 }
+
+/// **What live verification caught.** `default_branch()` reports the name
+/// behind `origin/HEAD`, which on a worktree-centric checkout has no local
+/// ref — the user deleted the `main` they never sit on. An earlier fix made
+/// `default_branch()` return `None` in that case, which threw the usable answer
+/// away: the create path then based new work on whatever branch the checkout
+/// was parked on, reintroducing the exact defect base refs exist to close.
+///
+/// So the name is still reported, and resolving it is the caller's job. Every
+/// unit test before this had a local `main`, which is why only driving the real
+/// binaries found it.
+#[tokio::test]
+async fn default_branch_still_names_a_default_that_lives_only_on_the_remote() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = repo_whose_default_is_remote_only(tmp.path());
+    let repo = Repository::open(&work).await.unwrap();
+
+    assert_eq!(
+        repo.default_branch().await.unwrap().as_deref(),
+        Some("main"),
+        "the default branch is `main`; it just lives at origin/main"
+    );
+    // The bare name does not resolve — which is exactly why a caller that needs
+    // something checkoutable has to try the remote-tracking spelling.
+    assert!(repo.sha_of("main").await.unwrap().is_none());
+    assert!(repo.sha_of("origin/main").await.unwrap().is_some());
+}

--- a/crates/remote-host/src/auth/peer.rs
+++ b/crates/remote-host/src/auth/peer.rs
@@ -97,6 +97,30 @@ impl Peer {
         }
     }
 
+    /// Whether this caller is a **full-scope operator on the local socket** —
+    /// somebody sitting at the machine, not a paired remote device and not a
+    /// session-confined agent.
+    ///
+    /// Not a capability, and never a substitute for one: every use sits *after*
+    /// an ACL predicate has already answered "may this peer do this at all",
+    /// and narrows a capability the peer demonstrably holds. It exists because
+    /// a small number of requests are safe to serve to somebody sitting at the
+    /// machine and not to a device across a network — naming a git ref the host
+    /// will resolve and check out is the first of them.
+    ///
+    /// Local authority is minted only by this crate's own serve path
+    /// ([`Peer::local`] is `pub(crate)`), so no remote handshake can claim it.
+    ///
+    /// **Full scope is part of the test, not an accident of the caller.** A
+    /// bare "is it local" would answer `true` for [`LocalScope::Session`] — a
+    /// confined agent, which is exactly the caller that scope exists to box in.
+    /// Today every use sits behind a predicate that already requires full
+    /// scope, so the distinction is invisible; naming it here is what keeps the
+    /// next use from inheriting a hole its author never looked for.
+    pub fn is_local_operator(&self) -> bool {
+        matches!(&self.0, PeerKind::Local(scope) if scope.is_full())
+    }
+
     /// The session this caller IS, when it is a confined agent.
     ///
     /// The one place a scope is read as a *value* rather than asked a yes/no

--- a/crates/remote-host/src/dispatcher/serve.rs
+++ b/crates/remote-host/src/dispatcher/serve.rs
@@ -8,6 +8,7 @@ use futures::future::{Either, select};
 use futures::stream::{BoxStream, SelectAll, StreamExt};
 use oximux_agents::session_registry::{ChoiceKind, Seq, SessionId};
 use oximux_remote_proto::Transport;
+use oximux_remote_proto::messages::CreateBaseWire;
 use oximux_remote_proto::proto::{Request, Response, RpcError};
 
 use super::stream::{Live, forward_terminal};
@@ -467,7 +468,19 @@ impl Dispatcher {
             let Some(peer) = authorized_peer(&state.authn, &self.auth) else {
                 return self.send(transport, Response::Error(RpcError::Unauthorized)).await;
             };
-            let response = self.create_worktree(&peer, &project_path, &slug).await;
+            // The v16 verb is the v24 verb with a `Default` base. Served
+            // unchanged and forever: a stale CLI must go on speaking what it
+            // spoke.
+            let response = self
+                .create_worktree(&peer, &project_path, &slug, &CreateBaseWire::Default)
+                .await;
+            return self.send(transport, response).await;
+        }
+        if let Request::CreateWorktreeV2 { project_path, slug, base } = req {
+            let Some(peer) = authorized_peer(&state.authn, &self.auth) else {
+                return self.send(transport, Response::Error(RpcError::Unauthorized)).await;
+            };
+            let response = self.create_worktree(&peer, &project_path, &slug, &base).await;
             return self.send(transport, response).await;
         }
         if let Request::ListWorktrees { project_path } = req {

--- a/crates/remote-host/src/dispatcher/team.rs
+++ b/crates/remote-host/src/dispatcher/team.rs
@@ -351,8 +351,11 @@ impl Dispatcher {
         // The host derives the path from the slug; the client never supplies
         // one, exactly as `CreateWorktree` requires.
         let slug = format!("{}-{}", slugify(run_name), slugify(role));
+        // `Default`: a team run is unattended, and "wherever the host's HEAD
+        // was" is the behaviour this path has always had. Choosing a base for
+        // it is a decision with an owner, and that owner is not this call site.
         worktrees
-            .create(project, &slug)
+            .create(project, &slug, &oximux_remote_proto::messages::CreateBaseWire::Default)
             .await
             .map(|row| row.path)
             .map_err(|_| "the role's worktree could not be created".to_string())

--- a/crates/remote-host/src/dispatcher/worktree_rpcs.rs
+++ b/crates/remote-host/src/dispatcher/worktree_rpcs.rs
@@ -8,6 +8,7 @@
 //! caller on a service-less host sees `Unsupported`.
 
 use oximux_core::WorkPhase;
+use oximux_remote_proto::messages::CreateBaseWire;
 use oximux_remote_proto::proto::{Response, RpcError};
 
 use super::Dispatcher;
@@ -39,14 +40,32 @@ impl Dispatcher {
         peer: &Peer,
         project_path: &str,
         slug: &str,
+        base: &CreateBaseWire,
     ) -> Response {
         if !self.auth.may_manage_worktrees(peer) {
+            return Response::Error(RpcError::Unauthorized);
+        }
+        // A second, narrower gate on top of the capability — and deliberately
+        // ordered after it, so the base rule cannot be probed by a peer that
+        // lacks the capability in the first place.
+        //
+        // Everything else this surface exposes is host-derived from a project
+        // the host already knows and a slug it validates; the client never
+        // names a location. A base ref is the exception — a string the host
+        // resolves and checks out — and `oximux-worktree-ops` additionally
+        // refuses to run an unreviewed ref's setup script. That guard covers
+        // the local CLI. For a peer that is not sitting at the machine, the
+        // stronger property is the one worth keeping: it cannot name a ref at
+        // all. If a later phase wants remote base refs, it owes this boundary a
+        // fresh decision rather than a quiet relaxation here.
+        if !base.is_default() && !peer.is_local_operator() {
+            tracing::warn!("remote peer asked for a worktree base ref; refusing");
             return Response::Error(RpcError::Unauthorized);
         }
         let Some(service) = self.worktrees.as_ref() else {
             return Response::Error(RpcError::Unsupported);
         };
-        match service.create(project_path, slug).await {
+        match service.create(project_path, slug, base).await {
             Ok(row) => Response::WorktreeCreated(row),
             Err(err) => worktree_failure(err),
         }
@@ -151,5 +170,164 @@ impl Dispatcher {
             Ok(rows) => Response::WorktreeProgress(rows),
             Err(err) => worktree_failure(err),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use ed25519_dalek::SigningKey;
+    use oximux_remote_proto::messages::{RegisterReq, WorktreeProgressWire, WorktreeWire};
+
+    use super::*;
+    use crate::auth::{AuthStore, PairingSlot, registration_proof};
+    use crate::dispatcher::Dispatcher;
+    use oximux_agents::session_registry::SessionRegistry;
+    use crate::worktrees::WorktreeService;
+
+    /// Records what actually reached the service, so a refusal that never got
+    /// there is distinguishable from one the service itself made.
+    #[derive(Default)]
+    struct SpyWorktrees {
+        creates: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl WorktreeService for SpyWorktrees {
+        async fn create(
+            &self,
+            project_path: &str,
+            slug: &str,
+            base: &CreateBaseWire,
+        ) -> Result<WorktreeWire, WorktreeError> {
+            self.creates.fetch_add(1, Ordering::SeqCst);
+            let branch = match base {
+                CreateBaseWire::Existing(name) => name.clone(),
+                CreateBaseWire::Default | CreateBaseWire::From(_) => format!("oximux/{slug}"),
+            };
+            Ok(WorktreeWire {
+                id: "wt-1".into(),
+                project_path: project_path.into(),
+                name: slug.into(),
+                slug: slug.into(),
+                branch,
+                path: "/data/wt".into(),
+            })
+        }
+        async fn list(&self, _: Option<&str>) -> Result<Vec<WorktreeWire>, WorktreeError> {
+            Ok(vec![])
+        }
+        async fn remove(&self, _: &str) -> Result<(), WorktreeError> {
+            Ok(())
+        }
+        async fn set_progress(
+            &self,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> Result<(), WorktreeError> {
+            Ok(())
+        }
+        async fn list_progress(
+            &self,
+            _: Option<&str>,
+        ) -> Result<Vec<WorktreeProgressWire>, WorktreeError> {
+            Ok(vec![])
+        }
+    }
+
+    /// A dispatcher with a spy service, plus a **fully paired, write-capable**
+    /// remote device.
+    ///
+    /// The pairing is not incidental. `may_manage_worktrees` runs first, so an
+    /// unpaired key would be refused by the capability gate and the test would
+    /// pass without the base gate existing at all. The seed is a real curve
+    /// point for the same reason — an arbitrary 32-byte fill is not a valid
+    /// verifying key, and the resulting `Unauthorized` looks exactly like a
+    /// policy refusal.
+    fn dispatcher_with_a_paired_device() -> (Dispatcher, Arc<SpyWorktrees>, Peer) {
+        let store = AuthStore::new();
+        let secret = [0x22; 16];
+        store.set_pairing(PairingSlot::new(secret, None, false));
+        let pubkey = SigningKey::from_bytes(&[0x33; 32]).verifying_key().to_bytes();
+        let ts = 1_700_000_000;
+        store
+            .register(
+                &RegisterReq {
+                    app_pubkey: pubkey,
+                    device_name: "phone".into(),
+                    proof: registration_proof(&secret, &pubkey, ts),
+                    timestamp_secs: ts,
+                    session_id: None,
+                },
+                ts,
+            )
+            .expect("register");
+        let spy = Arc::new(SpyWorktrees::default());
+        let dispatcher = Dispatcher::new(Arc::new(SessionRegistry::new()), Arc::new(store))
+            .with_worktrees(spy.clone());
+        (dispatcher, spy, Peer::remote(pubkey))
+    }
+
+    /// The premise the whole gate rests on: this device CAN create worktrees.
+    /// Without this the refusals below would prove nothing.
+    #[test]
+    fn a_paired_device_may_still_create_an_ordinary_worktree() {
+        let (dispatcher, spy, peer) = dispatcher_with_a_paired_device();
+        let response = futures::executor::block_on(dispatcher.create_worktree(
+            &peer,
+            "/work",
+            "feat",
+            &CreateBaseWire::Default,
+        ));
+        assert!(matches!(response, Response::WorktreeCreated(_)), "{response:?}");
+        assert_eq!(spy.creates.load(Ordering::SeqCst), 1);
+    }
+
+    /// A base ref is a string the host resolves and checks out. A peer that is
+    /// not sitting at the machine may not name one — and the refusal must land
+    /// BEFORE the service, or the narrowing is decoration.
+    #[test]
+    fn a_remote_peer_may_not_name_a_base_ref() {
+        for base in [
+            CreateBaseWire::From("origin/pr-4711".into()),
+            CreateBaseWire::Existing("side".into()),
+        ] {
+            let (dispatcher, spy, peer) = dispatcher_with_a_paired_device();
+            let response = futures::executor::block_on(
+                dispatcher.create_worktree(&peer, "/work", "feat", &base),
+            );
+            assert_eq!(
+                response,
+                Response::Error(RpcError::Unauthorized),
+                "a remote peer named {base:?} and was not refused"
+            );
+            assert_eq!(
+                spy.creates.load(Ordering::SeqCst),
+                0,
+                "the refusal must be upstream of the service"
+            );
+        }
+    }
+
+    /// The same request from the machine's own socket is served — the gate is
+    /// about *who is asking*, not about the feature being off.
+    #[test]
+    fn a_local_operator_may_name_a_base_ref() {
+        let (dispatcher, spy, _) = dispatcher_with_a_paired_device();
+        let peer = Peer::local(crate::auth::LocalScope::Full);
+        let response = futures::executor::block_on(dispatcher.create_worktree(
+            &peer,
+            "/work",
+            "feat",
+            &CreateBaseWire::Existing("side".into()),
+        ));
+        match response {
+            Response::WorktreeCreated(row) => assert_eq!(row.branch, "side"),
+            other => panic!("expected WorktreeCreated, got {other:?}"),
+        }
+        assert_eq!(spy.creates.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/remote-host/src/dispatcher/worktree_rpcs.rs
+++ b/crates/remote-host/src/dispatcher/worktree_rpcs.rs
@@ -23,6 +23,7 @@ fn worktree_failure(err: WorktreeError) -> Response {
         WorktreeError::UnknownProject
         | WorktreeError::BadSlug
         | WorktreeError::AlreadyExists
+        | WorktreeError::NoSuchLocalBranch
         | WorktreeError::UnknownWorktree => Response::Error(RpcError::BadRequest(err.to_string())),
         // The host failed; detail was logged by the service.
         WorktreeError::CreateFailed
@@ -309,6 +310,25 @@ mod tests {
                 0,
                 "the refusal must be upstream of the service"
             );
+        }
+    }
+
+    /// A client-fixable mistake must reach the client as one.
+    ///
+    /// `--branch origin/main` used to collapse into `CreateFailed`, i.e.
+    /// `Internal("the worktree could not be created")` — a dead end for a user
+    /// whose only error was naming a remote-tracking branch. The refusal has to
+    /// carry the rule and the alternative, or the CLI cannot say anything
+    /// useful about it.
+    #[test]
+    fn adopting_a_name_that_is_not_a_local_branch_is_a_bad_request() {
+        let response = worktree_failure(WorktreeError::NoSuchLocalBranch);
+        match response {
+            Response::Error(RpcError::BadRequest(msg)) => {
+                assert!(msg.contains("--from"), "the refusal must name the way out: {msg}");
+                assert!(msg.contains("local branch"), "and the rule: {msg}");
+            }
+            other => panic!("must be client-fixable, not Internal: {other:?}"),
         }
     }
 

--- a/crates/remote-host/src/worktrees.rs
+++ b/crates/remote-host/src/worktrees.rs
@@ -15,7 +15,7 @@
 //! RPC on this surface ever turns a client-supplied string into a filesystem
 //! path.
 
-use oximux_remote_proto::messages::{WorktreeProgressWire, WorktreeWire};
+use oximux_remote_proto::messages::{CreateBaseWire, WorktreeProgressWire, WorktreeWire};
 
 /// Why a worktree operation could not happen.
 ///
@@ -60,14 +60,25 @@ pub enum WorktreeError {
 #[async_trait::async_trait]
 pub trait WorktreeService: Send + Sync {
     /// Create a worktree under the project rooted at `project_path`, on a fresh
-    /// branch derived from `slug`. The implementation validates both arguments:
-    /// the project must resolve against its own records, and the slug must pass
-    /// the same validation the app's own UI applies.
+    /// branch derived from `slug`. The implementation validates every argument:
+    /// the project must resolve against its own records, the slug must pass the
+    /// same validation the app's own UI applies, and a named `base` must pass
+    /// the ref-name validation before it reaches `git`.
+    ///
+    /// `base` says what the worktree is cut from.
+    /// [`CreateBaseWire::Default`] is the pre-v24 behaviour and the only value
+    /// a non-local peer may ask for — the dispatcher enforces that, because the
+    /// authorization question ("may this peer name a ref?") is about the peer
+    /// and the implementation only sees the request.
     ///
     /// Returns the created row, whose `path` the caller may hand straight to a
     /// `CreateSession`.
-    async fn create(&self, project_path: &str, slug: &str)
-    -> Result<WorktreeWire, WorktreeError>;
+    async fn create(
+        &self,
+        project_path: &str,
+        slug: &str,
+        base: &CreateBaseWire,
+    ) -> Result<WorktreeWire, WorktreeError>;
 
     /// The worktrees of one project (or of every project when `None`).
     /// Synthesized primary rows (the project root itself) are **not** listed —

--- a/crates/remote-host/src/worktrees.rs
+++ b/crates/remote-host/src/worktrees.rs
@@ -33,6 +33,15 @@ pub enum WorktreeError {
     /// A worktree (or branch) with that slug already exists for the project.
     #[error("a worktree with that name already exists")]
     AlreadyExists,
+    /// Adoption was asked for a name that is not a local branch.
+    ///
+    /// Client-fixable, so it must NOT collapse into [`Self::CreateFailed`]:
+    /// that arm answers `Internal("the worktree could not be created")`, which
+    /// tells a user who typed `--branch origin/main` nothing at all. Naming the
+    /// rule and the alternative is the difference between a dead end and a
+    /// correction — and `--from` is the verb that does what they meant.
+    #[error("no local branch by that name (a remote-tracking branch or a tag needs `--from`)")]
+    NoSuchLocalBranch,
     /// The create failed past validation. Detail is logged host-side.
     #[error("the worktree could not be created")]
     CreateFailed,

--- a/crates/remote-host/tests/worktrees_and_paging.rs
+++ b/crates/remote-host/tests/worktrees_and_paging.rs
@@ -17,7 +17,9 @@ use oximux_remote_host::{
     registration_proof,
 };
 use oximux_remote_proto::Transport;
-use oximux_remote_proto::messages::{HelloReq, RegisterReq, WorktreeProgressWire, WorktreeWire};
+use oximux_remote_proto::messages::{
+    CreateBaseWire, HelloReq, RegisterReq, WorktreeProgressWire, WorktreeWire,
+};
 use oximux_remote_proto::proto::{Request, Response, RpcError};
 use oximux_remote_proto::testing::duplex_pair;
 
@@ -54,15 +56,25 @@ struct CountingWorktrees {
 
 #[async_trait::async_trait]
 impl WorktreeService for CountingWorktrees {
-    async fn create(&self, project_path: &str, slug: &str)
-    -> Result<WorktreeWire, WorktreeError> {
+    async fn create(
+        &self,
+        project_path: &str,
+        slug: &str,
+        base: &CreateBaseWire,
+    ) -> Result<WorktreeWire, WorktreeError> {
         self.creates.fetch_add(1, Ordering::SeqCst);
+        // The base is reflected into `branch` so a test can tell which mode the
+        // dispatcher actually forwarded — the counter alone cannot.
+        let branch = match base {
+            CreateBaseWire::Existing(name) => name.clone(),
+            CreateBaseWire::Default | CreateBaseWire::From(_) => format!("oximux/{slug}"),
+        };
         Ok(WorktreeWire {
             id: "wt-1".into(),
             project_path: project_path.into(),
             name: slug.into(),
             slug: slug.into(),
-            branch: format!("oximux/{slug}"),
+            branch,
             path: format!("/data/worktrees/{slug}"),
         })
     }

--- a/crates/remote-proto/src/messages.rs
+++ b/crates/remote-proto/src/messages.rs
@@ -214,6 +214,43 @@ pub struct TranscriptPageWire {
     pub model: Option<String>,
 }
 
+/// What a new worktree is cut from, as
+/// [`Request::CreateWorktreeV2`](crate::proto::Request::CreateWorktreeV2)
+/// carries it.
+///
+/// **A new type on a new verb, never a field on the old one.** Postcard is not
+/// self-describing and ordinal 43's `CreateWorktree { project_path, slug }`
+/// payload is pinned; an appended `Option` would cost a byte even when `None`
+/// and break every pre-v24 host on a *plain* create. This rides
+/// `CreateWorktreeV2` instead, so the version gate keys on which verb to send.
+///
+/// [`Default`](Self::Default) exists so the V2 verb can carry an ordinary
+/// create — a client that speaks v24 sends V2 for everything, and the two verbs
+/// mean exactly the same thing when the base is `Default`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CreateBaseWire {
+    /// Whatever the host would have cut before base refs existed. Byte-for-byte
+    /// the behaviour of [`Request::CreateWorktree`](crate::proto::Request::CreateWorktree).
+    Default,
+    /// A new branch cut from this ref.
+    From(String),
+    /// Adopt this existing branch — no branch created, no prefix applied.
+    Existing(String),
+}
+
+impl CreateBaseWire {
+    /// Whether this asks for anything an ordinal-43 create could not express.
+    ///
+    /// Read in two places for two reasons that must not drift apart: the client
+    /// gates *which verb to send* on it, and the host gates *who may ask* on it
+    /// — a paired remote device is confined to `Default`, because naming a ref
+    /// is naming something the host must then resolve and check out on the
+    /// user's machine.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+
 /// One worktree (workspace) row — the
 /// [`Response::WorktreeCreated`](crate::proto::Response::WorktreeCreated) /
 /// [`Response::Worktrees`](crate::proto::Response::Worktrees) payload.

--- a/crates/remote-proto/src/proto.rs
+++ b/crates/remote-proto/src/proto.rs
@@ -117,12 +117,24 @@ pub use crate::messages::*;
 /// asks for a cron heartbeat, and leaving them out means `HeartbeatWire` needs
 /// no degradation path at all.
 ///
+/// v24: appended **base refs on worktree creation** (`CreateWorktreeV2`,
+/// answered by the existing `WorktreeCreated`). Every worktree used to branch
+/// off whatever the main checkout's HEAD happened to be, which silently based
+/// new work on a half-finished feature branch. A new verb rather than a field
+/// on ordinal 43 for the usual reason, sharpened by postcard's non-descriptive
+/// framing: an appended `Option` costs a byte even when `None`, so a v24 client
+/// making a *plain* create would become undecodable to every v23 host — the
+/// common case broken by the rare one. `CreateWorktree` is untouched and still
+/// served, and the client gates on which verb to send. The V2 verb also carries
+/// a narrower authorization than its payload alone implies: see
+/// [`Request::CreateWorktreeV2`].
+///
 /// Appending variants is *not* a breaking change — postcard ordinals of the
 /// existing ones are untouched, and an older peer simply never sends or receives
 /// the new calls. So this bumps while the transport ALPN
 /// (`remote_iroh::OXIMUX_ALPN`) deliberately does not: that tracks breaking
 /// changes only, and bumping it would refuse otherwise-compatible peers.
-pub const PROTOCOL_VERSION: u32 = 23;
+pub const PROTOCOL_VERSION: u32 = 24;
 
 /// The oldest peer whose event decoder knows `ThreadEvent::PermissionEdited`.
 ///
@@ -174,6 +186,21 @@ pub const TEAM_PER_ROLE_MIN_VERSION: u32 = 22;
 /// preset recurrence still works against any v10 host, so only `--cron` may
 /// require this.
 pub const SCHEDULE_CRON_MIN_VERSION: u32 = 23;
+
+/// The oldest host that understands a worktree base ref.
+///
+/// Read by the **client**, like [`TEAM_PER_ROLE_MIN_VERSION`] and
+/// [`SCHEDULE_CRON_MIN_VERSION`], and gated the same way: on what the command
+/// *asks for*, not on the verb family. A plain `worktree create` still goes out
+/// as [`Request::CreateWorktree`] and still works against any v16 host; only
+/// `--from` or `--branch` requires this, and only that form is refused by name
+/// against an older one.
+///
+/// Sending `CreateWorktreeV2` to a v23 host would not be a graceful
+/// downgrade — the host cannot decode an ordinal it does not know and answers
+/// [`RpcError::BadRequest`] with "undecodable request frame", a message about
+/// malformed bytes for what is really a version problem.
+pub const CREATE_WORKTREE_BASE_MIN_VERSION: u32 = 24;
 
 /// The oldest peer that can decode [`Response::ScheduleRunsChanged`]. Hosts
 /// must not push it to a connection whose declared version is older — see the
@@ -761,6 +788,29 @@ pub enum Request {
     /// [`ScheduleWire::recurrence`]), which is fine to *display* and wrong to
     /// reason about.
     ListSchedulesV2,
+    /// Create a worktree, naming what it is cut from.
+    ///
+    /// The v24 successor to [`Request::CreateWorktree`], same gate plus one:
+    /// a base other than [`CreateBaseWire::Default`] additionally requires a
+    /// **local** peer. `CreateWorktree`'s ordinal-43 payload is untouched and
+    /// still served, so an older client keeps working against a v24 host and a
+    /// v24 client sending `Default` could equally have sent either verb.
+    ///
+    /// **Why the extra gate.** Everything the worktree surface exposes today is
+    /// derived by the host from a project it already knows and a slug it
+    /// validates — the client never names a location or a ref. A base ref
+    /// breaks that: it is a string the host resolves and checks out, and the
+    /// worktree's own committed setup script is what provisioning then runs.
+    /// The unreviewed-ref guard in `oximux-worktree-ops` stops that script from
+    /// running by default, but the narrower property — *a paired device cannot
+    /// name a ref at all* — is worth keeping for peers that are not sitting at
+    /// the machine. A remote peer asking for a non-default base gets
+    /// [`RpcError::Unauthorized`].
+    CreateWorktreeV2 {
+        project_path: String,
+        slug: String,
+        base: CreateBaseWire,
+    },
 }
 
 /// Host → client.

--- a/crates/remote-proto/src/proto/tests.rs
+++ b/crates/remote-proto/src/proto/tests.rs
@@ -18,12 +18,12 @@ fn value_bearing_event() -> ThreadEvent {
 #[test]
 fn protocol_version_is_pinned() {
     assert_eq!(
-        PROTOCOL_VERSION, 23,
-        "v23 = cron schedules (CreateScheduleV2 / ListSchedulesV2, answered by \
-         ScheduleCreatedV2 / SchedulesV2). A fourth RecurrenceWire variant was not an \
-         option: that enum rides inside Vec<ScheduleWire> replies as well as inside \
-         CreateSchedule, so one cron schedule would make every ListSchedules reply \
-         undecodable for a pre-v23 peer — every row, not just the cron one"
+        PROTOCOL_VERSION, 24,
+        "v24 = worktree base refs (CreateWorktreeV2, answered by the existing \
+         WorktreeCreated). A field on CreateWorktree was not an option: postcard is \
+         not self-describing, so an appended Option costs a byte even when None — a \
+         v24 client making a PLAIN create would become undecodable to every v23 host, \
+         breaking the common case for the sake of the rare one"
     );
 }
 
@@ -533,6 +533,17 @@ fn early_variants_keep_their_literal_ordinals() {
     };
     assert_eq!(create_sched_v2.to_bytes().expect("encode")[0], 66);
     assert_eq!(Request::ListSchedulesV2.to_bytes().expect("encode")[0], 67);
+
+    // v24: worktree base refs — `CreateWorktreeV2` (68), answered by the
+    // existing `WorktreeCreated` (32). `CreateWorktree` (43) is pinned above
+    // and stays served; the two verbs are interchangeable when the base is
+    // `Default`, which is what lets the client gate on the verb.
+    let create_wt_v2 = Request::CreateWorktreeV2 {
+        project_path: String::new(),
+        slug: String::new(),
+        base: CreateBaseWire::Default,
+    };
+    assert_eq!(create_wt_v2.to_bytes().expect("encode")[0], 68);
     assert_eq!(Response::SchedulesV2(vec![]).to_bytes().expect("encode")[0], 50);
     let sched_v2 = ScheduleV2Wire {
         id: String::new(),

--- a/crates/storage/migrations/V029__workspace_branch_minted.sql
+++ b/crates/storage/migrations/V029__workspace_branch_minted.sql
@@ -1,0 +1,26 @@
+-- V029: record whether OxiMux MINTED this worktree's branch or ADOPTED one
+-- that already existed.
+--
+-- Until now the answer was structural: a worktree's branch was always
+-- `<prefix>/<slug>`, created by the same call that made the worktree, so every
+-- lifecycle path could delete it on the way out without asking. Base refs end
+-- that — a worktree may now check out a branch the user has had for a week —
+-- and `git branch -D` on one of those is not cleanup, it is data loss.
+--
+-- The create path knows which it did and nothing downstream can work it out
+-- afterwards. Inferring from the configured prefix would be wrong twice: for a
+-- user who turned the prefix off, and for an adopted branch that happens to
+-- match it. So the fact is written down where the delete paths can read it.
+--
+-- `DEFAULT 1` is correct for every existing row, not merely convenient:
+-- adopting a branch is new in this migration's own release, so every worktree
+-- that predates it was necessarily minted by OxiMux. Existing behaviour is
+-- preserved exactly.
+--
+-- INTEGER rather than BOOLEAN because SQLite has no boolean type; NOT NULL
+-- because "we do not know" is not a state this can be in — the only writer is
+-- the create path, which always knows.
+--
+-- Additive with a default, matching V011/V012/V015/V016/V026 on this table.
+
+ALTER TABLE workspaces ADD COLUMN branch_minted INTEGER NOT NULL DEFAULT 1;

--- a/crates/storage/src/migrations.rs
+++ b/crates/storage/src/migrations.rs
@@ -235,6 +235,13 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "schedules_cron",
         sql: include_str!("../migrations/V028__schedules_cron.sql"),
     },
+    // V029: minted-vs-adopted, so a worktree that merely checked out somebody's
+    // existing branch does not have it force-deleted on the way out.
+    Migration {
+        version: 29,
+        name: "workspace_branch_minted",
+        sql: include_str!("../migrations/V029__workspace_branch_minted.sql"),
+    },
 ];
 
 /// Returns the absolute path to the `migrations/` directory at runtime.
@@ -595,6 +602,55 @@ mod tests {
         assert_eq!(session.as_deref(), Some("s-1"), "existing data must survive");
         assert_eq!(agent, None, "an upgraded role names no agent");
         assert_eq!(model, None, "an upgraded role names no model");
+    }
+
+    /// The upgrade proof for V029: a worktree created before adoption existed
+    /// must open as **minted**, not adopted.
+    ///
+    /// The direction matters. `branch_minted` gates branch deletion, so a
+    /// pre-V029 row defaulting to `false` would silently stop cleaning up
+    /// branches OxiMux itself made — leaking a dangling branch per delete,
+    /// forever, with nothing to point at. `DEFAULT 1` is the correct reading of
+    /// history (adoption shipped with the column), not a convenience.
+    #[test]
+    fn a_pre_v029_workspace_upgrades_as_minted() {
+        let mut conn = mem_conn();
+        let upto_28: Vec<Migration> =
+            MIGRATIONS.iter().filter(|m| m.version <= 28).cloned().collect();
+        run_migrations(&mut conn, &upto_28).expect("ladder through V028");
+
+        conn.execute(
+            "INSERT INTO projects (id, name, root_path, default_branch, created_at) \
+             VALUES ('p-1', 'Acme', '/p', 'main', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed project");
+        conn.execute(
+            "INSERT INTO workspaces \
+             (id, project_id, name, slug, branch, worktree_path, status, created_at) \
+             VALUES ('ws-1', 'p-1', 'Feat', 'feat', 'oximux/feat', '/wt/feat', 'active', \
+                     '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed workspace");
+
+        // Guard against a vacuous test: V028 must not already have the column.
+        let has_column: bool = conn
+            .prepare("SELECT * FROM workspaces LIMIT 0")
+            .expect("prepare")
+            .column_names()
+            .contains(&"branch_minted");
+        assert!(
+            !has_column,
+            "V028 must not already have `branch_minted` — this test would be vacuous"
+        );
+
+        run_migrations(&mut conn, MIGRATIONS).expect("upgrade to head");
+
+        let minted: i64 = conn
+            .query_row("SELECT branch_minted FROM workspaces WHERE id = 'ws-1'", [], |r| r.get(0))
+            .expect("read back");
+        assert_eq!(minted, 1, "a pre-adoption worktree was minted by OxiMux");
     }
 
     /// The same upgrade proof for V028, on the table schedules live in: a

--- a/crates/storage/src/model.rs
+++ b/crates/storage/src/model.rs
@@ -68,6 +68,7 @@ pub struct WorkspaceRow {
     pub pinned: bool,
     pub comment: String,
     pub phase: String,
+    pub branch_minted: bool,
 }
 
 impl WorkspaceRow {
@@ -88,6 +89,7 @@ impl WorkspaceRow {
             pinned: row.get("pinned")?,
             comment: row.get("comment")?,
             phase: row.get("phase")?,
+            branch_minted: row.get("branch_minted")?,
         })
     }
 }
@@ -110,6 +112,7 @@ impl From<WorkspaceRow> for Workspace {
             pinned: r.pinned,
             comment: r.comment,
             phase: r.phase,
+            branch_minted: r.branch_minted,
         }
     }
 }

--- a/crates/storage/src/repositories/workspace.rs
+++ b/crates/storage/src/repositories/workspace.rs
@@ -24,6 +24,12 @@ impl WorkspaceRepo {
     /// `(project_id, slug)` pair already exists — callers (step 6) should
     /// catch this before invoking `git worktree add` to avoid a half-baked
     /// state.
+    /// Insert a workspace row.
+    ///
+    /// `branch_minted` says whether this create made `branch` or adopted a
+    /// branch that already existed. It is not a display field: every path that
+    /// removes a worktree reads it to decide whether removing the branch is
+    /// cleanup or data loss, and the create path is the only place that knows.
     pub fn insert(
         &self,
         project_id: &str,
@@ -31,6 +37,7 @@ impl WorkspaceRepo {
         slug: &str,
         branch: &str,
         worktree_path: &str,
+        branch_minted: bool,
     ) -> Result<Workspace, StorageError> {
         let id = new_id();
         let created_at = now();
@@ -40,9 +47,9 @@ impl WorkspaceRepo {
         self.db
             .with_conn(|c| {
                 c.execute(
-                    "INSERT INTO workspaces (id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, sort_order) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)",
-                    params![id, project_id, name, slug, branch, worktree_path, status, created_at, sort_order],
+                    "INSERT INTO workspaces (id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, sort_order, branch_minted) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, ?10)",
+                    params![id, project_id, name, slug, branch, worktree_path, status, created_at, sort_order, branch_minted],
                 )
             })
             .map_err(|e| classify_unique("workspaces", "project_id_slug", e))?;
@@ -62,6 +69,7 @@ impl WorkspaceRepo {
             pinned: false,
             comment: String::new(),
             phase: String::new(),
+            branch_minted,
         })
     }
 
@@ -212,7 +220,7 @@ impl WorkspaceRepo {
     pub fn get_by_id(&self, id: &str) -> Result<Option<Workspace>, StorageError> {
         let row = self.db.with_conn(|c| {
             c.query_row(
-                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase \
+                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase, branch_minted \
                  FROM workspaces WHERE id = ?1",
                 [id],
                 WorkspaceRow::from_row,
@@ -229,7 +237,7 @@ impl WorkspaceRepo {
     pub fn get_by_worktree_path(&self, path: &str) -> Result<Option<Workspace>, StorageError> {
         let row = self.db.with_conn(|c| {
             c.query_row(
-                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase \
+                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase, branch_minted \
                  FROM workspaces \
                  WHERE worktree_path = ?1 AND archived_at IS NULL \
                  ORDER BY created_at DESC LIMIT 1",
@@ -245,7 +253,7 @@ impl WorkspaceRepo {
     pub fn list_for_project(&self, project_id: &str) -> Result<Vec<Workspace>, StorageError> {
         let rows = self.db.with_conn(|c| {
             let mut stmt = c.prepare(
-                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase \
+                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase, branch_minted \
                  FROM workspaces \
                  WHERE project_id = ?1 AND archived_at IS NULL \
                  ORDER BY created_at DESC",
@@ -268,7 +276,7 @@ impl WorkspaceRepo {
     ) -> Result<Vec<Workspace>, StorageError> {
         let rows = self.db.with_conn(|c| {
             let mut stmt = c.prepare(
-                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase \
+                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase, branch_minted \
                  FROM workspaces \
                  WHERE project_id = ?1 AND archived_at IS NOT NULL \
                  ORDER BY archived_at DESC",
@@ -374,7 +382,7 @@ impl WorkspaceRepo {
     ) -> Result<Vec<Workspace>, StorageError> {
         let rows = self.db.with_conn(|c| {
             let mut stmt = c.prepare(
-                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase \
+                "SELECT id, project_id, name, slug, branch, worktree_path, status, created_at, archived_at, linked_issue, tint, sort_order, pinned, comment, phase, branch_minted \
                  FROM workspaces \
                  WHERE project_id = ?1 AND archived_at IS NULL \
                  ORDER BY sort_order ASC, created_at ASC",
@@ -454,7 +462,7 @@ mod tests {
     }
 
     fn ws(repo: &WorkspaceRepo, project_id: &str, slug: &str) -> Workspace {
-        repo.insert(project_id, slug, slug, "main", &format!("/p/{slug}"))
+        repo.insert(project_id, slug, slug, "main", &format!("/p/{slug}"), true)
             .expect("ws")
     }
 

--- a/crates/storage/tests/agent_session_repo.rs
+++ b/crates/storage/tests/agent_session_repo.rs
@@ -12,7 +12,7 @@ fn fixture() -> (String, WorkspaceRepo, AgentSessionRepo) {
 
     let p = projects.insert("Acme", "/r", "main").expect("project");
     let w = workspaces
-        .insert(&p.id, "F", "f", "oximux/f", "/wt/f")
+        .insert(&p.id, "F", "f", "oximux/f", "/wt/f", true)
         .expect("workspace");
     (w.id, workspaces, agents)
 }

--- a/crates/storage/tests/pane_session_repo.rs
+++ b/crates/storage/tests/pane_session_repo.rs
@@ -18,7 +18,7 @@ fn fixture() -> (
 
     let p = projects.insert("Acme", "/r", "main").expect("project");
     let w = workspaces
-        .insert(&p.id, "F", "f", "oximux/f", "/wt/f")
+        .insert(&p.id, "F", "f", "oximux/f", "/wt/f", true)
         .expect("workspace");
     (w.id, panes, agents, db)
 }

--- a/crates/storage/tests/project_repo.rs
+++ b/crates/storage/tests/project_repo.rs
@@ -68,7 +68,7 @@ fn project_delete_cascades_to_workspaces() {
     let (projects, workspaces) = repo();
     let p = projects.insert("A", "/a", "main").expect("project");
     workspaces
-        .insert(&p.id, "feat", "feat", "oximux/feat", "/wt/feat")
+        .insert(&p.id, "feat", "feat", "oximux/feat", "/wt/feat", true)
         .expect("workspace");
     projects.delete(&p.id).expect("delete project");
     let remaining = workspaces.list_for_project(&p.id).expect("list");

--- a/crates/storage/tests/workspace_repo.rs
+++ b/crates/storage/tests/workspace_repo.rs
@@ -21,7 +21,7 @@ fn project_and_repos() -> (String, WorkspaceRepo, PaneSessionRepo, AgentSessionR
 fn workspace_insert_returns_full_row() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "Feat", "feat", "oximux/feat", "/wt/feat")
+        .insert(&project_id, "Feat", "feat", "oximux/feat", "/wt/feat", true)
         .expect("insert");
     assert!(!w.id.is_empty());
     assert_eq!(w.project_id, project_id);
@@ -35,7 +35,7 @@ fn workspace_insert_returns_full_row() {
 fn workspace_get_by_id() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "F", "f", "oximux/f", "/wt/f")
+        .insert(&project_id, "F", "f", "oximux/f", "/wt/f", true)
         .expect("insert");
     let fetched = workspaces.get_by_id(&w.id).expect("get").expect("present");
     assert_eq!(fetched, w);
@@ -45,7 +45,7 @@ fn workspace_get_by_id() {
 fn workspace_set_linked_issue_round_trips() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "Fix", "fix", "oximux/fix", "/wt/fix")
+        .insert(&project_id, "Fix", "fix", "oximux/fix", "/wt/fix", true)
         .expect("insert");
     // Fresh inserts have no linked issue.
     assert!(w.linked_issue.is_none());
@@ -69,7 +69,7 @@ fn workspace_set_linked_issue_round_trips() {
 fn workspace_set_tint_round_trips() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "Tint", "tint", "oximux/tint", "/wt/tint")
+        .insert(&project_id, "Tint", "tint", "oximux/tint", "/wt/tint", true)
         .expect("insert");
     assert!(w.tint.is_none());
 
@@ -89,10 +89,10 @@ fn workspace_set_tint_round_trips() {
 fn workspace_list_for_project_excludes_archived() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let a = workspaces
-        .insert(&project_id, "A", "a", "oximux/a", "/wt/a")
+        .insert(&project_id, "A", "a", "oximux/a", "/wt/a", true)
         .expect("a");
     workspaces
-        .insert(&project_id, "B", "b", "oximux/b", "/wt/b")
+        .insert(&project_id, "B", "b", "oximux/b", "/wt/b", true)
         .expect("b");
     workspaces.mark_archived(&a.id).expect("archive a");
     let active = workspaces.list_for_project(&project_id).expect("list");
@@ -104,7 +104,7 @@ fn workspace_list_for_project_excludes_archived() {
 fn workspace_mark_archived_sets_timestamp_and_status() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "A", "a", "oximux/a", "/wt/a")
+        .insert(&project_id, "A", "a", "oximux/a", "/wt/a", true)
         .expect("insert");
     workspaces.mark_archived(&w.id).expect("archive");
     let after = workspaces.get_by_id(&w.id).expect("get").expect("present");
@@ -116,7 +116,7 @@ fn workspace_mark_archived_sets_timestamp_and_status() {
 fn workspace_rename() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "Old", "o", "oximux/o", "/wt/o")
+        .insert(&project_id, "Old", "o", "oximux/o", "/wt/o", true)
         .expect("insert");
     workspaces.rename(&w.id, "New").expect("rename");
     let after = workspaces.get_by_id(&w.id).expect("get").expect("present");
@@ -127,7 +127,7 @@ fn workspace_rename() {
 fn workspace_delete_removes_row() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "A", "a", "oximux/a", "/wt/a")
+        .insert(&project_id, "A", "a", "oximux/a", "/wt/a", true)
         .expect("insert");
     workspaces.delete(&w.id).expect("delete");
     assert!(workspaces.get_by_id(&w.id).expect("get").is_none());
@@ -137,10 +137,10 @@ fn workspace_delete_removes_row() {
 fn workspace_unique_project_slug_conflict() {
     let (project_id, workspaces, _, _) = project_and_repos();
     workspaces
-        .insert(&project_id, "A", "feat", "oximux/feat", "/wt/feat")
+        .insert(&project_id, "A", "feat", "oximux/feat", "/wt/feat", true)
         .expect("first");
     let err = workspaces
-        .insert(&project_id, "B", "feat", "oximux/feat2", "/wt/feat2")
+        .insert(&project_id, "B", "feat", "oximux/feat2", "/wt/feat2", true)
         .expect_err("conflict");
     match err {
         StorageError::Conflict { table, constraint } => {
@@ -158,7 +158,7 @@ fn workspace_unique_project_slug_conflict() {
 fn workspace_delete_cascades_to_panes_but_keeps_agent_history() {
     let (project_id, workspaces, panes, agents) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "A", "a", "oximux/a", "/wt/a")
+        .insert(&project_id, "A", "a", "oximux/a", "/wt/a", true)
         .expect("workspace");
     panes.insert(&w.id, "bash", "0,0,1,1", None).expect("pane");
     agents
@@ -179,7 +179,7 @@ fn workspace_delete_cascades_to_panes_but_keeps_agent_history() {
 fn workspace_archive_unarchive_round_trip_preserves_every_field() {
     let (project_id, workspaces, _, _) = project_and_repos();
     let w = workspaces
-        .insert(&project_id, "Feat", "feat", "oximux/feat", "/wt/feat")
+        .insert(&project_id, "Feat", "feat", "oximux/feat", "/wt/feat", true)
         .expect("insert");
     // Set every field a user can change, so the restore has something to lose.
     workspaces.set_tint(&w.id, Some("blue")).expect("tint");
@@ -246,10 +246,10 @@ fn workspace_list_archived_is_scoped_to_its_project() {
     let b = projects.insert("B", "/b", "main").expect("project b");
     let workspaces = WorkspaceRepo::new(db);
     let wa = workspaces
-        .insert(&a.id, "A1", "a1", "oximux/a1", "/wt/a1")
+        .insert(&a.id, "A1", "a1", "oximux/a1", "/wt/a1", true)
         .expect("insert a1");
     workspaces
-        .insert(&b.id, "B1", "b1", "oximux/b1", "/wt/b1")
+        .insert(&b.id, "B1", "b1", "oximux/b1", "/wt/b1", true)
         .expect("insert b1");
     workspaces.mark_archived(&wa.id).expect("archive");
 
@@ -264,4 +264,36 @@ fn workspace_list_archived_is_scoped_to_its_project() {
             .expect("list archived b")
             .is_empty()
     );
+}
+
+/// **The minted-vs-adopted flag survives a round trip.** Every path that
+/// removes a worktree reads it to decide whether removing the branch is
+/// cleanup or data loss, so a value that did not persist would silently pick
+/// the destructive answer.
+#[test]
+fn branch_minted_round_trips_in_both_states() {
+    let (project_id, workspaces, _, _) = project_and_repos();
+    let minted = workspaces
+        .insert(&project_id, "Mine", "mine", "oximux/mine", "/wt/mine", true)
+        .expect("insert minted");
+    let adopted = workspaces
+        .insert(&project_id, "Theirs", "theirs", "feature/api/retry", "/wt/theirs", false)
+        .expect("insert adopted");
+    assert!(minted.branch_minted, "the returned row must carry it");
+    assert!(!adopted.branch_minted);
+
+    // And it comes back off disk, which is the half that actually matters.
+    assert!(
+        workspaces.get_by_id(&minted.id).expect("get").expect("row").branch_minted,
+        "a minted branch read back as adopted would never be cleaned up"
+    );
+    assert!(
+        !workspaces.get_by_id(&adopted.id).expect("get").expect("row").branch_minted,
+        "an adopted branch read back as minted would be force-deleted"
+    );
+    // Listings too — the rail and the delete flow both read through these.
+    let listed = workspaces.list_for_project(&project_id).expect("list");
+    let by_slug = |s: &str| listed.iter().find(|w| w.slug == s).expect("listed").branch_minted;
+    assert!(by_slug("mine"));
+    assert!(!by_slug("theirs"));
 }

--- a/crates/worktree-ops/src/create_base.rs
+++ b/crates/worktree-ops/src/create_base.rs
@@ -1,0 +1,313 @@
+//! What a new worktree is cut from — and what that choice implies for
+//! provisioning.
+//!
+//! Before this existed, `git worktree add -b <branch> <path>` ran with no
+//! start-point, so every worktree branched off whatever the main checkout's
+//! HEAD happened to be. Creating a worktree while sitting on a half-finished
+//! feature branch silently based the new work on it, and the user found out
+//! at review time.
+//!
+//! The two modes are an enum rather than two optional strings because the
+//! fourth state — "adopt an existing branch, and also cut it from somewhere" —
+//! is not a thing, and a pair of `Option`s would let a caller build it.
+
+use oximux_git::Repository;
+use oximux_settings::SetupDecision;
+
+/// The base a new worktree is cut from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CreateBase {
+    /// Cut a brand-new branch named `branch`.
+    ///
+    /// `from: None` means **the repository's default branch**, resolved by the
+    /// create path, degrading to the main checkout's current HEAD only when
+    /// that default does not resolve locally. It does *not* mean "HEAD": every
+    /// unattended caller (the RPC, a team run, the chat pill) wants the default
+    /// branch and none of them wants whatever the user happens to be sitting
+    /// on, which is the defect this whole enum exists to close.
+    ///
+    /// `from: Some(r)` names an explicit start point. That one is strict — a
+    /// ref the user asked for by name and that does not resolve is an error,
+    /// not an invitation to substitute something else.
+    NewBranch {
+        branch: String,
+        from: Option<String>,
+    },
+    /// Check out an **existing** branch. No branch is created and no prefix
+    /// applies: the worktree adopts the branch under the name it already has.
+    ExistingBranch { name: String },
+}
+
+impl CreateBase {
+    /// A new branch cut from the repository's default branch (see the variant
+    /// doc for the degradation).
+    pub fn new_branch(branch: impl Into<String>) -> Self {
+        Self::NewBranch {
+            branch: branch.into(),
+            from: None,
+        }
+    }
+
+    /// A new branch cut from an explicit start point.
+    pub fn new_branch_from(branch: impl Into<String>, from: impl Into<String>) -> Self {
+        Self::NewBranch {
+            branch: branch.into(),
+            from: Some(from.into()),
+        }
+    }
+
+    /// Adopt an existing branch.
+    pub fn existing(name: impl Into<String>) -> Self {
+        Self::ExistingBranch { name: name.into() }
+    }
+
+    /// The branch the workspace row will name. In both modes this is the
+    /// branch the worktree ends up checked out on.
+    pub fn branch(&self) -> &str {
+        match self {
+            Self::NewBranch { branch, .. } => branch,
+            Self::ExistingBranch { name } => name,
+        }
+    }
+
+    /// Whether creating this worktree *minted* the branch — and therefore
+    /// whether a rollback may delete it.
+    ///
+    /// **This is a data-loss guard, not bookkeeping.** Rollback force-deletes
+    /// the branch (`delete_branch(branch, true)`), which is correct for a
+    /// branch that did not exist a moment ago and catastrophic for one the user
+    /// has been working on for a week. An adopted branch must survive a failed
+    /// create exactly as it was.
+    pub fn creates_branch(&self) -> bool {
+        matches!(self, Self::NewBranch { .. })
+    }
+
+    /// The ref this worktree is based on, when the caller named one.
+    ///
+    /// `None` for `NewBranch { from: None }` — not because the base is unknown
+    /// (it is the default branch) but because nobody *chose* it, which is the
+    /// distinction [`setup_decision`] turns on: the default branch is by
+    /// definition one the user has reviewed.
+    pub fn named_base(&self) -> Option<&str> {
+        match self {
+            Self::NewBranch { from, .. } => from.as_deref(),
+            Self::ExistingBranch { name } => Some(name),
+        }
+    }
+}
+
+/// Whether the setup script may run for a worktree cut from this base.
+///
+/// Provisioning runs the *worktree's own committed* `.oximux/scripts.toml` —
+/// "the branch's own copy is the one that will actually run". That is safe only
+/// while every worktree branches off the user's own HEAD, which is precisely
+/// the invariant [`CreateBase`] removes. Basing a worktree on a fetched
+/// contributor branch would otherwise run their script as the user, unattended,
+/// on any project with `auto_setup = true`.
+///
+/// So the rule is: **a ref the user has not reviewed never runs a setup
+/// script.**
+///
+/// - No base was named (`NewBranch { from: None }`) → the default branch, or
+///   the user's own checkout behind it. Both are the trust premise that already
+///   held, so the guard has nothing to add.
+/// - The named base **is** the default branch, in any of its spellings
+///   (`main`, `origin/main`, `refs/remotes/upstream/main`) → reviewed by
+///   definition. See [`is_the_default_branch`] for why this matters more than
+///   it looks.
+/// - The named base is an ancestor of the default branch → already in the
+///   history the user lives on. Provision normally.
+/// - Anything else, **including anything we could not check** →
+///   [`SetupDecision::Skip`], with a reason to show.
+///
+/// An explicit [`SetupDecision::Skip`] from the caller stays `Skip` with no
+/// reason of ours, and an explicit [`SetupDecision::Run`] is honoured: the
+/// guard is a *default*, not a prohibition. `Run setup` from the row menu is
+/// how a user opts in after reading the script.
+///
+/// # This fails CLOSED, and that is the whole point
+///
+/// An earlier draft treated "we could not establish ancestry" as "provision
+/// normally", on the reasoning that inventing a refusal from ignorance is
+/// rude. That reasoning is wrong here, and the asymmetry is why: failing
+/// closed costs the user one click (`Run setup`), while failing open runs a
+/// script from a ref they have not read, as them, unattended. A repository
+/// with no discoverable default branch — no `origin/HEAD`, no local
+/// `main`/`master` — is not exotic, and it is precisely the case where we know
+/// least about what the base is.
+///
+/// The guard still applies **only to a named base**, so no caller that never
+/// asks for one is affected.
+pub async fn setup_decision(
+    repo: &Repository,
+    base: &CreateBase,
+    requested: SetupDecision,
+    default_branch: Option<&str>,
+) -> (SetupDecision, Option<String>) {
+    // The caller already decided. `Run` is a deliberate opt-in past this guard;
+    // `Skip` is already the answer this could only agree with.
+    if requested != SetupDecision::Inherit {
+        return (requested, None);
+    }
+    let Some(named) = base.named_base() else {
+        return (requested, None);
+    };
+    // A malformed ref never reaches `git merge-base`. This runs upstream of
+    // `add_worktree_from`'s own validation, so without this the first `git`
+    // invocation to see an unvalidated ref would be the ancestry check.
+    if oximux_git::worktree::validate_ref_name(named).is_err() {
+        return (
+            SetupDecision::Skip,
+            Some(format!("Setup skipped: `{named}` is not a usable ref name.")),
+        );
+    }
+    let unverified = |detail: &str| {
+        (
+            SetupDecision::Skip,
+            Some(format!(
+                "Setup skipped: could not verify `{named}` against the default branch \
+                 ({detail}). Review the branch, then Run setup."
+            )),
+        )
+    };
+    let Some(default) = default_branch else {
+        tracing::info!(base = %named, "setup guard: no default branch to compare against");
+        return unverified("this repository has no default branch");
+    };
+    // The default branch itself, however it was spelled — the case that would
+    // otherwise produce the most false positives.
+    if is_the_default_branch(repo, named, default).await {
+        return (requested, None);
+    }
+    match repo.is_ancestor(named, default).await {
+        Ok(true) => (requested, None),
+        Ok(false) => (
+            SetupDecision::Skip,
+            Some(format!(
+                "Setup skipped: `{named}` is not based on `{default}`. \
+                 Review the branch, then Run setup."
+            )),
+        ),
+        Err(err) => {
+            tracing::warn!(?err, base = %named, %default, "ancestry check failed; skipping setup");
+            unverified("the ancestry check failed")
+        }
+    }
+}
+
+/// Whether `named` is the default branch under any of the spellings a user
+/// would reasonably type.
+///
+/// **Why an equality test is not enough.** `is_ancestor(named, default)` asks
+/// "is the base contained in the default branch's history". For
+/// `--from origin/main` against a local `main` that is even slightly behind the
+/// remote, `origin/main` is a *descendant*, so the honest answer is `false` and
+/// the guard fires. But basing work on the up-to-date remote default is the
+/// single most common reason to reach for `--from` at all — it is exactly what
+/// the `keep_default_up_to_date` setting produces automatically — so treating
+/// it as an unreviewed contributor branch would fire the warning on the safest
+/// thing a user can do, and train them to ignore it.
+///
+/// **Why the shape test alone is not enough either.** `origin/main` and
+/// `feature/main` are structurally identical — one segment, then the default's
+/// name — so no amount of string inspection separates a remote from somebody's
+/// branch. `feature/main` is a branch a person made and must NOT be waved
+/// through. So the shape test only decides *what to ask git*, and the answer
+/// comes from whether `refs/remotes/<prefix>/<default>` actually resolves.
+/// That is exact, costs one `rev-parse` on a path that already runs several,
+/// and needs no list of remote names.
+async fn is_the_default_branch(repo: &Repository, named: &str, default: &str) -> bool {
+    if named == default {
+        return true;
+    }
+    let Some(prefix) = remote_prefix_of(named, default) else {
+        return false;
+    };
+    repo.sha_of(&format!("refs/remotes/{prefix}/{default}"))
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+/// The single segment in front of `default` in `named`, when `named` has the
+/// shape `<one-segment>/<default>` or `refs/remotes/<one-segment>/<default>`.
+///
+/// Pure, and separated from the git question so the shape rule can be stated in
+/// tests without a repository. A `None` here means "not even shaped like a
+/// remote-tracking ref", which is a definite answer; a `Some` only means "worth
+/// asking git about".
+fn remote_prefix_of<'a>(named: &'a str, default: &str) -> Option<&'a str> {
+    let prefix = named.strip_suffix(default)?.strip_suffix('/')?;
+    let prefix = prefix.strip_prefix("refs/remotes/").unwrap_or(prefix);
+    // Exactly one segment. `a/b/main` is not `<remote>/main`.
+    (!prefix.is_empty() && !prefix.contains('/')).then_some(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_row_names_the_branch_in_both_modes() {
+        assert_eq!(CreateBase::new_branch("oximux/x").branch(), "oximux/x");
+        assert_eq!(
+            CreateBase::new_branch_from("oximux/x", "main").branch(),
+            "oximux/x"
+        );
+        assert_eq!(CreateBase::existing("side").branch(), "side");
+    }
+
+    #[test]
+    fn only_a_minted_branch_may_be_rolled_back() {
+        assert!(CreateBase::new_branch("oximux/x").creates_branch());
+        assert!(CreateBase::new_branch_from("oximux/x", "main").creates_branch());
+        assert!(
+            !CreateBase::existing("side").creates_branch(),
+            "rollback would force-delete the user's own branch"
+        );
+    }
+
+    #[test]
+    fn only_a_chosen_base_is_a_named_one() {
+        assert_eq!(CreateBase::new_branch("oximux/x").named_base(), None);
+        assert_eq!(
+            CreateBase::new_branch_from("oximux/x", "origin/pr").named_base(),
+            Some("origin/pr")
+        );
+        assert_eq!(CreateBase::existing("side").named_base(), Some("side"));
+    }
+}
+
+#[cfg(test)]
+mod remote_shape_tests {
+    use super::remote_prefix_of;
+
+    /// These are the names worth asking git about. Whether they ARE the remote
+    /// default is then settled by `refs/remotes/<prefix>/<default>` resolving —
+    /// which is what keeps `feature/main` (same shape, real branch) out.
+    #[test]
+    fn a_single_segment_in_front_of_the_default_is_a_candidate() {
+        assert_eq!(remote_prefix_of("origin/main", "main"), Some("origin"));
+        assert_eq!(remote_prefix_of("upstream/main", "main"), Some("upstream"));
+        assert_eq!(remote_prefix_of("refs/remotes/origin/main", "main"), Some("origin"));
+        // Same shape, and deliberately still a candidate: only git can say that
+        // no remote is called `feature`.
+        assert_eq!(remote_prefix_of("feature/main", "main"), Some("feature"));
+    }
+
+    #[test]
+    fn anything_that_is_not_that_shape_is_refused_outright() {
+        assert_eq!(remote_prefix_of("main", "main"), None, "handled by the equality arm");
+        assert_eq!(remote_prefix_of("mymain", "main"), None);
+        assert_eq!(remote_prefix_of("wip/api/main", "main"), None, "two segments");
+        assert_eq!(remote_prefix_of("origin/feature/main", "main"), None);
+        assert_eq!(remote_prefix_of("side", "main"), None);
+    }
+
+    #[test]
+    fn a_slashed_default_keeps_the_one_segment_rule() {
+        assert_eq!(remote_prefix_of("origin/release/4.x", "release/4.x"), Some("origin"));
+        assert_eq!(remote_prefix_of("a/b/release/4.x", "release/4.x"), None);
+    }
+}

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -442,28 +442,45 @@ pub async fn create_workspace_with_rollback(
     }
 }
 
-/// The default branch, but only if `git` can actually resolve it here.
+/// A ref naming the project's default branch that `git` can actually resolve.
 ///
-/// `default_branch()` answers with the name behind `origin/HEAD` when there is
-/// one, and that name need not exist as a local ref. Handing an unresolvable
-/// name to `git worktree add` is worse than useless: git DWIMs a name matching
-/// exactly one remote-tracking branch into `--track -b <that name>`, which
-/// **overrides an explicit `-b`** and produces a worktree on the wrong branch
-/// entirely (see [`Repository::add_worktree_from`]). So this asks git, and a
-/// `None` here means "base on HEAD", not "fail".
+/// [`Repository::default_branch`] answers with a *name* — `main` — which on a
+/// worktree-centric checkout may have no `refs/heads/` entry at all, because
+/// the user deleted the local branch they never sit on. So the name is tried in
+/// two spellings, and the order matters:
+///
+/// 1. `main` — the local branch, when it exists. What the user's own work is
+///    based on.
+/// 2. `origin/main` — the remote-tracking form. Still the default branch, just
+///    held somewhere else, and the correct base when there is no local copy.
+///
+/// **Only when neither resolves does this give up**, and `None` means "base on
+/// HEAD" rather than "fail" — a stale captured default must not make creating a
+/// worktree impossible.
+///
+/// Live verification is what established the second spelling is required: with
+/// only step 1, a repo whose default lives at `origin/main` degraded straight to
+/// HEAD and based new work on whatever feature branch the checkout was parked
+/// on. That is the defect base refs exist to close, reintroduced through the
+/// fallback — and no unit test caught it, because they all had a local `main`.
 async fn resolvable_default(repo: &Repository, default_branch: Option<&str>) -> Option<String> {
     let default = default_branch?;
-    match repo.sha_of(default).await {
-        Ok(Some(_)) => Some(default.to_string()),
-        Ok(None) => {
-            tracing::info!(%default, "default branch does not resolve locally; basing on HEAD");
-            None
-        }
-        Err(err) => {
-            tracing::warn!(?err, %default, "could not resolve the default branch; basing on HEAD");
-            None
+    // `origin/` matches `default_branch`'s own source (`refs/remotes/origin/HEAD`).
+    for candidate in [default.to_string(), format!("origin/{default}")] {
+        match repo.sha_of(&candidate).await {
+            Ok(Some(_)) => return Some(candidate),
+            Ok(None) => continue,
+            Err(err) => {
+                tracing::warn!(?err, %candidate, "could not resolve a default-branch candidate");
+                continue;
+            }
         }
     }
+    tracing::info!(
+        %default,
+        "default branch resolves neither locally nor as a remote-tracking ref; basing on HEAD"
+    );
+    None
 }
 
 /// Clear a worktree directory left behind by an interrupted create, so a retry

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -289,14 +289,19 @@ pub async fn create_workspace_with_rollback(
     // repository that cannot name one degrades to "provision normally" inside
     // `setup_decision` rather than failing the create.
     //
-    // Read for every mode except the two that name their own base outright, so
-    // an unnamed create can be based on the default branch rather than on
-    // whatever the checkout happens to be sitting on.
-    let default_branch = if matches!(base, CreateBase::ExistingBranch { .. }) {
-        None
-    } else {
-        repo.default_branch().await.ok().flatten()
-    };
+    // Read unconditionally: every mode needs it, so there is nothing to be
+    // lazy about. An unnamed create is *based* on it; a named base and an
+    // adopted branch are both *checked against* it; and the freshen step below
+    // targets it.
+    //
+    // An earlier version skipped the read for `ExistingBranch`, which looked
+    // like a saved subprocess and was a bug: `named_base()` is `Some` for that
+    // variant, so `setup_decision` hit its "no default branch" arm every time
+    // and told the user "could not verify `<branch>` against the default branch
+    // (this repository has no default branch)" on repositories that plainly had
+    // one — while also making an adopted ancestor branch unable to provision at
+    // all, and `freshen_default` a no-op for adopts.
+    let default_branch = repo.default_branch().await.ok().flatten();
     let (setup, setup_skip_reason) =
         create_base::setup_decision(&repo, base, provision.setup, default_branch.as_deref()).await;
 

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -414,7 +414,10 @@ pub async fn create_workspace_with_rollback(
     // The branch the ROW names — the minted one, or the adopted one. This is
     // the clause the module doc's three-way agreement turns on.
     let branch = base.branch();
-    match workspace_repo.insert(project_id, name, slug, branch, &path_str) {
+    // Recorded, not inferred: `creates_branch()` is a create-time fact, and
+    // every later path that removes this worktree needs it to tell cleanup from
+    // data loss. See `Workspace::branch_minted`.
+    match workspace_repo.insert(project_id, name, slug, branch, &path_str, base.creates_branch()) {
         Ok(mut workspace) => {
             // Best-effort metadata write — the worktree + row already exist, so
             // a failure here only loses the issue badge, not the workspace. The

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -1,10 +1,13 @@
 //! The worktree lifecycle, shared by every host.
 //!
 //! A worktree is three things that must agree: a git worktree on disk, the
-//! `oximux/<slug>` branch it checks out, and the `workspaces` row that names
-//! both. [`create_workspace_with_rollback`] is what keeps them in agreement
-//! when the third step fails after the first two succeeded, and it is the
-//! reason this module exists as one implementation rather than two.
+//! branch it checks out, and the `workspaces` row that names both. That branch
+//! used to be `oximux/<slug>` by construction; it is now whatever the row
+//! records, because a worktree may be cut on a configured prefix or may adopt
+//! an existing branch outright (see [`CreateBase`]).
+//! [`create_workspace_with_rollback`] is what keeps them in agreement when the
+//! third step fails after the first two succeeded, and it is the reason this
+//! module exists as one implementation rather than two.
 //!
 //! The path scheme is host-derived on purpose: a client names a project and a
 //! slug, never a location. [`worktree_path`] is that derivation, taking the
@@ -12,6 +15,7 @@
 //! its own root instead of the desktop's.
 
 pub mod branch_name;
+pub mod create_base;
 pub mod freshen;
 pub mod include;
 pub mod merge;
@@ -20,6 +24,7 @@ mod paths;
 mod service;
 pub mod setup;
 
+pub use create_base::{CreateBase, setup_decision};
 pub use include::{CopyReport, Skip};
 pub use merge::{
     MergePlan, MergeRefusal, MergeResult, apply_merge, merge_into_default, preflight_merge,
@@ -58,6 +63,11 @@ pub enum ProvisionEvent {
     FreshenStarted(String),
     /// What the freshen did — moved the branch, or skipped, with the reason.
     FreshenFinished(String),
+    /// The setup script will NOT run, and why. Distinct from simply not
+    /// emitting `SetupStarted`: a silent skip is indistinguishable from a
+    /// project that has no setup script, and this one is a decision OxiMux made
+    /// on the user's behalf that they may want to reverse with `Run setup`.
+    SetupSkipped(String),
     /// The setup script is about to run. Carries the script itself, because
     /// "which command produced this output" is the first question a failing
     /// transcript raises.
@@ -199,14 +209,24 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
         .join(slug)
 }
 
-/// Open the project repo, create a new worktree on branch `oximux/<slug>`,
+/// Open the project repo, create the worktree [`base`](CreateBase) describes,
 /// and insert the workspace row. On storage failure, runs the rollback
-/// (force-remove worktree + force-delete branch) so that the next listing
-/// reflects the on-disk truth.
+/// (force-remove worktree, and force-delete the branch **only if this create
+/// minted it**) so that the next listing reflects the on-disk truth.
 ///
 /// `name` is the human label (caller has already trimmed); `slug` MUST
-/// pre-validate via `validate_slug` upstream — this function assumes the
-/// slug is safe to pass to `git worktree add -b oximux/<slug>`.
+/// pre-validate via `validate_slug` upstream — it names the directory and the
+/// row in every mode. `base` carries the branch name, already resolved by
+/// [`branch_name`], and says where the branch is cut from; the git layer
+/// validates it again before `git` sees it.
+///
+/// # The base and the setup script
+///
+/// Provisioning runs the *worktree's own committed* setup script, which is
+/// safe only while every worktree branches off the user's own HEAD — the
+/// invariant `base` removes. So a base the user has not reviewed skips the
+/// script and says why; see [`create_base::setup_decision`], which owns that
+/// rule and every degradation in it.
 ///
 /// # Preconditions
 ///
@@ -231,7 +251,7 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
 #[allow(
     clippy::too_many_arguments,
     reason = "Eight of the nine are irreducible inputs to one operation: where the repo is, \
-              what the workspace is called, what its branch is called, where it goes, and what \
+              what the workspace is called, what it is cut from, where it goes, and what \
               to write it into. Bundling them into a params struct moves the same fields behind \
               a name that means nothing more than the function's own — and every one of the five \
               call sites would then build a struct to immediately destructure it. The ninth, \
@@ -242,7 +262,7 @@ pub async fn create_workspace_with_rollback(
     project_id: &str,
     name: &str,
     slug: &str,
-    branch: &str,
+    base: &CreateBase,
     worktree_path: &Path,
     linked_issue: Option<&str>,
     workspace_repo: &WorkspaceRepo,
@@ -259,28 +279,70 @@ pub async fn create_workspace_with_rollback(
     // Accepted rather than guessed at: deleting a branch whose name we inferred
     // from a directory is how a reclaim destroys work it did not create.
     if provision.reclaim_orphan
-        && let Some(err) = reclaim_orphan(&repo, worktree_path, branch, workspace_repo).await
+        && let Some(err) = reclaim_orphan(&repo, worktree_path, base, workspace_repo).await
     {
         return CreateOutcome::GitFailed(err);
     }
 
-    // Optional, off by default, and unable to fail the create. `git worktree
-    // add` branches from HEAD, so this changes the new worktree's base only
-    // when the root checkout is on the default branch — which is the usual
-    // state, and the case the setting is for. Every refusal inside is silent
-    // and ordinary; see `freshen` for both.
+    // Read once and used twice: to decide whether the chosen base is one the
+    // user has already reviewed, and (below) as the freshen target. A
+    // repository that cannot name one degrades to "provision normally" inside
+    // `setup_decision` rather than failing the create.
+    //
+    // Read for every mode except the two that name their own base outright, so
+    // an unnamed create can be based on the default branch rather than on
+    // whatever the checkout happens to be sitting on.
+    let default_branch = if matches!(base, CreateBase::ExistingBranch { .. }) {
+        None
+    } else {
+        repo.default_branch().await.ok().flatten()
+    };
+    let (setup, setup_skip_reason) =
+        create_base::setup_decision(&repo, base, provision.setup, default_branch.as_deref()).await;
+
+    // Optional, off by default, and unable to fail the create. Whether it
+    // changes what the new worktree is *based on* now depends on the base: it
+    // does when the base IS the default branch (the common case, and the one
+    // the setting is for), and does not when the base names something else or
+    // when a no-start-point create leaves the root checkout's HEAD in charge.
+    // Every refusal inside is silent and ordinary; see `freshen` for both.
     if provision.freshen_default {
-        match repo.default_branch().await {
-            Ok(Some(default)) => {
-                provision.emit(ProvisionEvent::FreshenStarted(default.clone()));
-                let outcome = freshen::freshen_default_branch(&repo, &default).await;
+        match default_branch.as_deref() {
+            Some(default) => {
+                provision.emit(ProvisionEvent::FreshenStarted(default.to_string()));
+                let outcome = freshen::freshen_default_branch(&repo, default).await;
                 tracing::debug!(?outcome, %default, "freshen default branch before create");
                 provision.emit(ProvisionEvent::FreshenFinished(outcome.summary()));
             }
-            _ => tracing::debug!("freshen skipped: no default branch detected"),
+            None => tracing::debug!("freshen skipped: no default branch detected"),
         }
     }
-    if let Err(err) = repo.add_worktree(worktree_path, branch).await {
+    let added = match base {
+        // Explicit, therefore strict: a start point the user named by hand and
+        // that does not resolve is an error, never a silent substitution.
+        CreateBase::NewBranch {
+            branch,
+            from: Some(start_point),
+        } => repo.add_worktree_from(worktree_path, branch, start_point).await,
+        // No base named: the repository's default branch — and HEAD only when
+        // that default does not resolve *locally*.
+        //
+        // The degradation is not hypothetical. `default_branch()` reports the
+        // name behind `origin/HEAD`, which on a worktree-centric checkout is
+        // routinely a branch with no `refs/heads/` entry at all (the user
+        // deleted the local `main` they never sit on). Refusing to create a
+        // worktree because a piece of captured metadata went stale is the
+        // failure this fallback exists to avoid — the plan's own risk note
+        // calls for exactly it.
+        CreateBase::NewBranch { branch, from: None } => {
+            match resolvable_default(&repo, default_branch.as_deref()).await {
+                Some(default) => repo.add_worktree_from(worktree_path, branch, &default).await,
+                None => repo.add_worktree(worktree_path, branch).await,
+            }
+        }
+        CreateBase::ExistingBranch { name } => repo.add_worktree_existing(worktree_path, name).await,
+    };
+    if let Err(err) = added {
         return CreateOutcome::GitFailed(format!("add_worktree: {err}"));
     }
 
@@ -317,7 +379,16 @@ pub async fn create_workspace_with_rollback(
     // `run_cleanup_before_remove` uses — it is committed, so the branch's own
     // copy is the one that will actually run.
     let scripts = oximux_settings::load_for_project(worktree_path);
-    if provision.setup.resolve(scripts.auto_setup)
+    // The guard only has something to say when a script would otherwise have
+    // run — telling the user setup was skipped on a project that has no setup
+    // script is noise about a decision that changed nothing.
+    if let Some(reason) = setup_skip_reason
+        && scripts.script(ScriptKind::Setup).is_some()
+    {
+        tracing::info!(worktree = %worktree_path.display(), %reason, "setup skipped: unreviewed base");
+        provision.emit(ProvisionEvent::SetupSkipped(reason));
+    }
+    if setup.resolve(scripts.auto_setup)
         && let Some(script) = scripts.script(ScriptKind::Setup)
     {
         provision.emit(ProvisionEvent::SetupStarted(script.to_string()));
@@ -331,7 +402,7 @@ pub async fn create_workspace_with_rollback(
                 outcome = %transcript.outcome.summary(),
                 "setup failed during provisioning; rolling back"
             );
-            let rollback_error = rollback(&repo, worktree_path, branch).await;
+            let rollback_error = rollback(&repo, worktree_path, base).await;
             return CreateOutcome::SetupFailed {
                 transcript,
                 rollback_error,
@@ -340,6 +411,9 @@ pub async fn create_workspace_with_rollback(
     }
 
     let path_str = worktree_path.to_string_lossy().to_string();
+    // The branch the ROW names — the minted one, or the adopted one. This is
+    // the clause the module doc's three-way agreement turns on.
+    let branch = base.branch();
     match workspace_repo.insert(project_id, name, slug, branch, &path_str) {
         Ok(mut workspace) => {
             // Best-effort metadata write — the worktree + row already exist, so
@@ -355,13 +429,37 @@ pub async fn create_workspace_with_rollback(
             }
             CreateOutcome::Created(workspace)
         }
-        Err(insert_error) => match rollback(&repo, worktree_path, branch).await {
+        Err(insert_error) => match rollback(&repo, worktree_path, base).await {
             Some(rollback_error) => CreateOutcome::StorageFailedRollbackDirty {
                 insert_error,
                 rollback_error,
             },
             None => CreateOutcome::StorageFailedRollbackClean(insert_error),
         },
+    }
+}
+
+/// The default branch, but only if `git` can actually resolve it here.
+///
+/// `default_branch()` answers with the name behind `origin/HEAD` when there is
+/// one, and that name need not exist as a local ref. Handing an unresolvable
+/// name to `git worktree add` is worse than useless: git DWIMs a name matching
+/// exactly one remote-tracking branch into `--track -b <that name>`, which
+/// **overrides an explicit `-b`** and produces a worktree on the wrong branch
+/// entirely (see [`Repository::add_worktree_from`]). So this asks git, and a
+/// `None` here means "base on HEAD", not "fail".
+async fn resolvable_default(repo: &Repository, default_branch: Option<&str>) -> Option<String> {
+    let default = default_branch?;
+    match repo.sha_of(default).await {
+        Ok(Some(_)) => Some(default.to_string()),
+        Ok(None) => {
+            tracing::info!(%default, "default branch does not resolve locally; basing on HEAD");
+            None
+        }
+        Err(err) => {
+            tracing::warn!(?err, %default, "could not resolve the default branch; basing on HEAD");
+            None
+        }
     }
 }
 
@@ -388,9 +486,10 @@ pub async fn create_workspace_with_rollback(
 async fn reclaim_orphan(
     repo: &Repository,
     worktree_path: &Path,
-    branch: &str,
+    base: &CreateBase,
     workspace_repo: &WorkspaceRepo,
 ) -> Option<String> {
+    let branch = base.branch();
     if !worktree_path.exists() {
         return None;
     }
@@ -421,7 +520,7 @@ async fn reclaim_orphan(
     // The same ladder the failure paths use: git knows about this worktree, so
     // let git detach it and drop the branch rather than tearing the directory
     // out from under `.git/worktrees`.
-    let rollback_err = rollback(repo, worktree_path, branch).await;
+    let rollback_err = rollback(repo, worktree_path, base).await;
     // Git can decline a path it never registered (a create killed between
     // `mkdir` and `worktree add`). The directory still has to go.
     if worktree_path.exists()
@@ -445,12 +544,19 @@ async fn reclaim_orphan(
 ///
 /// Shared by the storage-failure and setup-failure arms: two rollback ladders
 /// for the same two artifacts would be two chances to drift.
-async fn rollback(repo: &Repository, worktree_path: &Path, branch: &str) -> Option<String> {
+async fn rollback(repo: &Repository, worktree_path: &Path, base: &CreateBase) -> Option<String> {
     let mut err = None;
     if let Err(e) = repo.remove_worktree(worktree_path, true).await {
         err = Some(format!("remove_worktree: {e}"));
     }
-    if let Err(e) = repo.delete_branch(branch, true).await {
+    // ONLY a branch this create minted. `delete_branch(_, true)` is
+    // `git branch -D` — correct for a branch that did not exist a moment ago,
+    // and a week of someone's work for a branch the worktree merely adopted.
+    // Undoing a checkout means removing the worktree; it never means deleting
+    // the branch that was checked out.
+    if base.creates_branch()
+        && let Err(e) = repo.delete_branch(base.branch(), true).await
+    {
         err = Some(match err {
             Some(prev) => format!("{prev}; delete_branch: {e}"),
             None => format!("delete_branch: {e}"),

--- a/crates/worktree-ops/src/merge.rs
+++ b/crates/worktree-ops/src/merge.rs
@@ -382,6 +382,7 @@ mod tests {
             name: "Feat".into(),
             slug: "feat".into(),
             branch: branch.into(),
+            branch_minted: true,
             worktree_path: "/wt/feat".into(),
             status: "active".into(),
             created_at: String::new(),

--- a/crates/worktree-ops/src/service.rs
+++ b/crates/worktree-ops/src/service.rs
@@ -16,14 +16,15 @@
 use std::path::PathBuf;
 
 use oximux_git::{Repository, validate_slug};
+use oximux_git::worktree::{derive_slug, validate_ref_name};
 use oximux_remote_host::{WorktreeError, WorktreeService};
-use oximux_remote_proto::messages::{WorktreeProgressWire, WorktreeWire};
+use oximux_remote_proto::messages::{CreateBaseWire, WorktreeProgressWire, WorktreeWire};
 use oximux_storage::{ProjectRepo, WorkspaceRepo};
 
 use crate::branch_name;
 use crate::{
-    CreateOutcome, Provision, create_workspace_with_rollback, run_cleanup_before_remove,
-    worktree_path,
+    CreateBase, CreateOutcome, Provision, create_workspace_with_rollback,
+    run_cleanup_before_remove, worktree_path,
 };
 
 /// Manages worktrees against the same repos and path scheme the desktop uses.
@@ -55,6 +56,30 @@ impl RepoWorktrees {
     }
 }
 
+/// The slug that will name the directory and the row.
+///
+/// The slug names both in **every** mode — only the branch changes — so
+/// adopting a branch still needs one. An empty slug in that mode means "derive
+/// it from the branch": a client asking for `--branch feature/api/retry` should
+/// not have to say the directory twice.
+///
+/// **The derivation lives here, on the host, deliberately.** `derive_slug` is
+/// in `oximux-git`, which is kept off `oximux-cli`'s dependency path — the same
+/// edge this crate was extracted to protect. A client-side copy of the rule
+/// would be a second naming implementation free to disagree with this one, and
+/// the disagreement would only show up as a directory named something the user
+/// did not expect.
+///
+/// The result is validated by the caller exactly as an explicit slug is, so a
+/// branch that derives to something `validate_slug` refuses is refused too,
+/// rather than reaching git.
+fn effective_slug(slug: &str, base: &CreateBaseWire) -> String {
+    match (slug, base) {
+        ("", CreateBaseWire::Existing(branch)) => derive_slug(branch),
+        (slug, _) => slug.to_string(),
+    }
+}
+
 /// One DB row as the wire shows it.
 fn wire(row: oximux_core::Workspace, project_path: &str) -> WorktreeWire {
     WorktreeWire {
@@ -69,8 +94,25 @@ fn wire(row: oximux_core::Workspace, project_path: &str) -> WorktreeWire {
 
 #[async_trait::async_trait]
 impl WorktreeService for RepoWorktrees {
-    async fn create(&self, project_path: &str, slug: &str)
-    -> Result<WorktreeWire, WorktreeError> {
+    async fn create(
+        &self,
+        project_path: &str,
+        slug: &str,
+        base: &CreateBaseWire,
+    ) -> Result<WorktreeWire, WorktreeError> {
+        // A base ref is validated here as well as at the git layer: `BadSlug`
+        // is a refusal the client can act on, where a git failure two layers
+        // down arrives as the opaque `CreateFailed`.
+        match base {
+            CreateBaseWire::Default => {}
+            CreateBaseWire::From(r) | CreateBaseWire::Existing(r) => {
+                if validate_ref_name(r).is_err() {
+                    return Err(WorktreeError::BadSlug);
+                }
+            }
+        }
+        let slug = effective_slug(slug, base);
+        let slug = slug.as_str();
         if validate_slug(slug).is_err() {
             return Err(WorktreeError::BadSlug);
         }
@@ -95,19 +137,32 @@ impl WorktreeService for RepoWorktrees {
         // `reclaim_orphan` would stop recognising its own debris.
         let root = std::path::Path::new(&project.root_path);
         let git_settings = oximux_settings::git::GitSettings::load_from_dir(&self.data_dir);
-        let branch = match Repository::open(root).await {
-            Ok(repo) => branch_name::resolve_branch_name(&git_settings, &repo, slug).await,
-            // The create below opens the same repository and reports the real
-            // failure; naming the branch the shipped way here keeps that the
-            // error the caller sees.
-            Err(_) => branch_name::branch_name(Some(oximux_settings::git::DEFAULT_PREFIX), slug),
+        // Existing-branch mode mints no name at all — it adopts one — so the
+        // resolver runs only for the two modes that create a branch.
+        let create_base = match base {
+            CreateBaseWire::Existing(name) => CreateBase::existing(name.clone()),
+            CreateBaseWire::Default | CreateBaseWire::From(_) => {
+                let branch = match Repository::open(root).await {
+                    Ok(repo) => branch_name::resolve_branch_name(&git_settings, &repo, slug).await,
+                    // The create below opens the same repository and reports the
+                    // real failure; naming the branch the shipped way here keeps
+                    // that the error the caller sees.
+                    Err(_) => {
+                        branch_name::branch_name(Some(oximux_settings::git::DEFAULT_PREFIX), slug)
+                    }
+                };
+                match base {
+                    CreateBaseWire::From(r) => CreateBase::new_branch_from(branch, r.clone()),
+                    _ => CreateBase::new_branch(branch),
+                }
+            }
         };
         let outcome = create_workspace_with_rollback(
             root,
             &project.id,
             slug,
             slug,
-            &branch,
+            &create_base,
             &target,
             None,
             &self.workspaces,
@@ -378,5 +433,40 @@ mod progress_tests {
         service.set_progress(&a, None, Some("shipped")).await.expect("set");
         let rows = service.list_progress(None).await.expect("list");
         assert_eq!(rows[0].phase, "shipped");
+    }
+}
+
+#[cfg(test)]
+mod slug_tests {
+    use super::*;
+
+    #[test]
+    fn an_explicit_slug_is_used_verbatim_in_every_mode() {
+        for base in [
+            CreateBaseWire::Default,
+            CreateBaseWire::From("main".into()),
+            CreateBaseWire::Existing("feature/api/retry".into()),
+        ] {
+            assert_eq!(effective_slug("retry", &base), "retry", "base {base:?}");
+        }
+    }
+
+    #[test]
+    fn an_omitted_slug_is_derived_from_the_adopted_branch() {
+        let base = CreateBaseWire::Existing("feature/api/retry".into());
+        // `derive_slug` flattens the slashes the branch is allowed to carry —
+        // a slug is one path component, and `validate_slug` would refuse the
+        // branch name as written.
+        assert_eq!(effective_slug("", &base), "feature-api-retry");
+    }
+
+    #[test]
+    fn an_omitted_slug_is_not_derived_in_a_mode_that_mints_a_branch() {
+        // Nothing to derive from: these modes name the branch after the slug,
+        // so an empty one stays empty and `validate_slug` refuses it upstream.
+        // Deriving `main` from `--from main` would silently name the worktree
+        // after its base.
+        assert_eq!(effective_slug("", &CreateBaseWire::Default), "");
+        assert_eq!(effective_slug("", &CreateBaseWire::From("main".into())), "");
     }
 }

--- a/crates/worktree-ops/src/service.rs
+++ b/crates/worktree-ops/src/service.rs
@@ -341,8 +341,18 @@ impl WorktreeService for RepoWorktrees {
         // Best-effort, like the desktop flow: a surviving branch is reported in
         // logs but must not strand the row, or the listing would keep showing a
         // worktree whose directory is gone.
-        if let Err(err) = repo.delete_branch(&row.branch, false).await {
-            tracing::warn!(?err, branch = %row.branch, "remote worktree remove: branch survives");
+        // Only a branch this worktree's create minted — the same guard the
+        // desktop delete applies, for the same reason: an adopted branch is
+        // the user's, and removing a worktree is not permission to delete it.
+        if row.branch_minted {
+            if let Err(err) = repo.delete_branch(&row.branch, false).await {
+                tracing::warn!(?err, branch = %row.branch, "remote worktree remove: branch survives");
+            }
+        } else {
+            tracing::info!(
+                branch = %row.branch,
+                "keeping an adopted branch: this worktree checked it out, it did not create it"
+            );
         }
         self.workspaces.delete(&row.id).map_err(|err| {
             tracing::warn!(?err, id, "remote worktree remove: row delete failed");
@@ -365,8 +375,8 @@ mod progress_tests {
         let projects = ProjectRepo::new(db.clone());
         let workspaces = WorkspaceRepo::new(db.clone());
         let project = projects.insert("p", "/p", "main").expect("project");
-        let a = workspaces.insert(&project.id, "a", "a", "oximux/a", "/p/a").expect("a");
-        let b = workspaces.insert(&project.id, "b", "b", "oximux/b", "/p/b").expect("b");
+        let a = workspaces.insert(&project.id, "a", "a", "oximux/a", "/p/a", true).expect("a");
+        let b = workspaces.insert(&project.id, "b", "b", "oximux/b", "/p/b", true).expect("b");
         let service = RepoWorktrees::new(projects, workspaces, "/data".into());
         (service, project.root_path, a.id, b.id)
     }

--- a/crates/worktree-ops/src/service.rs
+++ b/crates/worktree-ops/src/service.rs
@@ -127,6 +127,29 @@ impl WorktreeService for RepoWorktrees {
         if existing.iter().any(|w| w.slug == slug) {
             return Err(WorktreeError::AlreadyExists);
         }
+        // Adoption needs a local branch, and saying so HERE is what makes the
+        // refusal readable. `add_worktree_existing` enforces the same rule, but
+        // its error arrives as `CreateFailed` — i.e. `Internal("the worktree
+        // could not be created")` — which tells a user who typed
+        // `--branch origin/main` nothing. Same reasoning as the slug pre-check
+        // above: classify the common mistake so the client can act on it.
+        if let CreateBaseWire::Existing(name) = base {
+            let root = std::path::Path::new(&project.root_path);
+            let local = match Repository::open(root).await {
+                Ok(repo) => repo
+                    .sha_of(&format!("refs/heads/{name}"))
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_some(),
+                // Cannot open the repo: let the create below report the real
+                // failure rather than blaming the branch name for it.
+                Err(_) => true,
+            };
+            if !local {
+                return Err(WorktreeError::NoSuchLocalBranch);
+            }
+        }
         // Host-derived target: `<data_dir>/projects/<project_id>/worktrees/<slug>`
         // — the client never supplies a path.
         let target = worktree_path(&self.data_dir, &project.id, slug);

--- a/crates/worktree-ops/tests/workspace_merge.rs
+++ b/crates/worktree-ops/tests/workspace_merge.rs
@@ -137,6 +137,7 @@ async fn fixture(slug: &str) -> Fixture {
         slug: slug.into(),
         branch: format!("oximux/{slug}"),
         worktree_path: wt_path.to_string_lossy().into_owned(),
+        branch_minted: true,
         status: "active".into(),
         created_at: String::new(),
         archived_at: None,

--- a/crates/worktree-ops/tests/workspace_rename_rollback.rs
+++ b/crates/worktree-ops/tests/workspace_rename_rollback.rs
@@ -70,6 +70,8 @@ async fn fixture(slug: &str) -> Fixture {
             slug,
             &format!("oximux/{slug}"),
             &wt_path.to_string_lossy(),
+            // Minted: these tests are about renaming a worktree OxiMux made.
+            true,
         )
         .expect("workspace row");
 
@@ -478,6 +480,7 @@ async fn a_failure_at_the_row_step_walks_back_both_earlier_steps() {
             "fix-login",
             "oximux/already-taken",
             &new_path.to_string_lossy(),
+            true,
         )
         .expect("seed the sibling already holding the target slug");
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -327,8 +327,10 @@ Create a worktree (and its branch) under a project. The host derives the on-disk
 
 | Argument | Takes a value | Description |
 | --- | --- | --- |
-| `<SLUG>` | yes | The worktree slug (becomes branch `oximux/<slug>`) |
+| `<SLUG>` | yes | The worktree slug (becomes the branch, under the configured prefix) |
 | `--project` | yes | The project's root path (default: the current directory). Must be a project the host knows (see `projects ls`) |
+| `--from` | yes | Cut the new branch from this ref instead of the host's current checkout — a branch, a tag, or a SHA |
+| `--branch` | yes | Check out an EXISTING branch into the new worktree. No branch is created and no prefix is applied |
 
 #### `oximux worktree ls`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -329,7 +329,7 @@ Create a worktree (and its branch) under a project. The host derives the on-disk
 | --- | --- | --- |
 | `<SLUG>` | yes | The worktree slug (becomes the branch, under the configured prefix) |
 | `--project` | yes | The project's root path (default: the current directory). Must be a project the host knows (see `projects ls`) |
-| `--from` | yes | Cut the new branch from this ref instead of the host's current checkout — a branch, a tag, or a SHA |
+| `--from` | yes | Cut the new branch from this ref instead of the repository's default branch — a branch, a tag, or a SHA |
 | `--branch` | yes | Check out an EXISTING branch into the new worktree. No branch is created and no prefix is applied |
 
 #### `oximux worktree ls`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -330,7 +330,7 @@ Create a worktree (and its branch) under a project. The host derives the on-disk
 | `<SLUG>` | yes | The worktree slug (becomes the branch, under the configured prefix) |
 | `--project` | yes | The project's root path (default: the current directory). Must be a project the host knows (see `projects ls`) |
 | `--from` | yes | Cut the new branch from this ref instead of the repository's default branch — a branch, a tag, or a SHA |
-| `--branch` | yes | Check out an EXISTING branch into the new worktree. No branch is created and no prefix is applied |
+| `--branch` | yes | Check out an existing LOCAL branch into the new worktree. No branch is created and no prefix is applied |
 
 #### `oximux worktree ls`
 

--- a/docs/worktree-provisioning.md
+++ b/docs/worktree-provisioning.md
@@ -48,6 +48,30 @@ default_tabs = ["server", "logs"]
 The manual **Run setup** row in the rail's context menu is unchanged and is
 still how you re-run setup in an existing worktree.
 
+### Setup is skipped on a base you have not reviewed
+
+Provisioning runs the worktree's **own committed** `scripts.toml`, so the
+script that runs is the one on the branch you are checking out — not the one on
+your default branch. That is safe while a worktree is cut from your own
+checkout, and it stops being safe the moment you base one on somebody else's
+branch: `--from origin/pr-4711` would otherwise run a contributor's script on
+your machine, unattended, on any project with `auto_setup = true`.
+
+So when the base is **not already part of your default branch**, setup is
+skipped and the reason is shown before you commit in the dialog, and written to
+the provisioning transcript afterwards:
+
+```
+Setup skipped: `pr-4711` is not based on `main`. Review the branch, then Run setup.
+```
+
+Read the script, then use **Run setup** from the row menu — or choose **Run
+setup** in the dialog, which overrides the guard deliberately. The skip is a
+default, not a prohibition.
+
+A base that *is* an ancestor of the default branch provisions exactly as
+before, and so does an ordinary create that names no base at all.
+
 > Do not put secrets in `scripts.toml`. It is meant to be committed, the same
 > trust boundary as `commands.toml`.
 

--- a/docs/worktree-provisioning.md
+++ b/docs/worktree-provisioning.md
@@ -48,6 +48,28 @@ default_tabs = ["server", "logs"]
 The manual **Run setup** row in the rail's context menu is unchanged and is
 still how you re-run setup in an existing worktree.
 
+## Verifying a change to any of this
+
+`scripts/live-verify-worktree.sh` drives the real `oximux serve` and
+`oximux worktree` against a real git repository:
+
+```sh
+cargo build -p oximux-cli
+./scripts/live-verify-worktree.sh
+```
+
+Run it after touching `crates/git/src/worktree.rs`, `crates/worktree-ops`, or
+the CLI's worktree verbs — **before** believing a green `cargo test`.
+
+The reason it exists is that this engine is a pile of `git` subprocesses whose
+behaviour depends on the *shape* of the repository they run in, and a fixture is
+a shape somebody chose. When base refs shipped, 5761 unit tests passed over a
+worktree being cut from the wrong branch entirely: every fixture had a local
+`main`, and the field frequently does not. So the repo the script builds is
+shaped like the failure — default branch only at `origin/main`, checkout parked
+on a feature branch, a second branch to adopt — and it asserts the things that
+actually broke, including that an adopted branch survives a delete.
+
 ### An adopted branch is never deleted for you
 
 A worktree can check out a branch that already exists (`--branch <NAME>`, or

--- a/docs/worktree-provisioning.md
+++ b/docs/worktree-provisioning.md
@@ -48,6 +48,21 @@ default_tabs = ["server", "logs"]
 The manual **Run setup** row in the rail's context menu is unchanged and is
 still how you re-run setup in an existing worktree.
 
+### An adopted branch is never deleted for you
+
+A worktree can check out a branch that already exists (`--branch <NAME>`, or
+**Existing branch** in the create dialog) instead of cutting a new one. When it
+does, OxiMux records that it did not create that branch — and every path that
+later removes the worktree leaves the branch alone, including **Force Delete**.
+
+Removing a worktree is not permission to delete the branch it was sitting on.
+For a worktree whose branch OxiMux minted (`<prefix>/<slug>`, the ordinary
+case), deletion still removes the branch as it always has: that branch has no
+life outside the worktree.
+
+Worktrees created before this shipped are all treated as minted, which is what
+they are — adopting a branch did not exist yet.
+
 ### Setup is skipped on a base you have not reviewed
 
 Provisioning runs the worktree's **own committed** `scripts.toml`, so the

--- a/scripts/live-verify-worktree.sh
+++ b/scripts/live-verify-worktree.sh
@@ -136,6 +136,19 @@ B=$(echo "$OUT" | branch_of 2>/dev/null); ADOPTED_ID=$(echo "$OUT" | id_of 2>/de
 git branch --format='%(refname:short)' | grep -q '^oximux/side$' \
   && bad "a prefixed branch was minted anyway" || ok "no prefixed branch minted"
 
+# Adopt means adopt. A remote-tracking name would make git MINT a local branch,
+# and a tag would detach HEAD — either way the row would name something the
+# worktree is not on. Both must be refused, and the refusal must point at
+# `--from`, which is the verb that actually does what the user meant.
+git tag -f v-live side >/dev/null 2>&1
+for v in origin/main v-live; do
+  OUT=$("$CLI" --dir "$DIR" worktree create adopt-bad --project "$ROOT/repo" --branch "$v" 2>&1)
+  case "$OUT" in
+    *"--from"*) ok "--branch '$v' refused, and the message names --from";;
+    *)          bad "--branch '$v' was not refused with useful guidance -- $OUT";;
+  esac
+done
+
 say "4. flag-shaped and revision-shaped refs are refused before git runs"
 for v in "-B main" "--force" "main..side" "side~1" "main@{1}"; do
   if "$CLI" --dir "$DIR" worktree create probe --project "$ROOT/repo" --from "$v" >/dev/null 2>&1

--- a/scripts/live-verify-worktree.sh
+++ b/scripts/live-verify-worktree.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Drive the REAL `oximux serve` and `oximux worktree` against a REAL git repo.
+#
+#   scripts/live-verify-worktree.sh                        # target/debug/oximux-cli
+#   scripts/live-verify-worktree.sh path/to/oximux         # or a binary you name
+#
+# Exits 0 when every check passes, 1 otherwise, and prints one PASS/FAIL line
+# per check so a failure names the property that broke.
+#
+# WHY THIS EXISTS, and why the unit suite is not enough.
+#
+# The worktree engine is a pile of `git` subprocesses whose behaviour depends on
+# the SHAPE of the repository they run in — and a fixture is a repository shape
+# somebody chose. When phase 2 (base refs) shipped, 5761 unit tests passed over
+# a worktree being cut from the wrong branch entirely, because every fixture had
+# a local `main` and the field frequently does not: a worktree-centric checkout
+# routinely has its default branch only at `origin/main`, the local copy having
+# been deleted by a user who never sits on it. In that shape `git worktree add`
+# DWIMs a bare `main` into `--track -b main` and silently OVERRIDES an explicit
+# `-b`, so creation reported success while the worktree sat on the wrong branch
+# and the `workspaces` row named a branch that did not exist.
+#
+# So the repo this builds is deliberately shaped like the FAILURE, not like a
+# happy path: default branch remote-only, checkout parked on a feature branch,
+# and a second branch to adopt. Run it after touching anything under
+# `crates/git/src/worktree.rs`, `crates/worktree-ops`, or the CLI's worktree
+# verbs. It is not wired into CI (it wants a built binary and a writable temp
+# dir); it is a thing you run before you believe a green suite.
+#
+# NOT `set -o pipefail`: several checks read from commands that exit non-zero by
+# design (usage errors), and pipefail would turn a matching grep into a failure.
+set -u
+
+CLI="${1:-target/debug/oximux-cli}"
+[ -x "$CLI" ] || { echo "no CLI at $CLI — build it first: cargo build -p oximux-cli" >&2; exit 2; }
+CLI=$(cd "$(dirname "$CLI")" && pwd)/$(basename "$CLI")
+# `/usr/bin/sqlite3` explicitly: PATH may resolve to an Android SDK build whose
+# behaviour is not the system one's.
+SQLITE=/usr/bin/sqlite3
+for tool in git python3 "$SQLITE"; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "missing prerequisite: $tool" >&2; exit 2; }
+done
+
+FAILED=0
+say() { printf '\n=== %s ===\n' "$*"; }
+ok()  { printf 'PASS  %s\n' "$*"; }
+bad() { printf 'FAIL  %s\n' "$*"; FAILED=1; }
+
+ROOT=$(mktemp -d)
+SERVE_PID=""
+# SIGTERM, then a bounded wait, then SIGKILL. A plain `kill` is not enough:
+# `serve` does not always exit promptly, and the temp dir below would then be
+# removed out from under a live host. A process wedged in uninterruptible state
+# survives even the SIGKILL — that is a machine-level fault, not this script's,
+# and it clears on reboot.
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null
+    for _ in $(seq 1 20); do kill -0 "$SERVE_PID" 2>/dev/null || break; sleep 0.25; done
+    kill -9 "$SERVE_PID" 2>/dev/null
+    wait "$SERVE_PID" 2>/dev/null
+  fi
+  rm -rf "$ROOT" 2>/dev/null
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# A repository shaped like the failure case.
+# ---------------------------------------------------------------------------
+git init -q --bare "$ROOT/origin"
+git init -q "$ROOT/repo"
+cd "$ROOT/repo" || exit 2
+git config user.email live@verify.test; git config user.name Live; git config commit.gpgsign false
+echo v1 > a.txt; git add a.txt; git commit -qm init
+git branch -m main
+git remote add origin "$ROOT/origin"; git push -q origin main
+git branch side                                          # a branch to adopt
+echo v2 > b.txt; git add b.txt; git commit -qm second    # main moves past side
+git checkout -q -b wip                                   # park the checkout off-default
+echo wip > c.txt; git add c.txt; git commit -qm wip
+git branch -D main -q                                    # the local default is gone
+git remote set-head origin main
+
+say "repo state"
+echo "local branches: $(git branch --format='%(refname:short)' | tr '\n' ' ')"
+echo "HEAD: $(git branch --show-current)  (deliberately NOT the default branch)"
+
+# ---------------------------------------------------------------------------
+# The real host.
+# ---------------------------------------------------------------------------
+say "booting oximux serve"
+"$CLI" serve --data-dir "$ROOT/data" > "$ROOT/serve.out" 2> "$ROOT/serve.err" &
+SERVE_PID=$!
+for _ in $(seq 1 60); do [ -s "$ROOT/serve.out" ] && break; sleep 0.5; done
+DIR=$(python3 -c "import json;print(json.load(open('$ROOT/serve.out'))['dataDir'])" 2>/dev/null)
+[ -n "$DIR" ] || { echo "serve never became ready:"; tail -5 "$ROOT/serve.err"; exit 1; }
+echo "host up, dataDir=$DIR"
+
+# The CLI has no `projects add`, so register the project the way the desktop
+# would — straight into the host's own database.
+"$SQLITE" "$ROOT/data/oximux.db" \
+  "INSERT INTO projects (id,name,root_path,default_branch,created_at) \
+   VALUES ('p1','Live','$ROOT/repo','main','2026-01-01T00:00:00Z');" \
+  || { echo "could not seed the project row" >&2; exit 1; }
+
+wt()        { "$CLI" --dir "$DIR" --json worktree "$@"; }
+branch_of() { python3 -c "import json,sys;print(json.load(sys.stdin)['data']['branch'])"; }
+path_of()   { python3 -c "import json,sys;print(json.load(sys.stdin)['data']['path'])"; }
+id_of()     { python3 -c "import json,sys;print(json.load(sys.stdin)['data']['id'])"; }
+
+# ---------------------------------------------------------------------------
+say "1. plain create — the default branch lives only on the remote"
+OUT=$(wt create feat --project "$ROOT/repo" 2>&1)
+B=$(echo "$OUT" | branch_of 2>/dev/null)
+[ "$B" = "oximux/feat" ] && ok "branch is $B (git's DWIM did not hijack it onto 'main')" \
+                         || bad "branch is '$B', expected oximux/feat -- $OUT"
+git rev-parse --verify --quiet main >/dev/null && bad "a local 'main' was created behind our back" \
+                                                || ok "no stray local 'main'"
+git rev-parse --verify --quiet oximux/feat >/dev/null && ok "oximux/feat exists (the row does not name a phantom)" \
+                                                      || bad "oximux/feat missing — the row names a branch that was never made"
+[ "$(git rev-parse oximux/feat)" = "$(git rev-parse origin/main)" ] \
+  && ok "based on origin/main, not on the wip HEAD" \
+  || bad "based on $(git rev-parse --short oximux/feat), wanted origin/main $(git rev-parse --short origin/main)"
+[ -f "$(echo "$OUT" | path_of)/c.txt" ] && bad "wip work leaked into the worktree" || ok "no wip files in the worktree"
+
+say "2. create --from <ref>"
+OUT=$(wt create fromside --project "$ROOT/repo" --from side 2>&1)
+B=$(echo "$OUT" | branch_of 2>/dev/null)
+[ "$B" = "oximux/fromside" ] && ok "branch is $B" || bad "branch is '$B' -- $OUT"
+[ "$(git rev-parse oximux/fromside)" = "$(git rev-parse side)" ] && ok "cut from 'side' exactly" || bad "not based on side"
+
+say "3. create --branch <name> (adopt)"
+OUT=$(wt create --project "$ROOT/repo" --branch side 2>&1)
+B=$(echo "$OUT" | branch_of 2>/dev/null); ADOPTED_ID=$(echo "$OUT" | id_of 2>/dev/null)
+[ "$B" = "side" ] && ok "adopted 'side' under its own name" || bad "branch is '$B', expected side -- $OUT"
+git branch --format='%(refname:short)' | grep -q '^oximux/side$' \
+  && bad "a prefixed branch was minted anyway" || ok "no prefixed branch minted"
+
+say "4. flag-shaped and revision-shaped refs are refused before git runs"
+for v in "-B main" "--force" "main..side" "side~1" "main@{1}"; do
+  if "$CLI" --dir "$DIR" worktree create probe --project "$ROOT/repo" --from "$v" >/dev/null 2>&1
+  then bad "--from '$v' was ACCEPTED"; else ok "--from '$v' refused"; fi
+done
+
+say "5. usage rules"
+OUT=$("$CLI" --dir "$DIR" worktree create x --project "$ROOT/repo" --from main --branch side 2>&1)
+case "$OUT" in *"cannot be used with"*) ok "--from/--branch mutually exclusive";;
+                                     *) bad "mutual exclusion not enforced -- $OUT";; esac
+# A usage error must not depend on a host being up.
+OUT=$("$CLI" --dir /nonexistent worktree create 2>&1)
+case "$OUT" in *"wants a slug"*) ok "missing-slug usage error needs no reachable host";;
+                              *) bad "usage error still requires a host -- $OUT";; esac
+
+say "6. deleting an ADOPTED worktree must not delete the branch"
+SIDE_SHA=$(git rev-parse side)
+"$CLI" --dir "$DIR" worktree rm "$ADOPTED_ID" >/dev/null 2>&1
+if git rev-parse --verify --quiet side >/dev/null; then
+  ok "adopted branch 'side' survived the delete"
+  [ "$(git rev-parse side)" = "$SIDE_SHA" ] && ok "and still points where it did" || bad "'side' moved"
+else
+  bad "DATA LOSS: the adopted branch was deleted"
+fi
+
+say "7. deleting a MINTED worktree must still clean its branch up"
+MINTED_ID=$(wt ls 2>/dev/null | python3 -c "
+import json,sys
+print(next(r['id'] for r in json.load(sys.stdin)['data'] if r['branch']=='oximux/fromside'))" 2>/dev/null)
+"$CLI" --dir "$DIR" worktree rm "$MINTED_ID" >/dev/null 2>&1
+git rev-parse --verify --quiet oximux/fromside >/dev/null \
+  && bad "a minted branch leaked — cleanup regressed" || ok "minted branch cleaned up"
+
+say "RESULT"
+[ "$FAILED" = 0 ] && echo "ALL LIVE CHECKS PASSED" || echo "SOME LIVE CHECKS FAILED"
+exit $FAILED


### PR DESCRIPTION
Closes phase 2 of the worktree feature enhancement plan.

## The defect

`add_worktree` was `git worktree add -b <branch> <path>` with **no start-point**, so every worktree branched off whatever the main checkout's HEAD happened to be. Create one while sitting on a half-finished feature branch and the new work was silently based on it — you found out at review time.

## What creation takes now

```rust
enum CreateBase {
    NewBranch { branch: String, from: Option<String> },  // None = the default branch
    ExistingBranch { name: String },                     // adopt, no prefix
}
```

An enum rather than two `Option`s because "adopt a branch and also cut a new one" is not a state a caller should be able to build — and because rollback has to tell the two apart: it force-deletes the branch, which is right for one minted a moment ago and a week of somebody's work for one merely adopted.

`from: None` means **the repository's default branch**, resolved with git at create time. It used to mean HEAD. Every unattended caller — the RPC, a team run, the chat pill — wanted the default branch and none of them wanted whatever the user was sitting on, so this fixes those paths too and lets callers stop threading `default_branch` by hand.

## Surfaces

- **Dialog**: a **From** control defaulting to the project's default branch, a `New branch` / `Existing branch` segmented mode, and the setup-skip notice shown *before* you commit.
- **CLI**: `--from <REF>` and `--branch <NAME>`, mutually exclusive. The usage check runs before the socket, so a missing argument no longer reports "the host is not reachable".
- **Wire**: `PROTOCOL_VERSION` 24 with a new `Request::CreateWorktreeV2` carrying `CreateBaseWire`. Ordinal 43 keeps its payload byte-for-byte and stays served; the client sends V2 only when the base needs it, so a plain `worktree create` still works against a v16–v23 host. A base ref requires a **local operator** — a paired device may still name only a project and a slug.

## The setup-script guard

Provisioning runs the worktree's **own committed** `.oximux/scripts.toml`, which is safe only while every worktree branches off your own HEAD — the invariant this removes. Basing a worktree on a fetched contributor branch would otherwise run their script as you, unattended, on any project with `auto_setup = true`.

So a base not already contained in the default branch skips the script and says why. The guard **fails closed**: a base we cannot verify is skipped too. The asymmetry decides it — failing closed costs one click on `Run setup`, failing open runs an unreviewed script as the user.

## Two things git does that the argv does not reveal

Both found by post-implementation review, both reproduced against real `git` 2.55:

1. **`worktree add -b <new> -- <path> <start>` DWIMs a start point that names no local branch but exactly one remote-tracking branch into `--track -b <that name>` — and that overrides the explicit `-b`.** On a checkout whose local `main` was deleted (ordinary for worktree-centric users), this landed the worktree on `main`, never created `oximux/<slug>`, and reported success — leaving the row naming a branch that did not exist. Start points now resolve to a SHA first, which removes the ambiguity the DWIM keys on.
2. **Handed a tag or a remote-only name, `worktree add <path> <name>` detaches HEAD or mints a local branch.** "Adopt" now requires `refs/heads/<name>`.

`default_branch()` also no longer reports the name behind `origin/HEAD` without checking it resolves locally — that was the enabling condition for the first.

## An adopted branch is never deleted for you

Create-time rollback already refused to force-delete an adopted branch. Deleting the *workspace* went through a different door and ran `git branch -D` unconditionally. `branch_minted` is now persisted (migration **V029**, `DEFAULT 1`) and both removal paths gate on it.

`DEFAULT 1` is the correct reading of history, not a convenience: adopting a branch ships in this same release, so every worktree predating the column was necessarily minted by OxiMux. Defaulting to 0 would have silently stopped cleaning up branches OxiMux made, leaking one per delete.

## Verification

- `cargo test --workspace` green; `RUSTFLAGS=-D warnings cargo clippy --workspace --all-targets` clean.
- Real-`git`-in-a-tempdir integration tests throughout, including the DWIM regression, the adopt-refusals, both arms of the setup guard, and the minted-vs-adopted record.
- A pre-V029 workspace row is proven to upgrade as **minted**, with a guard against the test going vacuous.
- The wire-skew suite was run for real against the **v0.1.21 (v23) release** and mutation-checked: remove the version gate and that host answers `undecodable request frame` and the test fails. Note CI does not set `OXIMUX_SKEW_CLI`, so there the append-only claim rests on the ordinal pins.
- **Driven live end-to-end** against a real `oximux serve` + CLI, on a repo shaped like the failure case (default branch existing only as `origin/main`, checkout parked on a feature branch): 17/17 checks pass — the plain create lands on `oximux/feat` based on `origin/main` with no wip files and no stray local `main`; `--from` and `--branch` behave; four flag-shaped refs refused; the adopted branch survives a delete while a minted one is still cleaned up.

That live run earned its place: it caught a defect **5761 unit tests passed over**. My fix for review finding M9 had made `default_branch()` return `None` when the default has no local ref, which threw away the usable `origin/main` and degraded the base all the way to the current checkout — reintroducing the exact defect this PR closes. Every unit test had a local `main`, so only real binaries on a realistic repo exposed it. Fixed in 12846de, with a regression test pinning the remote-only shape.

## Review

13 findings from a post-implementation review (1 Critical, 4 High, 6 Medium, 2 Low); every one reproduced before being acted on. 12 fixed, 1 accepted and recorded (the CI skew gap). Details in the phase file's Code Review Round.

https://claude.ai/code/session_01PQNc3BwQ9tEbp7jhcyKsuU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create worktrees from a branch, tag, commit, or existing branch using the CLI or desktop dialog.
  * CLI worktree creation now supports `--from` and `--branch` options.
  * Desktop project setup detects each repository’s default branch automatically.
  * Existing branches are preserved when their worktrees are removed.
  * Setup scripts are skipped for unreviewed base revisions, with an explanation and an option to run setup.
* **Bug Fixes**
  * New worktrees consistently start from the project’s default branch instead of the current checkout.
  * Improved handling of remote-only default branches and rapid folder selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->