### PR TITLE
feat(worktree): put desktop worktrees under a configurable, browsable root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8394,6 +8394,7 @@ name = "oximux-worktree-ops"
 version = "0.1.21"
 dependencies = [
  "async-trait",
+ "dunce",
  "ignore",
  "oximux-core",
  "oximux-git",

--- a/apps/desktop/src/shell/agent_chat/computer_use.rs
+++ b/apps/desktop/src/shell/agent_chat/computer_use.rs
@@ -450,9 +450,10 @@ fn plan(
 ///
 /// Two questions, cheapest first. The settings answer covers an opted-in root
 /// and everything beneath it, which is every chat that sits inside the project.
-/// It cannot cover a worktree: OxiMux creates those *beside* the project
-/// (`suggest_worktree_path` → `<parent>/oximux-wt-…`), so no containment rule
-/// reaches one. Resolving the worktree back to the repository that owns it is
+/// It cannot cover a worktree: OxiMux creates those *outside* the project
+/// (under the configured worktree root, `~/OxiMux/worktrees/<project>/<slug>`
+/// by default), so no containment rule reaches one. Resolving the worktree
+/// back to the repository that owns it is
 /// what makes "verify the build you just made" work in the isolation this
 /// feature exists for, rather than that being the one workflow it silently
 /// refuses.
@@ -1343,9 +1344,9 @@ mod enablement_tests {
         );
     }
 
-    /// A committed repo plus a linked worktree beside it — the shape
-    /// `suggest_worktree_path` produces, where the worktree is a *sibling* of
-    /// the project rather than a child.
+    /// A committed repo plus a linked worktree beside it — a worktree that is
+    /// not a child of the project, which is the shape every OxiMux-created
+    /// worktree has.
     fn repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("project");

--- a/apps/desktop/src/shell/settings_modal/layout.rs
+++ b/apps/desktop/src/shell/settings_modal/layout.rs
@@ -100,6 +100,13 @@ pub(super) struct SettingEntry {
     /// Render the control full-width *beneath* the label rather than pinned
     /// right. See [`entry_stacked`] for when a row needs it.
     pub stacked: bool,
+    /// A line under a stacked control — a format rule, a live verdict. Placed
+    /// by [`stacked_row`] as its own full-width child, never nested inside
+    /// the control: a wrapping hint inside a control's own flex column is
+    /// measured against that column's indefinite width, reports a height for
+    /// the wrong number of lines, and pushes every row after it off the card.
+    /// See [`entry_stacked_hinted`].
+    pub hint: Option<AnyElement>,
 }
 
 /// Build a [`SettingEntry`] from a label, description, and control element.
@@ -113,6 +120,7 @@ pub(super) fn entry(
         description: description.into(),
         control: control.into_any_element(),
         stacked: false,
+        hint: None,
     }
 }
 
@@ -131,6 +139,18 @@ pub(super) fn entry_stacked(
     control: impl IntoElement,
 ) -> SettingEntry {
     SettingEntry { stacked: true, ..entry(label, description, control) }
+}
+
+/// [`entry_stacked`] with a line beneath the control — the entry form of
+/// [`setting_row_action_hint`]'s hint slot, for a pane whose rows are
+/// [`SettingEntry`]s so search can list them.
+pub(super) fn entry_stacked_hinted(
+    label: impl Into<SharedString>,
+    description: impl Into<SharedString>,
+    control: impl IntoElement,
+    hint: impl IntoElement,
+) -> SettingEntry {
+    SettingEntry { hint: Some(hint.into_any_element()), ..entry_stacked(label, description, control) }
 }
 
 /// Case-insensitive substring match of `query` against a row's label or
@@ -160,7 +180,7 @@ pub(super) fn entries_card(
         .into_iter()
         .map(|e| {
             if e.stacked {
-                setting_row_stack(e.label, e.description, e.control, theme, typography)
+                stacked_row(e.label, e.description, None, e.control, e.hint, theme, typography)
             } else {
                 setting_row_desc(e.label, e.description, e.control, theme, typography)
             }

--- a/apps/desktop/src/shell/settings_modal/mod.rs
+++ b/apps/desktop/src/shell/settings_modal/mod.rs
@@ -106,6 +106,18 @@ pub struct SettingsModal {
     /// The custom prefix as it was at `open()`, so close can tell an
     /// uncommitted edit from no edit at all.
     pub(super) git_prefix_seed: String,
+    /// The worktree-directory field, lazily built on `open()`.
+    pub(super) git_dir_input: Option<Entity<InputState>>,
+    /// Live while the field exists.
+    pub(super) _git_dir_sub: Option<Subscription>,
+    /// The directory text as last committed (empty for the default), so close
+    /// can tell an uncommitted edit from none.
+    pub(super) git_dir_seed: String,
+    /// Why the directory field's current text is refused, rendered under it.
+    /// `None` while the text is acceptable. Set on every keystroke by the
+    /// same validator the create path runs, so the reason arrives while the
+    /// user is looking at the field — and a refused text is never written.
+    pub(super) git_dir_notice: Option<String>,
     /// Working copy of the rate-limit retry settings.
     pub(crate) retry: oximux_settings::agent_retry::AgentRetrySettings,
     /// Working copy of the per-agent launch defaults; reseeded from the live
@@ -349,6 +361,10 @@ impl SettingsModal {
             git_prefix_input: None,
             git_prefix_seed: String::new(),
             _git_prefix_sub: None,
+            git_dir_input: None,
+            _git_dir_sub: None,
+            git_dir_seed: String::new(),
+            git_dir_notice: None,
             retry: oximux_settings::agent_retry::AgentRetrySettings::shipped(),
             agent_launch: AgentLaunchSettings::default(),
             dictation: DictationSettings::default(),
@@ -545,6 +561,34 @@ impl SettingsModal {
             },
         ));
         self.git_prefix_input = Some(prefix_input);
+
+        // Worktree directory. Validated on every keystroke — the notice under
+        // the field is the fast feedback path — and written only on blur/Enter
+        // and only when it passes. A refused directory stays in the field
+        // with its reason and never reaches `git.toml`: the create path
+        // re-validates anyway, but a setting that fails every create is worse
+        // than one the pane declined to save.
+        let dir_seed = self.git.worktree_dir.clone().unwrap_or_default();
+        self.git_dir_seed = dir_seed.clone();
+        self.git_dir_notice = pane_git::refusal(&dir_seed, false);
+        let dir_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(pane_git::default_root_placeholder())
+                .default_value(dir_seed)
+        });
+        self._git_dir_sub = Some(cx.subscribe(
+            &dir_input,
+            |this, input, ev: &InputEvent, cx| match ev {
+                InputEvent::Change => {
+                    let text = input.read(cx).value().to_string();
+                    this.git_dir_notice = pane_git::refusal(&text, false);
+                    cx.notify();
+                }
+                InputEvent::Blur | InputEvent::PressEnter { .. } => this.commit_git_dir(cx),
+                _ => {}
+            },
+        ));
+        self.git_dir_input = Some(dir_input);
 
         // Agents pane's environment editor. Reset the selection first: a reopen
         // must not land on a profile deleted since, which would silently edit
@@ -769,6 +813,14 @@ impl SettingsModal {
         }
         self.git_prefix_input = None;
         self._git_prefix_sub = None;
+        // Same flush for the directory field. `commit_git_dir` refuses an
+        // invalid text itself, so closing on one drops the edit rather than
+        // saving it.
+        if self.git_dir_input.is_some() && self.git_dir_text(cx) != self.git_dir_seed {
+            self.commit_git_dir(cx);
+        }
+        self.git_dir_input = None;
+        self._git_dir_sub = None;
         // Same flush-before-drop hazard as custom words: the working copy is
         // synced on every keystroke, but only blur/Enter writes the file, and
         // clicking dead space doesn't blur a gpui input. Without this, typing an
@@ -843,6 +895,52 @@ impl SettingsModal {
             tracing::warn!(%err, "settings modal: failed to write git.toml");
         }
         cx.notify();
+    }
+
+    /// The directory field's current text, trimmed; empty when the field is
+    /// not built.
+    pub(super) fn git_dir_text(&self, cx: &Context<Self>) -> String {
+        self.git_dir_input
+            .as_ref()
+            .map(|i| i.read(cx).value().trim().to_string())
+            .unwrap_or_default()
+    }
+
+    /// Commit the directory field: validate, and write `git.toml` only when
+    /// it passes. An empty field means the default root. A refused text
+    /// leaves the saved value alone and keeps its reason under the field.
+    pub(super) fn commit_git_dir(&mut self, cx: &mut Context<Self>) {
+        let text = self.git_dir_text(cx);
+        self.git_dir_notice = pane_git::refusal(&text, true);
+        if self.git_dir_notice.is_some() {
+            cx.notify();
+            return;
+        }
+        self.git.worktree_dir = (!text.is_empty()).then(|| text.clone());
+        self.git_dir_seed = text;
+        self.persist_git(cx);
+    }
+
+    /// Open a native folder picker and drop the chosen path into the
+    /// directory field, then commit it. Same shape as the schedule pane's
+    /// Browse: the panel resolves outside the GPUI window, so the result is
+    /// applied back on the UI thread via `update_in`.
+    pub(super) fn browse_git_dir(&mut self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            let folder = rfd::AsyncFileDialog::new().pick_folder().await;
+            let Some(path) = folder.map(|h| h.path().to_path_buf()) else {
+                return;
+            };
+            let _ = this.update_in(cx, |this, window, cx| {
+                if let Some(input) = this.git_dir_input.clone() {
+                    input.update(cx, |s, cx| {
+                        s.set_value(path.to_string_lossy().to_string(), window, cx)
+                    });
+                    this.commit_git_dir(cx);
+                }
+            });
+        })
+        .detach();
     }
 
     /// Persist the AI working copy to `commit_message_ai.toml`.

--- a/apps/desktop/src/shell/settings_modal/pane_git.rs
+++ b/apps/desktop/src/shell/settings_modal/pane_git.rs
@@ -8,12 +8,15 @@
 
 use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px};
 use gpui_component::{Sizable as _, input::Input};
-use oximux_settings::{Density, Theme, Typography, git::BranchPrefixMode};
+use oximux_settings::{Density, Theme, Typography, git::BranchPrefixMode, git::GitSettings};
 
 use super::SettingsModal;
-use super::controls::toggle_switch;
-use super::layout::{SettingEntry, entries_card, entry, entry_stacked, hint_text};
+use super::controls::{toggle_switch, value_chip};
+use super::layout::{
+    SettingEntry, entries_card, entry, entry_stacked, entry_stacked_hinted, hint_text, notice_text,
+};
 use super::segmented::{Segment, segmented};
+use crate::shell::workspace::configured_locator::{ConfiguredLocator, DEFAULT_ROOT_UNDER_HOME};
 
 /// Render the Git pane: the settings rows plus a quiet save-location caption.
 pub(super) fn render(
@@ -39,7 +42,7 @@ pub(super) fn render(
                 .text_color(theme.fg_subtle)
                 .child(
                     "Changes save to git.toml and apply to the next worktree you create. \
-                     Existing branches are never renamed.",
+                     Existing branches are never renamed and existing worktrees are never moved.",
                 ),
         )
         .into_any_element()
@@ -115,23 +118,66 @@ pub(super) fn entries(
         hint_text(preview, theme, typography),
     ));
 
-    // Phase 6 owns the seam this field writes to. Rendered disabled rather
-    // than hidden: a pane that grows a field later reads as less finished than
-    // one that shows what is coming, and the note says why it does nothing.
-    rows.push(entry(
-        "Worktree directory",
-        "Where new worktrees are created. Not configurable yet — worktrees go in \
-         OxiMux's own data directory.",
-        hint_text(
-            modal
-                .git
-                .worktree_dir
-                .clone()
-                .unwrap_or_else(|| "OxiMux data directory".to_string()),
-            theme,
-            typography,
-        ),
-    ));
+    // The directory field, with Browse beside it and one line under it: the
+    // refusal reason while the text is unacceptable, otherwise where the next
+    // worktree will land. Validated by the same function the create path
+    // runs, so a directory the pane accepts is one a create will accept.
+    //
+    // The line under the field goes through the entry's hint slot, NOT into
+    // a flex column of our own around the field: nested that way, the
+    // wrapping hint measured against an indefinite width and pushed the
+    // keep-default toggle and the card's caption clean off the pane. The
+    // field row itself is the schedules pane's working-directory shape.
+    //
+    // And that line is ONE line, truncated, not a wrapping paragraph: it
+    // carries a filesystem path, which has no break opportunities, and a
+    // long unbreakable token in a wrapping hint made every row after it —
+    // the keep-default toggle, the card's caption — disappear from the pane
+    // while the hint itself painted fine. Found live; the test text system
+    // does not reproduce it. A single ellipsized line inside its own flex
+    // row is the shape the codebase already knows works for nowrap text.
+    if let Some(state) = modal.git_dir_input.as_ref() {
+        let under = match &modal.git_dir_notice {
+            Some(reason) => notice_text(false, reason.clone(), theme, typography),
+            None => hint_text(landing_hint(&modal.git_dir_text(cx)), theme, typography),
+        };
+        let under = div()
+            .flex()
+            .flex_row()
+            .w_full()
+            .min_w_0()
+            .child(div().min_w_0().truncate().child(under));
+        let field_row = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .w_full()
+            .gap(px(8.0))
+            .child(
+                div().flex_1().child(
+                    Input::new(state)
+                        .small()
+                        .text_size(px(typography.t_body_sm))
+                        .into_any_element(),
+                ),
+            )
+            .child(value_chip(
+                "git-dir-browse",
+                "Browse…",
+                theme,
+                density,
+                typography,
+                |this: &mut SettingsModal, _w, cx| this.browse_git_dir(cx),
+                cx,
+            ));
+        rows.push(entry_stacked_hinted(
+            "Worktree directory",
+            "Where new worktrees are created, as <directory>/<project>/<slug>. \
+             Leave empty for the default. Existing worktrees stay where they are.",
+            field_row,
+            under,
+        ));
+    }
 
     let keep_fresh = toggle_switch(
         "git-keep-default-fresh",
@@ -151,4 +197,49 @@ pub(super) fn entries(
     ));
 
     rows
+}
+
+/// The placeholder for an empty directory field: the default root, spelled
+/// the way a user would type it.
+pub(super) fn default_root_placeholder() -> String {
+    format!("~/{DEFAULT_ROOT_UNDER_HOME}")
+}
+
+/// Why `text` is refused as a worktree directory, or `None` when it would be
+/// accepted. Empty text is the default root, which is validated too — a home
+/// that is itself a git repository is refused here as it would be at create.
+///
+/// Runs what the create path runs, through the configured locator's own
+/// root resolution, so the pane and the create cannot disagree about a
+/// directory. `commit` selects the full check with the write probe; the
+/// per-keystroke caller passes `false` and gets the shape rules only, which
+/// read the disk and write nothing.
+pub(super) fn refusal(text: &str, commit: bool) -> Option<String> {
+    let settings = GitSettings {
+        worktree_dir: (!text.trim().is_empty()).then(|| text.to_string()),
+        ..GitSettings::shipped()
+    };
+    let home = dirs::home_dir();
+    let root = ConfiguredLocator::root_from(&settings, home.as_deref());
+    let locator = ConfiguredLocator::new(root, crate::app_paths::data_dir(), Vec::new());
+    let verdict = if commit { locator.validated_root() } else { locator.root_shape() };
+    verdict.err().map(|err| err.to_string())
+}
+
+/// Where the next worktree will land for the accepted `text`, with the home
+/// directory spelled `~` — the way the placeholder spells it, and short enough
+/// to read at a glance.
+fn landing_hint(text: &str) -> String {
+    let settings = GitSettings {
+        worktree_dir: (!text.trim().is_empty()).then(|| text.to_string()),
+        ..GitSettings::shipped()
+    };
+    let home = dirs::home_dir();
+    let root = ConfiguredLocator::root_from(&settings, home.as_deref())
+        .map(|r| match home.as_deref().and_then(|h| r.strip_prefix(h).ok()) {
+            Some(rest) => format!("~/{}", rest.display()),
+            None => r.display().to_string(),
+        })
+        .unwrap_or_else(default_root_placeholder);
+    format!("New worktrees go to {root}/<project>/<slug>.")
 }

--- a/apps/desktop/src/shell/workspace/configured_locator.rs
+++ b/apps/desktop/src/shell/workspace/configured_locator.rs
@@ -1,0 +1,277 @@
+//! The desktop's worktree locator: a configured, browsable root.
+//!
+//! Rail-created worktrees used to live at
+//! `<data_dir>/projects/<uuid>/worktrees/<slug>` — inside Application Support,
+//! under an opaque project id, findable by nothing. Chat-created ones lived
+//! somewhere else again, as a sibling `oximux-wt-<slug>` beside the repo. Both
+//! now resolve through this one locator, under a root the user can see and
+//! change: `~/OxiMux/worktrees/<project>/<slug>` by default.
+//!
+//! **Existing rows are not moved.** The row stores its own `worktree_path`, so
+//! a worktree created under the old scheme keeps working at its old location
+//! forever; the setting affects only the next create.
+//!
+//! The RPC surface does not use this. `oximux serve` and the desktop's own
+//! remote service keep the host-derived scheme through
+//! [`oximux_worktree_ops::HostDerivedLocator`], which they construct themselves.
+
+use std::path::{Path, PathBuf};
+
+use gpui::App;
+use oximux_core::Project;
+use oximux_settings::git::GitSettings;
+use oximux_storage::ProjectRepo;
+use oximux_worktree_ops::{
+    LocateError, WorktreeLocator, project_dir_name, validate_worktree_root,
+    validate_worktree_root_shape,
+};
+
+/// The default root, beneath the home directory.
+pub const DEFAULT_ROOT_UNDER_HOME: &str = "OxiMux/worktrees";
+
+/// Where the desktop puts a new worktree: `<root>/<project>/<slug>`.
+#[derive(Debug, Clone)]
+pub struct ConfiguredLocator {
+    /// The configured or default root, or `None` when neither exists (no home
+    /// directory and nothing configured).
+    root: Option<PathBuf>,
+    /// The app data directory, which the root must not be inside.
+    data_dir: Option<PathBuf>,
+    /// Every project this host knows, so two repositories with one name get
+    /// two directories. See [`project_dir_name`].
+    projects: Vec<Project>,
+}
+
+impl ConfiguredLocator {
+    pub fn new(root: Option<PathBuf>, data_dir: Option<PathBuf>, projects: Vec<Project>) -> Self {
+        Self { root, data_dir, projects }
+    }
+
+    /// The root `settings` names: `worktree_dir` with a leading `~` expanded,
+    /// or [`DEFAULT_ROOT_UNDER_HOME`] when it is unset or blank.
+    ///
+    /// `~` is honoured because `git.toml` is meant to be hand-edited and
+    /// version-controlled, and a path with a home directory spelled out is
+    /// not portable between two machines the same file lives on.
+    pub fn root_from(settings: &GitSettings, home: Option<&Path>) -> Option<PathBuf> {
+        match settings.worktree_dir.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(configured) => Some(expand_home(configured, home)),
+            None => home.map(|h| h.join(DEFAULT_ROOT_UNDER_HOME)),
+        }
+    }
+
+    /// The root this locator resolves under, as configured and before
+    /// validation.
+    pub fn root(&self) -> Option<&Path> {
+        self.root.as_deref()
+    }
+
+    /// The validated root, or why it was refused. What every
+    /// [`locate`](Self::locate) starts from, and what the settings pane runs
+    /// when the field is committed.
+    pub fn validated_root(&self) -> Result<PathBuf, LocateError> {
+        let root = self.root.as_deref().ok_or(LocateError::NoRoot)?;
+        validate_worktree_root(root, self.data_dir.as_deref())
+    }
+
+    /// [`validated_root`](Self::validated_root) without the write probe —
+    /// the per-keystroke form for the settings field, which must not create
+    /// a file in the user's home directory on every character typed.
+    pub fn root_shape(&self) -> Result<PathBuf, LocateError> {
+        let root = self.root.as_deref().ok_or(LocateError::NoRoot)?;
+        validate_worktree_root_shape(root, self.data_dir.as_deref())
+    }
+
+    /// The directory a project's worktrees share: `<root>/<project dir name>`.
+    pub fn project_dir(&self, project: &Project) -> Result<PathBuf, LocateError> {
+        Ok(self.validated_root()?.join(project_dir_name(project, &self.projects)))
+    }
+}
+
+impl WorktreeLocator for ConfiguredLocator {
+    /// Validated on every call, not only when the pane saved it — a
+    /// hand-edited `git.toml`, or a repository that appeared under the root
+    /// since, is caught here rather than producing a nested worktree.
+    fn locate(&self, project: &Project, slug: &str) -> Result<PathBuf, LocateError> {
+        Ok(self.project_dir(project)?.join(slug))
+    }
+}
+
+/// `~` and `~/rest` against `home`; anything else as written. With no home
+/// directory a `~` path is left as written and the writability check refuses
+/// it with a reason, which beats silently creating a directory named `~`.
+fn expand_home(configured: &str, home: Option<&Path>) -> PathBuf {
+    match (configured.strip_prefix('~'), home) {
+        (Some(""), Some(home)) => home.to_path_buf(),
+        (Some(rest), Some(home)) if rest.starts_with(['/', '\\']) => home.join(&rest[1..]),
+        _ => PathBuf::from(configured),
+    }
+}
+
+/// The desktop's locator, built from the saved git settings, the app data
+/// directory, the home directory, and the project list.
+///
+/// Built fresh per create rather than held as a global: it snapshots the
+/// project list for name disambiguation, and a global would go stale the
+/// moment a project was added.
+pub fn desktop_locator(project_repo: &ProjectRepo, cx: &App) -> ConfiguredLocator {
+    let settings = crate::git_settings::settings(cx);
+    let home = dirs::home_dir();
+    let root = ConfiguredLocator::root_from(&settings, home.as_deref());
+    let projects = project_repo.list_ordered(usize::MAX).unwrap_or_else(|err| {
+        // Without the list, two same-named projects could share a directory.
+        // Locating still works; it just cannot disambiguate. Logged because
+        // it is a storage failure, not a normal state.
+        tracing::warn!(?err, "worktree locator: project list unavailable");
+        Vec::new()
+    });
+    ConfiguredLocator::new(root, crate::app_paths::data_dir(), projects)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(id: &str, name: &str, root: &Path) -> Project {
+        Project {
+            id: id.to_string(),
+            name: name.to_string(),
+            root_path: root.to_string_lossy().into_owned(),
+            default_branch: "main".to_string(),
+            created_at: String::new(),
+            last_opened_at: None,
+            sort_order: 0.0,
+        }
+    }
+
+    fn with_dir(dir: Option<&str>) -> GitSettings {
+        GitSettings { worktree_dir: dir.map(str::to_string), ..GitSettings::shipped() }
+    }
+
+    #[test]
+    fn the_default_root_is_under_the_home_directory() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(None), Some(home)),
+            Some(PathBuf::from("/home/u/OxiMux/worktrees"))
+        );
+        // Blank means unset — a user who cleared the field gets the default,
+        // not a worktree at the current directory.
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(Some("   ")), Some(home)),
+            Some(PathBuf::from("/home/u/OxiMux/worktrees"))
+        );
+    }
+
+    #[test]
+    fn a_configured_root_is_used_as_written_with_tilde_expanded() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(Some("/srv/wt")), Some(home)),
+            Some(PathBuf::from("/srv/wt"))
+        );
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(Some("~/wt")), Some(home)),
+            Some(PathBuf::from("/home/u/wt"))
+        );
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(Some("~")), Some(home)),
+            Some(PathBuf::from("/home/u"))
+        );
+        // `~user` is not ours to expand.
+        assert_eq!(
+            ConfiguredLocator::root_from(&with_dir(Some("~bob/wt")), Some(home)),
+            Some(PathBuf::from("~bob/wt"))
+        );
+    }
+
+    #[test]
+    fn no_home_and_no_setting_means_no_root() {
+        assert_eq!(ConfiguredLocator::root_from(&with_dir(None), None), None);
+        let locator = ConfiguredLocator::new(None, None, Vec::new());
+        let p = project("p1", "api", Path::new("/repos/api"));
+        assert_eq!(locator.locate(&p, "feat"), Err(LocateError::NoRoot));
+    }
+
+    /// The layout the whole phase is for: readable, browsable, per project.
+    #[test]
+    fn locate_lays_out_root_project_slug() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("worktrees");
+        let p = project("p1", "API Service", Path::new("/repos/api"));
+        let locator = ConfiguredLocator::new(Some(root.clone()), None, vec![p.clone()]);
+        assert_eq!(
+            locator.locate(&p, "fix-login").expect("locate"),
+            oximux_worktree_ops::canonicalize_lenient(&root)
+                .join("api-service")
+                .join("fix-login")
+        );
+    }
+
+    #[test]
+    fn two_projects_with_one_name_get_two_directories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = project("aaaa1111-x", "api", Path::new("/work/api"));
+        let b = project("bbbb2222-y", "api", Path::new("/oss/api"));
+        let locator = ConfiguredLocator::new(
+            Some(tmp.path().to_path_buf()),
+            None,
+            vec![a.clone(), b.clone()],
+        );
+        let pa = locator.locate(&a, "feat").expect("a");
+        let pb = locator.locate(&b, "feat").expect("b");
+        assert_ne!(pa, pb);
+        assert!(pa.parent().unwrap().ends_with("api-aaaa1111"), "{}", pa.display());
+    }
+
+    /// Validation is in `locate`, not only in the pane: a hand-edited
+    /// `git.toml` pointing into a repository is refused at create time with
+    /// the reason, never silently redirected.
+    #[test]
+    fn locate_refuses_a_root_inside_a_repository_every_time() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".git")).expect("fake repo");
+        let p = project("p1", "api", Path::new("/repos/api"));
+        let locator =
+            ConfiguredLocator::new(Some(tmp.path().join("wt")), None, vec![p.clone()]);
+        assert!(matches!(
+            locator.locate(&p, "feat"),
+            Err(LocateError::InsideRepository { .. })
+        ));
+    }
+
+    /// A root inside the data directory is the location this setting exists
+    /// to leave, and is refused as such.
+    #[test]
+    fn locate_refuses_a_root_inside_the_data_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).expect("mkdir");
+        let p = project("p1", "api", Path::new("/repos/api"));
+        let locator = ConfiguredLocator::new(
+            Some(data_dir.join("worktrees")),
+            Some(data_dir),
+            vec![p.clone()],
+        );
+        assert!(matches!(locator.locate(&p, "feat"), Err(LocateError::InsideDataDir { .. })));
+    }
+
+    /// The narrowed reclaim rule, on the configured locator: the minted path
+    /// and nothing else — not a directory of the user's own under the same
+    /// root, not another slug's.
+    #[test]
+    fn may_reclaim_recognises_only_its_own_minted_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let p = project("p1", "api", Path::new("/repos/api"));
+        let locator =
+            ConfiguredLocator::new(Some(tmp.path().to_path_buf()), None, vec![p.clone()]);
+        let minted = locator.locate(&p, "feat").expect("locate");
+        std::fs::create_dir_all(&minted).expect("mkdir");
+        let users_own = tmp.path().join("api").join("my-notes");
+        std::fs::create_dir_all(&users_own).expect("mkdir");
+
+        assert!(locator.may_reclaim(&p, "feat", &minted));
+        assert!(!locator.may_reclaim(&p, "feat", &users_own));
+        assert!(!locator.may_reclaim(&p, "my-notes", &minted));
+    }
+}

--- a/apps/desktop/src/shell/workspace/mod.rs
+++ b/apps/desktop/src/shell/workspace/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod add_project_dialog;
 pub mod base_choice;
+pub mod configured_locator;
 pub mod merge_notices;
 pub mod merge_ops;
 pub mod project_picker;

--- a/apps/desktop/src/shell/workspace/rename_ops.rs
+++ b/apps/desktop/src/shell/workspace/rename_ops.rs
@@ -129,11 +129,12 @@ fn slug_degradation(name: &str, slug: &str, current_branch: &str) -> Option<Stri
 /// Where a renamed worktree's directory should go.
 ///
 /// Keeps the directory's existing naming SHAPE rather than replacing the whole
-/// final component with the new slug: the two creation paths in the app name
-/// their directories differently (`<slug>` under the data dir, `oximux-wt-<slug>`
-/// beside the repo), and a rename should not silently re-shape one into the
-/// other. Only the slug inside the name is swapped; a directory whose name does
-/// not contain the old slug falls back to the plain new slug.
+/// final component with the new slug: rows created before the configured
+/// worktree root existed name their directories differently (`<slug>` under
+/// the data dir, `oximux-wt-<slug>` beside the repo), and a rename should not
+/// silently re-shape one into another. Only the slug inside the name is
+/// swapped; a directory whose name does not contain the old slug falls back to
+/// the plain new slug.
 fn renamed_worktree_dir(old_path: &Path, old_slug: &str, new_slug: &str) -> PathBuf {
     let parent = old_path.parent().map(Path::to_path_buf).unwrap_or_default();
     let current = old_path

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -146,8 +146,9 @@ pub(crate) fn build_add_project_dialog(
 // because this module is the desktop's door to it.
 use crate::shell::workspace::base_choice::BaseChoice;
 pub use oximux_worktree_ops::{
-    CreateBase, CreateOutcome, Provision, ProvisionEvent, SetupTranscript,
-    create_workspace_with_rollback, run_cleanup_before_remove,
+    CreateBase, CreateOutcome, HostDerivedLocator, LocateError, Provision, ProvisionEvent,
+    SetupTranscript, WorktreeLocator, create_workspace_with_rollback, provisioning_marker,
+    run_cleanup_before_remove,
 };
 
 /// Upper bound on `default_tabs`. The list is repo-controlled and needs no
@@ -528,21 +529,6 @@ pub(crate) fn refocus_active_pane(
     window.defer(cx, move |window, app| {
         panes.update(app, |p, cx| p.focus_active(window, cx));
     });
-}
-
-/// Compose the worktree dir path under the desktop's own data root.
-/// Returns `None` when the app data directory is unavailable (sandbox or
-/// unset `$HOME`) — caller surfaces this as a create failure.
-///
-/// The derivation itself is shared with `oximux serve`, which supplies its
-/// own `--data-dir` instead; this wrapper is only the desktop's answer to
-/// "which root?".
-pub(crate) fn worktree_path(project_id: &str, slug: &str) -> Option<PathBuf> {
-    Some(oximux_worktree_ops::worktree_path(
-        &crate::app_paths::data_dir()?,
-        project_id,
-        slug,
-    ))
 }
 
 impl Focusable for WorkspaceRoot {
@@ -1973,21 +1959,36 @@ impl WorkspaceRoot {
             );
             return;
         }
-        let Some(worktree_path) = worktree_path(&project.id, &slug) else {
-            tracing::warn!("workspace create: cannot resolve data dir");
-            return;
+        // Where it goes: the configured root, validated now so a refused
+        // directory is a toast the user reads rather than a create that fails
+        // later with a git error. The locator is also what authorises the
+        // reclaim of an interrupted create's debris at this path.
+        let locator = super::configured_locator::desktop_locator(&self.app_state.project_repo, cx);
+        let worktree_path = match locator.locate(&project, &slug) {
+            Ok(path) => path,
+            Err(err) => {
+                tracing::warn!(%err, slug = %slug, "workspace create: no worktree location");
+                crate::shell::toast::toast_op_error(
+                    cx,
+                    &format!("Create workspace \u{201c}{slug}\u{201d}"),
+                    &err.to_string(),
+                );
+                return;
+            }
         };
         // Detect an existing workspace for this slug and OPEN it instead of
-        // erroring on a duplicate worktree. The worktree path is deterministic
-        // from (project, slug), so a re-create from the same issue resolves to
-        // the same stored row — clicking "+ Workspace" twice should land on the
-        // existing workspace's agent, not fail with `add_worktree` "already
-        // exists".
-        let worktree_path_str = worktree_path.to_string_lossy().to_string();
+        // erroring on a duplicate worktree — clicking "+ Workspace" twice
+        // should land on the existing workspace's agent, not fail with
+        // `add_worktree` "already exists". Looked up by slug, not by path:
+        // the minted path is no longer a pure function of (project, slug),
+        // since the project's directory name gains an id tag the moment
+        // another project shares its name, and a row created before that
+        // still names the old path.
         if let Ok(Some(existing)) = self
             .app_state
             .workspace_repo
-            .get_by_worktree_path(&worktree_path_str)
+            .list_for_project(&project.id)
+            .map(|rows| rows.into_iter().find(|w| w.slug == slug))
         {
             tracing::info!(
                 workspace_id = %existing.id,
@@ -2044,22 +2045,20 @@ impl WorkspaceRoot {
                 cx.background_spawn(async move { stream_provisioning(transcript_path, rx).await })
             };
             let outcome = create_workspace_with_rollback(
-                &project_root,
-                &project_id,
+                &project,
                 &name_trimmed,
                 &slug,
                 &base,
                 &worktree_path,
+                // The locator that minted the path, so debris from an
+                // interrupted create there is reclaimed on retry — the flow
+                // above has already looked for a workspace row naming it.
+                &locator,
                 linked_issue.as_deref(),
                 &workspace_repo,
                 // No per-request override from this path yet: the create dialog
                 // has no setup toggle, so the project's `auto_setup` decides.
-                // Reclaim opted into here and nowhere else in the desktop:
-                // this path is host-derived under the data dir, and the flow
-                // above has already looked for a workspace row naming it.
-                &Provision::new(setup_decision, tx)
-                    .reclaiming_orphans()
-                    .freshening_default(freshen_default),
+                &Provision::new(setup_decision, tx).freshening_default(freshen_default),
             )
             .await;
             // The sender is gone with `Provision`, so the drain has ended or is

--- a/apps/desktop/src/workspace_root/render.rs
+++ b/apps/desktop/src/workspace_root/render.rs
@@ -560,15 +560,31 @@ impl Render for WorkspaceRoot {
                     let weak_view = view.downgrade();
                     let slug = action.slug.clone();
                     let project_root = std::path::PathBuf::from(&project.root_path);
-                    // Sibling `oximux-wt-<slug>` path — the same convention the
-                    // manual "New Worktree" form and the retired git-only path
-                    // used, so both land in one place.
-                    let worktree_path = std::path::PathBuf::from(
-                        crate::shell::worktree_panel::list_render::suggest_worktree_path(
-                            &project_root,
-                            &slug,
-                        ),
+                    // The same locator the rail's create uses, so a chat-made
+                    // worktree lands beside a rail-made one — the sibling
+                    // `oximux-wt-<slug>` scheme this path used to have is gone.
+                    // A refused root is the chat's own failure banner, not a
+                    // log line: this path runs unattended.
+                    use crate::shell::workspace_ops::WorktreeLocator as _;
+                    let locator = crate::shell::workspace::configured_locator::desktop_locator(
+                        &this.app_state.project_repo,
+                        cx,
                     );
+                    let worktree_path = match locator.locate(&project, &slug) {
+                        Ok(path) => path,
+                        Err(err) => {
+                            tracing::warn!(%err, slug = %slug, "create-worktree-workspace: no worktree location");
+                            view.update(cx, |v, cx| {
+                                v.on_worktree_create_outcome(
+                                    crate::shell::workspace_ops::ChatWorktreeOutcome::GitFailed(
+                                        err.to_string(),
+                                    ),
+                                    cx,
+                                )
+                            });
+                            return;
+                        }
+                    };
                     let workspace_repo = this.app_state.workspace_repo.clone();
                     let project_id = project.id.clone();
                     // The same resolved prefix the chat pill previewed with —
@@ -599,12 +615,18 @@ impl Render for WorkspaceRoot {
                         // ways for anyone to notice.
                         let base = CreateBase::new_branch(branch);
                         let outcome = create_workspace_with_rollback(
-                            &project_root,
-                            &project_id,
+                            &project,
                             &slug,
                             &slug,
                             &base,
                             &worktree_path,
+                            // The locator that minted the path. Reclaim of an
+                            // interrupted create's debris needs that, the
+                            // provisioning mark only an interrupted create
+                            // leaves, and no row naming the path — the
+                            // reclaim checks all three itself, which is what
+                            // lets this unattended path carry a locator at all.
+                            &locator,
                             None,
                             &workspace_repo,
                             // The chat's own worktree: the project's setting
@@ -613,13 +635,6 @@ impl Render for WorkspaceRoot {
                             // though the chat surface only shows the one-line
                             // outcome — otherwise a failure here would be the
                             // hardest one to diagnose and the least visible.
-                            // No `reclaiming_orphans()` here on purpose. This
-                            // path targets a sibling `oximux-wt-<slug>` beside
-                            // the project root — a location a person may well
-                            // own — and it never checks for an existing row.
-                            // Both of the reclaim's safety premises are false
-                            // here, so a collision must stay an ordinary
-                            // `add_worktree` failure.
                             &Provision::new(
                                 oximux_settings::SetupDecision::Inherit,
                                 provision_tx,

--- a/apps/desktop/tests/workspace_create_rollback.rs
+++ b/apps/desktop/tests/workspace_create_rollback.rs
@@ -8,9 +8,12 @@
 use std::path::Path;
 use std::process::Command;
 
+use oximux_app::shell::workspace::configured_locator::ConfiguredLocator;
 use oximux_app::shell::workspace_ops::{
-    CreateBase, CreateOutcome, Provision, create_workspace_with_rollback,
+    CreateBase, CreateOutcome, LocateError, Provision, WorktreeLocator,
+    create_workspace_with_rollback, provisioning_marker,
 };
+use oximux_core::Project;
 use oximux_git::Repository;
 use oximux_storage::{ProjectRepo, WorkspaceRepo, open_memory};
 
@@ -44,6 +47,33 @@ fn init_repo(cwd: &Path) {
 /// than resolving settings that no headless test has.
 fn branch_of(slug: &str) -> String {
     format!("{}/{slug}", oximux_settings::git::DEFAULT_PREFIX)
+}
+
+/// The locator every pre-existing test in this file means: one that mints
+/// exactly the `<tmp>/worktrees/<slug>` path the tests were written against.
+///
+/// Rather than a host-derived locator with the paths rewritten to match, so
+/// that a test which deliberately targets a path *nobody minted* (the sibling
+/// `oximux-wt-mine` below) keeps saying so in its own text.
+#[derive(Debug)]
+struct TestLocator(std::path::PathBuf);
+
+impl WorktreeLocator for TestLocator {
+    fn locate(&self, _project: &Project, slug: &str) -> Result<std::path::PathBuf, LocateError> {
+        Ok(self.0.join("worktrees").join(slug))
+    }
+}
+
+fn test_locator(tmp: &Path) -> TestLocator {
+    TestLocator(tmp.to_path_buf())
+}
+
+/// Put a finished worktree back into the state a kill during provisioning
+/// leaves it in: the mark present. A successful create clears the mark after
+/// the row insert, so a test modelling an interruption has to restore it.
+fn leave_mid_provisioning(worktree_path: &Path) {
+    let mark = provisioning_marker(worktree_path).expect("a linked worktree has a gitdir");
+    std::fs::write(&mark, b"").expect("write mark");
 }
 
 /// The base every pre-existing test in this file means: a new branch named the
@@ -80,12 +110,12 @@ async fn rollback_on_insert_conflict_removes_worktree_and_branch() {
     let worktree_path = tmp.path().join("worktrees").join(slug);
 
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Fix Login",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -134,12 +164,12 @@ async fn create_workspace_happy_path_inserts_row_and_keeps_worktree() {
     let worktree_path = tmp.path().join("worktrees").join(slug);
 
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "New Feat",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -209,12 +239,12 @@ async fn a_failing_setup_script_rolls_back_worktree_branch_and_row() {
     let worktree_path = tmp.path().join("worktrees").join(slug);
 
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Bad Setup",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -281,12 +311,12 @@ async fn a_failing_setup_script_is_not_run_when_the_project_did_not_opt_in() {
     let slug = "opted-out";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Opted Out",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -327,12 +357,12 @@ async fn included_files_are_present_before_the_setup_script_runs() {
     let slug = "with-env";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "With Env",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -370,12 +400,12 @@ async fn an_include_pattern_matching_nothing_does_not_fail_creation() {
     let slug = "no-match";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "No Match",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -411,12 +441,12 @@ async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry()
 
     // First create succeeds, leaving worktree + branch + row.
     let first = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Interrupted",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -427,21 +457,24 @@ async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry()
         other => panic!("expected Created, got {other:?}"),
     };
 
-    // Simulate the crash: the row never made it (or was lost), but git's half
-    // is on disk. This is exactly the state a kill during setup leaves behind.
+    // Simulate the crash: the row never made it, git's half is on disk, and
+    // the provisioning mark is still there — exactly the state a kill during
+    // setup leaves behind. The mark is re-written because a *finished* create
+    // clears it, and the point of this test is the unfinished one.
     workspace_repo.delete(&created.id).expect("drop the row");
+    leave_mid_provisioning(&worktree_path);
     assert!(worktree_path.exists(), "precondition: the orphan is on disk");
 
     let retry = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Interrupted",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
-        &Provision::default().reclaiming_orphans(),
+        &Provision::default(),
     )
     .await;
 
@@ -456,10 +489,10 @@ async fn an_orphaned_worktree_from_an_interrupted_create_is_reclaimed_on_retry()
     }
 }
 
-/// The reclaim is a delete, so it verifies rather than trusts. A caller that
-/// opts in but is wrong — a workspace row *does* name this path — must not lose
-/// the user's worktree. Without the in-function row check this test destroys a
-/// live workspace and its uncommitted work.
+/// The reclaim is a delete, so it verifies rather than trusts. A locator that
+/// minted the path but is wrong about it being debris — a workspace row *does*
+/// name this path — must not lose the user's worktree. Without the in-function
+/// row check this test destroys a live workspace and its uncommitted work.
 #[tokio::test]
 async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -476,12 +509,12 @@ async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
     let slug = "live-work";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let first = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Live Work",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -492,17 +525,18 @@ async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
     // Uncommitted work the user would lose if the reclaim went ahead.
     std::fs::write(worktree_path.join("wip.txt"), "hours of work\n").expect("write wip");
 
-    // The row is still there, so opting in must not be enough.
+    // The row is still there, so the locator having minted the path must not
+    // be enough.
     let second = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Live Work",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
-        &Provision::default().reclaiming_orphans(),
+        &Provision::default(),
     )
     .await;
 
@@ -517,10 +551,11 @@ async fn reclaim_refuses_a_path_a_workspace_row_still_names() {
     );
 }
 
-/// A caller that has NOT opted in must never have its target path touched, even
-/// when no row names it. This is the chat-initiated worktree's protection: it
-/// targets a sibling directory beside the project root, where a person's own
-/// worktree can legitimately live.
+/// A path the locator did NOT mint must never be touched, even when no row
+/// names it. There is no boolean to opt in with any more; the only thing that
+/// authorises a reclaim is the locator recognising its own path — and a
+/// sibling directory beside the project root, where a person's own worktree
+/// can legitimately live, is not one.
 #[tokio::test]
 async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -541,12 +576,12 @@ async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
     std::fs::write(worktree_path.join("notes.txt"), "not yours\n").expect("write");
 
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Mine",
         slug,
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -560,7 +595,7 @@ async fn a_caller_that_did_not_opt_in_never_has_its_path_reclaimed() {
     assert_eq!(
         std::fs::read_to_string(worktree_path.join("notes.txt")).expect("survives"),
         "not yours\n",
-        "a non-opted-in create deleted a directory it did not own"
+        "a create deleted a directory its locator did not mint"
     );
 }
 
@@ -613,12 +648,12 @@ async fn a_base_that_is_not_an_ancestor_of_the_default_skips_the_setup_script() 
     let slug = "review-theirs";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Review Theirs",
         slug,
         &CreateBase::new_branch_from(branch_of(slug), "side"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -651,12 +686,12 @@ async fn a_base_that_is_an_ancestor_of_the_default_still_runs_setup() {
     let slug = "ordinary";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Ordinary",
         slug,
         &CreateBase::new_branch_from(branch_of(slug), "main"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -682,12 +717,12 @@ async fn an_explicit_run_setup_overrides_the_unreviewed_base_guard() {
     let slug = "opted-in";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Opted In",
         slug,
         &CreateBase::new_branch_from(branch_of(slug), "side"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision {
@@ -718,12 +753,12 @@ async fn the_skip_reason_reaches_the_provisioning_transcript() {
     let slug = "watched";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Watched",
         slug,
         &CreateBase::new_branch_from(branch_of(slug), "side"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::new(oximux_settings::SetupDecision::Inherit, tx),
@@ -760,12 +795,12 @@ async fn an_adopted_branch_becomes_the_rows_branch_with_no_prefix_applied() {
     let slug = "adopted";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Adopted",
         slug,
         &CreateBase::existing("side"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -804,12 +839,12 @@ async fn a_failed_create_never_deletes_the_branch_it_adopted() {
 
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Adopted Conflict",
         slug,
         &CreateBase::existing("side"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -867,13 +902,13 @@ async fn an_unattended_create_does_not_inherit_a_feature_branch_head() {
     let slug = "from-chat";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "From Chat",
         slug,
         // What the chat pill passes.
         &CreateBase::new_branch_from(branch_of(slug), &project.default_branch),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -934,13 +969,13 @@ async fn a_default_branch_that_exists_only_on_the_remote_still_creates_the_named
     let slug = "feat";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        &project_root,
-        &project.id,
+        &project,
         "Feat",
         slug,
         // What ⌘N with every control left alone produces.
         &base_of(slug),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -992,12 +1027,12 @@ async fn the_row_records_whether_the_branch_was_minted_or_adopted() {
 
     // Adopted: `side` existed before OxiMux ever saw it.
     let adopted = match create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Adopted",
         "adopted",
         &CreateBase::existing("side"),
         &tmp.path().join("worktrees").join("adopted"),
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -1016,12 +1051,12 @@ async fn the_row_records_whether_the_branch_was_minted_or_adopted() {
 
     // Minted: ours, and cleanup must still remove it.
     let minted = match create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Minted",
         "minted",
         &base_of("minted"),
         &tmp.path().join("worktrees").join("minted"),
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::default(),
@@ -1088,12 +1123,12 @@ async fn adopting_a_branch_contained_in_the_default_still_runs_setup() {
     let slug = "adopt-behind";
     let worktree_path = tmp.path().join("worktrees").join(slug);
     let outcome = create_workspace_with_rollback(
-        project_root,
-        &project.id,
+        &project,
         "Adopt Behind",
         slug,
         &CreateBase::existing("behind"),
         &worktree_path,
+        &test_locator(tmp.path()),
         None,
         &workspace_repo,
         &Provision::new(oximux_settings::SetupDecision::Inherit, tx),
@@ -1112,4 +1147,291 @@ async fn adopting_a_branch_contained_in_the_default_still_runs_setup() {
             panic!("setup was skipped for a reviewed base: {text}");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Worktree location seam (phase 6)
+// ---------------------------------------------------------------------------
+
+/// A configured locator rooted at `<tmp>/wt`, knowing exactly `projects`.
+fn configured(tmp: &Path, projects: &[Project]) -> ConfiguredLocator {
+    ConfiguredLocator::new(Some(tmp.join("wt")), Some(tmp.join("data")), projects.to_vec())
+}
+
+/// The recovery the first draft of this phase would have deleted: under a
+/// user-chosen root, retrying a slug whose directory was left behind by a
+/// killed create must still succeed rather than failing `already exists`
+/// forever. The locator minted the path, so it may clear it.
+#[tokio::test]
+async fn an_interrupted_create_recovers_on_retry_under_the_configured_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("mkdir");
+    init_repo(&project_root);
+    let (workspace_repo, project) = seed_project(&project_root);
+    let locator = configured(tmp.path(), std::slice::from_ref(&project));
+
+    let slug = "interrupted";
+    let worktree_path = locator.locate(&project, slug).expect("locate");
+    // Canonical on both sides: the locator resolves the root (`/private/var`
+    // for a macOS `/var` tempdir), and a literal compare would call that a
+    // different directory.
+    let root = std::fs::canonicalize(tmp.path()).expect("canon").join("wt");
+    assert!(
+        worktree_path.starts_with(&root),
+        "the configured root, not the data dir: {}",
+        worktree_path.display()
+    );
+
+    let first = create_workspace_with_rollback(
+        &project,
+        "Interrupted",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    let created = match first {
+        CreateOutcome::Created(ws) => ws,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    workspace_repo.delete(&created.id).expect("drop the row");
+    leave_mid_provisioning(&worktree_path);
+    assert!(worktree_path.exists(), "precondition: the orphan is on disk");
+
+    let retry = create_workspace_with_rollback(
+        &project,
+        "Interrupted",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(
+        matches!(retry, CreateOutcome::Created(_)),
+        "retry after an interrupted create must succeed under the configured root, got {retry:?}"
+    );
+}
+
+/// The narrowed rule, pinned. A directory the user made under the configured
+/// root — at a path this locator would not mint for the slug being created —
+/// is never reclaimed, whatever the caller passes. This is the test that
+/// notices if `may_reclaim` ever answers from the locator's kind instead of
+/// the path.
+#[tokio::test]
+async fn a_directory_a_person_made_under_the_configured_root_is_never_reclaimed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("mkdir");
+    init_repo(&project_root);
+    let (workspace_repo, project) = seed_project(&project_root);
+    let locator = configured(tmp.path(), std::slice::from_ref(&project));
+
+    // The user's own folder, beside where OxiMux would put `feat`.
+    let slug = "feat";
+    let minted = locator.locate(&project, slug).expect("locate");
+    let users_own = minted.parent().expect("project dir").join("my-notes");
+    std::fs::create_dir_all(&users_own).expect("mkdir");
+    std::fs::write(users_own.join("notes.txt"), "not yours\n").expect("write");
+    assert!(!locator.may_reclaim(&project, slug, &users_own));
+
+    // A caller that targets the user's folder for a create — the shape a
+    // future call site could take by passing the wrong path.
+    let outcome = create_workspace_with_rollback(
+        &project,
+        "Feat",
+        slug,
+        &base_of(slug),
+        &users_own,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(
+        matches!(outcome, CreateOutcome::GitFailed(_)),
+        "an occupied path the locator did not mint must fail: {outcome:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(users_own.join("notes.txt")).expect("survives"),
+        "not yours\n",
+        "the reclaim deleted a directory a person made"
+    );
+}
+
+/// Two repositories both called `api` do not share a directory under the
+/// configured root, so the same slug in each creates two worktrees.
+#[tokio::test]
+async fn two_projects_with_one_name_do_not_collide_under_the_configured_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db = open_memory().expect("open memory");
+    let project_repo = ProjectRepo::new(db.clone());
+    let workspace_repo = WorkspaceRepo::new(db);
+    let mut projects = Vec::new();
+    for dir in ["work", "oss"] {
+        let root = tmp.path().join(dir).join("api");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        init_repo(&root);
+        projects.push(
+            project_repo.insert("api", root.to_str().unwrap(), "main").expect("project"),
+        );
+    }
+    let locator = configured(tmp.path(), &projects);
+
+    let mut paths = Vec::new();
+    for project in &projects {
+        let slug = "feat";
+        let worktree_path = locator.locate(project, slug).expect("locate");
+        let outcome = create_workspace_with_rollback(
+            project,
+            "Feat",
+            slug,
+            &base_of(slug),
+            &worktree_path,
+            &locator,
+            None,
+            &workspace_repo,
+            &Provision::default(),
+        )
+        .await;
+        match outcome {
+            CreateOutcome::Created(ws) => paths.push(ws.worktree_path),
+            other => panic!("expected Created for {}, got {other:?}", project.root_path),
+        }
+    }
+    assert_ne!(paths[0], paths[1], "same-named projects shared a worktree directory");
+    for path in &paths {
+        assert!(Path::new(path).exists(), "{path} should be on disk");
+        let project_dir = Path::new(path).parent().unwrap().file_name().unwrap().to_string_lossy();
+        assert!(project_dir.starts_with("api-"), "readable first, unique always: {project_dir}");
+    }
+}
+
+/// The other half of the reclaim rule. A worktree that FINISHED and later lost
+/// its row — the project was removed and the same repository re-added under a
+/// fresh id, say — sits at the very path the locator mints, with no row
+/// naming it, and holds the user's work. It must not be mistaken for an
+/// interrupted create: only the provisioning mark says "interrupted", and a
+/// finished create clears it.
+#[tokio::test]
+async fn a_finished_worktree_whose_row_is_gone_is_never_reclaimed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("mkdir");
+    init_repo(&project_root);
+    let (workspace_repo, project) = seed_project(&project_root);
+    let locator = configured(tmp.path(), std::slice::from_ref(&project));
+
+    let slug = "kept";
+    let worktree_path = locator.locate(&project, slug).expect("locate");
+    let first = create_workspace_with_rollback(
+        &project,
+        "Kept",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    let created = match first {
+        CreateOutcome::Created(ws) => ws,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert!(
+        !provisioning_marker(&worktree_path).expect("gitdir").exists(),
+        "a finished create must clear its mark"
+    );
+    std::fs::write(worktree_path.join("wip.txt"), "hours of work\n").expect("write wip");
+
+    // The row goes away without the worktree: the removed-project cascade,
+    // or an archive (which the row lookup does not see either).
+    workspace_repo.delete(&created.id).expect("drop the row");
+
+    let retry = create_workspace_with_rollback(
+        &project,
+        "Kept",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(
+        matches!(retry, CreateOutcome::GitFailed(_)),
+        "a finished worktree must not be reclaimed, got {retry:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join("wip.txt")).expect("wip survives"),
+        "hours of work\n",
+        "the reclaim deleted a finished worktree's work"
+    );
+}
+
+/// Archiving keeps the directory and hides the row from the path lookup, so
+/// an archived workspace is the same shape as the case above — pinned
+/// separately because it is the one a user reaches without ever removing a
+/// project.
+#[tokio::test]
+async fn an_archived_worktree_is_never_reclaimed_by_a_same_slug_create() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("mkdir");
+    init_repo(&project_root);
+    let (workspace_repo, project) = seed_project(&project_root);
+    let locator = configured(tmp.path(), std::slice::from_ref(&project));
+
+    let slug = "parked";
+    let worktree_path = locator.locate(&project, slug).expect("locate");
+    let first = create_workspace_with_rollback(
+        &project,
+        "Parked",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    let created = match first {
+        CreateOutcome::Created(ws) => ws,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    std::fs::write(worktree_path.join("wip.txt"), "parked work\n").expect("write wip");
+    workspace_repo.mark_archived(&created.id).expect("archive");
+
+    let again = create_workspace_with_rollback(
+        &project,
+        "Parked",
+        slug,
+        &base_of(slug),
+        &worktree_path,
+        &locator,
+        None,
+        &workspace_repo,
+        &Provision::default(),
+    )
+    .await;
+    assert!(!matches!(again, CreateOutcome::Created(_)), "{again:?}");
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join("wip.txt")).expect("wip survives"),
+        "parked work\n",
+        "the reclaim deleted an archived worktree's work"
+    );
 }

--- a/crates/settings/src/computer_use.rs
+++ b/crates/settings/src/computer_use.rs
@@ -153,11 +153,11 @@ impl ComputerUseSettings {
     /// project the user enabled, and requiring the two to be spelled identically
     /// would leave the pane listing a project whose chats silently get nothing.
     ///
-    /// Containment is not the whole answer: a linked worktree is a *sibling* of
-    /// its project (`suggest_worktree_path` puts it at `<parent>/oximux-wt-…`),
-    /// so no amount of prefix matching reaches it. Resolving a worktree back to
-    /// its main repository needs git and belongs to the caller; this stays pure
-    /// so it can be tested without one.
+    /// Containment is not the whole answer: a linked worktree lives *outside*
+    /// its project (under the configured worktree root, `~/OxiMux/worktrees`
+    /// by default), so no amount of prefix matching reaches it. Resolving a
+    /// worktree back to its main repository needs git and belongs to the
+    /// caller; this stays pure so it can be tested without one.
     pub fn is_enabled_for(&self, dir: &Path) -> bool {
         self.covering_root(dir).is_some()
     }

--- a/crates/settings/src/git.rs
+++ b/crates/settings/src/git.rs
@@ -69,9 +69,16 @@ pub struct GitSettings {
     /// still there rather than having it silently discarded by a control they
     /// were only looking at.
     pub custom_prefix: String,
-    /// Where new worktrees are created. `None` means the host-derived scheme
-    /// OxiMux has always used. **Inert until Phase 6 wires the seam** — the
-    /// pane renders it disabled and says so.
+    /// Where the desktop creates new worktrees, laid out as
+    /// `<dir>/<project>/<slug>`. `None` means the default,
+    /// `~/OxiMux/worktrees`. A leading `~` is expanded.
+    ///
+    /// Validated when it is *used*, not only when the pane saved it — the
+    /// file is meant to be hand-edited — and refused with a reason when it
+    /// points inside a git working tree, inside the app's data directory, or
+    /// somewhere unwritable. Existing worktrees are never moved by changing
+    /// it. The headless host ignores it: `oximux serve` keeps the host-derived
+    /// scheme under its own data directory.
     pub worktree_dir: Option<String>,
     /// On worktree create, fetch and fast-forward the local default branch so
     /// the new worktree starts from current work rather than from whatever was
@@ -89,8 +96,8 @@ impl GitSettings {
     /// File this is persisted to, beside the other per-app settings.
     pub const FILE_NAME: &'static str = "git.toml";
 
-    /// The shipped default: today's behaviour exactly — `oximux/<slug>`
-    /// branches, host-derived paths, no fetching on create.
+    /// The shipped default: `oximux/<slug>` branches, the default worktree
+    /// directory, no fetching on create.
     pub fn shipped() -> Self {
         Self {
             branch_prefix: BranchPrefixMode::Custom,

--- a/crates/worktree-ops/Cargo.toml
+++ b/crates/worktree-ops/Cargo.toml
@@ -39,6 +39,11 @@ oximux-no-window = { workspace = true }
 # be anchored and budgeted (see `include.rs`).
 ignore = { workspace = true }
 async-trait = { workspace = true }
+# Canonical paths WITHOUT the `\\?\` verbatim prefix `std::fs::canonicalize`
+# adds on Windows: a minted path becomes a `git worktree add` argument, a
+# stored `worktree_path`, and the rail's displayed text, and Git for Windows
+# does not take verbatim paths.
+dunce = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/worktree-ops/src/lib.rs
+++ b/crates/worktree-ops/src/lib.rs
@@ -9,15 +9,17 @@
 //! third step fails after the first two succeeded, and it is the reason this
 //! module exists as one implementation rather than two.
 //!
-//! The path scheme is host-derived on purpose: a client names a project and a
-//! slug, never a location. [`worktree_path`] is that derivation, taking the
-//! data directory explicitly so `oximux serve --data-dir` puts worktrees under
-//! its own root instead of the desktop's.
+//! Where a worktree goes is a [`WorktreeLocator`]'s answer, and so is whether
+//! a directory already there may be cleared as debris. The remote surface
+//! keeps the host-derived scheme — a client names a project and a slug, never
+//! a location — through [`HostDerivedLocator`]; the desktop, which is the
+//! host, resolves a configured, browsable root instead. See [`locator`].
 
 pub mod branch_name;
 pub mod create_base;
 pub mod freshen;
 pub mod include;
+pub mod locator;
 pub mod merge;
 pub mod rename;
 mod paths;
@@ -26,6 +28,10 @@ pub mod setup;
 
 pub use create_base::{CreateBase, setup_decision};
 pub use include::{CopyReport, Skip};
+pub use locator::{
+    HostDerivedLocator, LocateError, WorktreeLocator, canonicalize_lenient, project_dir_name,
+    validate_worktree_root, validate_worktree_root_shape, worktree_path,
+};
 pub use merge::{
     MergePlan, MergeRefusal, MergeResult, apply_merge, merge_into_default, preflight_merge,
 };
@@ -38,7 +44,7 @@ pub use setup::{SETUP_TIMEOUT, SetupOutcome, SetupTranscript};
 
 use std::path::{Path, PathBuf};
 
-use oximux_core::Workspace;
+use oximux_core::{Project, Workspace};
 use oximux_git::Repository;
 use oximux_settings::{ScriptKind, SetupDecision};
 use oximux_storage::{StorageError, WorkspaceRepo};
@@ -90,20 +96,14 @@ pub struct Provision {
     pub setup: SetupDecision,
     /// Where to stream [`ProvisionEvent`]s, if anyone is watching.
     pub sink: Option<UnboundedSender<ProvisionEvent>>,
-    /// Whether a directory already at the target path may be deleted as debris
-    /// from an interrupted create. See [`Provision::reclaiming_orphans`].
-    ///
-    /// Off by default, and deliberately so: the default has to be the one that
-    /// cannot destroy anything.
-    pub reclaim_orphan: bool,
     /// Fetch and fast-forward the local default branch before the worktree is
     /// cut. Mirrors the user's `keep_default_up_to_date` setting.
     ///
     /// Whether that changes what the new worktree is *based on* depends on
     /// where HEAD is — see [`crate::freshen`], which spells out both cases.
     ///
-    /// Off by default for the same reason as `reclaim_orphan`, plus one more:
-    /// it makes creating a worktree touch the network.
+    /// Off by default because the default has to be the one that does nothing
+    /// surprising, and this one makes creating a worktree touch the network.
     pub freshen_default: bool,
 }
 
@@ -113,7 +113,6 @@ impl Provision {
         Self {
             setup,
             sink: Some(sink),
-            reclaim_orphan: false,
             freshen_default: false,
         }
     }
@@ -121,24 +120,6 @@ impl Provision {
     /// Opt in to freshening the default branch before the worktree is cut.
     pub fn freshening_default(mut self, freshen: bool) -> Self {
         self.freshen_default = freshen;
-        self
-    }
-
-    /// Opt in to clearing a directory already sitting at the target path.
-    ///
-    /// **Only for callers that own the path scheme.** The caller asserts two
-    /// things by calling this: the path is host-derived
-    /// (`<data_dir>/projects/<id>/worktrees/<slug>`, see [`worktree_path`]), so
-    /// nothing a person put there by hand can be at that location; and the
-    /// caller has already looked for a workspace row naming it.
-    ///
-    /// The second half is re-checked here rather than trusted — see
-    /// [`reclaim_orphan`] — but the first half cannot be, which is why this is
-    /// opt-in rather than automatic. The chat-initiated worktree uses a sibling
-    /// `oximux-wt-<slug>` directory beside the project root, exactly where a
-    /// person's own worktree could live, and must never turn this on.
-    pub fn reclaiming_orphans(mut self) -> Self {
-        self.reclaim_orphan = true;
         self
     }
 
@@ -194,21 +175,6 @@ pub enum CreateOutcome {
     },
 }
 
-/// Compose the worktree dir path:
-/// `<data_dir>/projects/<project_id>/worktrees/<slug>`.
-///
-/// `data_dir` is passed rather than resolved here because the two hosts
-/// disagree about it: the desktop always uses its own app data root, while
-/// `oximux serve` honours `--data-dir`. Deriving it internally would put a
-/// server's worktrees under the desktop's directory.
-pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
-    data_dir
-        .join("projects")
-        .join(project_id)
-        .join("worktrees")
-        .join(slug)
-}
-
 /// Open the project repo, create the worktree [`base`](CreateBase) describes,
 /// and insert the workspace row. On storage failure, runs the rollback
 /// (force-remove worktree, and force-delete the branch **only if this create
@@ -219,6 +185,19 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
 /// row in every mode. `base` carries the branch name, already resolved by
 /// [`branch_name`], and says where the branch is cut from; the git layer
 /// validates it again before `git` sees it.
+///
+/// # The path and the locator
+///
+/// `worktree_path` is where the worktree goes; `locator` is what named it.
+/// They travel together so that the authority to *clear* the path arrives
+/// with the path: a directory already at `worktree_path` is reclaimed as
+/// debris only when [`WorktreeLocator::may_reclaim`] says this locator minted
+/// exactly that path for exactly this slug, **and** the directory still
+/// carries the provisioning mark an interrupted create leaves behind (see
+/// [`provisioning_marker`]). A caller cannot opt in with a boolean, and
+/// cannot pass a path the locator did not mint and still have it reclaimed —
+/// the locator simply answers no, and the create fails the ordinary way. See
+/// [`locator`] for why the answer is per path, not per kind.
 ///
 /// # The base and the setup script
 ///
@@ -231,9 +210,9 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
 /// # Preconditions
 ///
 /// The caller MUST have established that no workspace row references
-/// `worktree_path`. Given that, a directory already at `worktree_path` is
-/// debris from an interrupted create and is cleared before the git step — see
-/// [`reclaim_orphan`].
+/// `worktree_path`. Given that, a directory already at `worktree_path` that
+/// the locator minted is debris from an interrupted create and is cleared
+/// before the git step — see [`reclaim_orphan`].
 ///
 /// # Provisioning
 ///
@@ -250,24 +229,27 @@ pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
 /// rollback ladder that was already here for the storage case.
 #[allow(
     clippy::too_many_arguments,
-    reason = "Eight of the nine are irreducible inputs to one operation: where the repo is, \
-              what the workspace is called, what it is cut from, where it goes, and what \
-              to write it into. Bundling them into a params struct moves the same fields behind \
-              a name that means nothing more than the function's own — and every one of the five \
-              call sites would then build a struct to immediately destructure it. The ninth, \
-              `provision`, is already the grouped form of what would otherwise be three."
+    reason = "Eight of the nine are irreducible inputs to one operation: which project, \
+              what the workspace is called, what it is cut from, where it goes and who named \
+              that place, and what to write it into. Bundling them into a params struct moves \
+              the same fields behind a name that means nothing more than the function's own — \
+              and every one of the call sites would then build a struct to immediately \
+              destructure it. The ninth, `provision`, is already the grouped form of what would \
+              otherwise be three."
 )]
 pub async fn create_workspace_with_rollback(
-    project_root: &Path,
-    project_id: &str,
+    project: &Project,
     name: &str,
     slug: &str,
     base: &CreateBase,
     worktree_path: &Path,
+    locator: &dyn WorktreeLocator,
     linked_issue: Option<&str>,
     workspace_repo: &WorkspaceRepo,
     provision: &Provision,
 ) -> CreateOutcome {
+    let project_root = Path::new(&project.root_path);
+    let project_id = project.id.as_str();
     let repo = match Repository::open(project_root).await {
         Ok(r) => r,
         Err(err) => return CreateOutcome::GitFailed(format!("open project repo: {err}")),
@@ -278,7 +260,13 @@ pub async fn create_workspace_with_rollback(
     // `alice/foo`) dangling — the reclaim cannot know a name nothing recorded.
     // Accepted rather than guessed at: deleting a branch whose name we inferred
     // from a directory is how a reclaim destroys work it did not create.
-    if provision.reclaim_orphan
+    //
+    // Asked only when the path is occupied, and the locator is asked first:
+    // `may_reclaim` canonicalizes both sides, which is cheap, and an occupied
+    // path we did not mint must fail the ordinary way without a row lookup
+    // ever being consulted about it.
+    if worktree_path.exists()
+        && locator.may_reclaim(project, slug, worktree_path)
         && let Some(err) = reclaim_orphan(&repo, worktree_path, base, workspace_repo).await
     {
         return CreateOutcome::GitFailed(err);
@@ -349,6 +337,21 @@ pub async fn create_workspace_with_rollback(
     };
     if let Err(err) = added {
         return CreateOutcome::GitFailed(format!("add_worktree: {err}"));
+    }
+    // From here until the row is written this worktree is *ours to lose*: a
+    // kill during the include copy or the setup script leaves it on disk
+    // with no row. The mark is what lets a retry tell that state from a
+    // finished worktree whose row went away later (project removed,
+    // workspace archived) — which looks identical from the outside and holds
+    // someone's work. Best-effort: a mark that could not be written means a
+    // retry after an interruption fails `already exists` (the pre-mark
+    // behaviour), never that anything is deleted.
+    if let Some(mark) = provisioning_marker(worktree_path) {
+        if let Err(err) = std::fs::write(&mark, b"") {
+            tracing::warn!(?err, mark = %mark.display(), "could not write the provisioning mark");
+        }
+    } else {
+        tracing::warn!(worktree = %worktree_path.display(), "no gitdir for the provisioning mark");
     }
 
     // Include copy: best-effort by contract. Every skip is reported and nothing
@@ -424,6 +427,17 @@ pub async fn create_workspace_with_rollback(
     // data loss. See `Workspace::branch_minted`.
     match workspace_repo.insert(project_id, name, slug, branch, &path_str, base.creates_branch()) {
         Ok(mut workspace) => {
+            // The row exists, so this is a workspace now, not debris. Cleared
+            // AFTER the insert: a kill between the two leaves a live row plus
+            // a stale mark, and the row check below refuses that — the safe
+            // side. Cleared before the insert, the same kill would leave a
+            // rowless, markless worktree that no retry could ever clear.
+            if let Some(mark) = provisioning_marker(worktree_path)
+                && let Err(err) = std::fs::remove_file(&mark)
+                && err.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(?err, mark = %mark.display(), "could not clear the provisioning mark");
+            }
             // Best-effort metadata write — the worktree + row already exist, so
             // a failure here only loses the issue badge, not the workspace. The
             // in-memory field is set ONLY on a confirmed write.
@@ -499,10 +513,17 @@ async fn resolvable_default(repo: &Repository, default_branch: Option<&str>) -> 
 /// fail with "already exists" on every retry from then on. Before this, that
 /// window was a few milliseconds and the case was theoretical.
 ///
-/// **Why deleting is safe here — and the two things that make it so.** Reached
-/// only when the caller opted in via [`Provision::reclaiming_orphans`], which
-/// asserts the path is host-derived and therefore not somewhere a person keeps
-/// work. On top of that, this re-checks that no workspace row names the path.
+/// **Why deleting is safe here — and the three things that make it so.**
+/// Reached only when the caller's [`WorktreeLocator`] confirmed it minted
+/// exactly this path for exactly this slug, so it is not somewhere a person
+/// keeps work. Then the directory must still carry the provisioning mark
+/// ([`provisioning_marker`]), which only an interrupted create leaves behind:
+/// a worktree that *finished* and later lost its row — the project was
+/// removed and the same repository re-added under a fresh id, or the
+/// workspace was archived, which `get_by_worktree_path` does not see — sits at
+/// the same minted path and holds someone's work, and the mark is the one
+/// thing that tells the two apart. Last, this re-checks that no workspace row
+/// names the path.
 ///
 /// The row check is not redundant with the caller's own. A precondition that
 /// lives only in a doc comment is one refactor away from being false, and the
@@ -516,6 +537,18 @@ async fn reclaim_orphan(
 ) -> Option<String> {
     let branch = base.branch();
     if !worktree_path.exists() {
+        return None;
+    }
+    // No mark, no reclaim — whatever else is true. A directory git never
+    // registered (no `.git` pointer) has no mark either, and is refused the
+    // same way: git creates the leaf itself, so a leaf with no pointer is
+    // never our debris.
+    if !provisioning_marker(worktree_path).is_some_and(|mark| mark.exists()) {
+        tracing::warn!(
+            worktree = %worktree_path.display(),
+            "refusing to reclaim: the directory carries no provisioning mark, so it is a \
+             finished worktree or someone's own directory, not an interrupted create"
+        );
         return None;
     }
     // A row naming this path means it is a live workspace, not debris —
@@ -561,6 +594,32 @@ async fn reclaim_orphan(
     }
     None
 }
+
+/// Where an in-progress create leaves its mark: a file in the worktree's own
+/// gitdir (`<main>/.git/worktrees/<name>/oximux-provisioning`).
+///
+/// In the gitdir rather than the working tree because the working tree is
+/// what the setup script sees and what `.oximuxinclude` fills — a stray file
+/// there would be visible to both and to `git status`. The gitdir is private
+/// to this worktree and is removed with it, so the mark can never outlive the
+/// thing it marks. `None` when `worktree_path` is not a linked worktree —
+/// there is no gitdir to write into, and nothing there is ours.
+///
+/// Public so the tests that model an interrupted create can set the state it
+/// leaves behind exactly.
+pub fn provisioning_marker(worktree_path: &Path) -> Option<PathBuf> {
+    // A linked worktree's `.git` is a FILE holding `gitdir: <path>`; a primary
+    // checkout's is a directory, and reading it fails — correctly, since a
+    // primary checkout is never something a create made.
+    let pointer = std::fs::read_to_string(worktree_path.join(".git")).ok()?;
+    let gitdir = pointer.trim().strip_prefix("gitdir:")?.trim();
+    // Absolute in practice; joined so a relative pointer resolves against the
+    // worktree, which is what git means by one.
+    Some(worktree_path.join(gitdir).join(PROVISIONING_MARK))
+}
+
+/// File name of the mark [`provisioning_marker`] resolves to.
+const PROVISIONING_MARK: &str = "oximux-provisioning";
 
 /// Undo the git half of a create: force-remove the worktree, force-delete the
 /// branch. Best-effort — both steps are attempted even when the first fails, so
@@ -646,21 +705,6 @@ async fn run_cleanup_bounded(worktree_path: &Path, timeout: std::time::Duration)
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn worktree_path_is_host_derived_from_the_data_dir() {
-        let path = worktree_path(Path::new("/data"), "proj-1", "feat-x");
-        assert_eq!(path, Path::new("/data/projects/proj-1/worktrees/feat-x"));
-    }
-
-    /// The whole reason `data_dir` is a parameter: two hosts, two roots.
-    #[test]
-    fn a_different_data_dir_relocates_the_worktree() {
-        let serve = worktree_path(Path::new("/srv/oximux"), "proj-1", "feat-x");
-        let desktop = worktree_path(Path::new("/home/u/Library"), "proj-1", "feat-x");
-        assert_ne!(serve, desktop);
-        assert!(serve.starts_with("/srv/oximux"));
-    }
 
     use std::time::{Duration, Instant};
 

--- a/crates/worktree-ops/src/locator.rs
+++ b/crates/worktree-ops/src/locator.rs
@@ -1,0 +1,580 @@
+//! Where a host puts a new worktree — and whether it may clear what it finds
+//! there.
+//!
+//! The path scheme used to be one function, [`worktree_path`], and one
+//! sentence of doctrine: *a client names a project and a slug, never a
+//! location*. That sentence is a security property of the **remote** surface,
+//! and it still holds — [`HostDerivedLocator`] is that derivation, and the RPC
+//! service constructs it itself. But it was never a law for the desktop, which
+//! is the host, and whose worktrees ended up under an opaque project UUID in
+//! Application Support where no one could find them.
+//!
+//! So the seam is a trait rather than a config flag. A locator answers two
+//! questions that must come from the same place:
+//!
+//! - [`WorktreeLocator::locate`] — where this slug's worktree goes.
+//! - [`WorktreeLocator::may_reclaim`] — whether a directory already at some
+//!   path is debris this locator's own interrupted create left behind.
+//!
+//! **The second is the invariant of this module.** Orphan reclaim is a
+//! delete, and the only thing that makes it safe is that it targets a path
+//! *this locator minted for this slug* — never a directory a person chose. The
+//! answer is per path and per slug; a locator that answered from its own kind
+//! (`true` for host-derived, `false` for configured) would either delete a
+//! user's directory or leave an interrupted create wedged forever, and both
+//! have happened in the design of this crate.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use oximux_core::Project;
+use oximux_git::worktree::derive_slug;
+
+/// Where a host puts a new worktree. Implemented once per host kind.
+///
+/// `Send + Sync` because the desktop holds one across the create's await
+/// points; `Debug` because [`crate::Provision`] and the outcomes around it are.
+pub trait WorktreeLocator: Send + Sync + fmt::Debug {
+    /// The directory a worktree for `slug` in `project` should be created at.
+    ///
+    /// Validates every time and returns `Err` rather than falling back
+    /// silently: a configured root can be hand-edited in `git.toml` without
+    /// ever passing through the settings pane, and a repository or a symlink
+    /// can appear under a validated path afterwards.
+    fn locate(&self, project: &Project, slug: &str) -> Result<PathBuf, LocateError>;
+
+    /// May orphan reclaim clear debris at `path` for `slug`?
+    ///
+    /// True only when this locator itself would have minted exactly `path` for
+    /// exactly `slug` — i.e. the directory is one an interrupted OxiMux create
+    /// left behind, not a place a person chose. **Never a blanket answer about
+    /// the locator kind**, and never `true` when either side fails to
+    /// canonicalize: a mint-check that compares two spellings of a path is how
+    /// a reclaim deletes something it did not make.
+    fn may_reclaim(&self, project: &Project, slug: &str, path: &Path) -> bool {
+        let Ok(minted) = self.locate(project, slug) else {
+            return false;
+        };
+        match (dunce::canonicalize(&minted), dunce::canonicalize(path)) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+/// Why a locator refused to name a path.
+///
+/// Each carries enough to say *what* was wrong with *which* directory, because
+/// the reader is a person looking at a settings field or a failed create, and
+/// "invalid worktree directory" sends them to a log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocateError {
+    /// No root to derive under: the platform reported no home directory and
+    /// nothing is configured.
+    NoRoot,
+    /// The root sits inside a git working tree. Worktrees nested in a working
+    /// tree confuse every tool that walks up to find `.git`, including git.
+    InsideRepository { root: PathBuf, repository: PathBuf },
+    /// The root is the app's data directory or inside it — the place this
+    /// setting exists to move worktrees *out of*.
+    InsideDataDir { root: PathBuf },
+    /// The root, or its nearest existing ancestor, is not a writable
+    /// directory.
+    NotWritable { root: PathBuf, reason: String },
+    /// The root is relative. A relative root would resolve against whatever
+    /// the process's working directory happens to be — `/` for a GUI launch —
+    /// and `~user` forms, which nothing here expands, arrive relative too.
+    NotAbsolute { root: PathBuf },
+}
+
+impl fmt::Display for LocateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoRoot => {
+                write!(f, "no worktree directory: no home directory and none configured")
+            }
+            Self::InsideRepository { root, repository } => write!(
+                f,
+                "worktree directory {} is inside the git repository at {}; \
+                 choose a directory outside any working tree",
+                root.display(),
+                repository.display()
+            ),
+            Self::InsideDataDir { root } => write!(
+                f,
+                "worktree directory {} is inside OxiMux's data directory; \
+                 choose a directory you can browse",
+                root.display()
+            ),
+            Self::NotWritable { root, reason } => {
+                write!(f, "worktree directory {} is not writable: {reason}", root.display())
+            }
+            Self::NotAbsolute { root } => write!(
+                f,
+                "worktree directory {} is not an absolute path; spell it out from the root, \
+                 or start it with ~/",
+                root.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LocateError {}
+
+/// Compose the host-derived worktree dir path:
+/// `<data_dir>/projects/<project_id>/worktrees/<slug>`.
+///
+/// `data_dir` is passed rather than resolved here because the two hosts
+/// disagree about it: the desktop always uses its own app data root, while
+/// `oximux serve` honours `--data-dir`. Deriving it internally would put a
+/// server's worktrees under the desktop's directory.
+pub fn worktree_path(data_dir: &Path, project_id: &str, slug: &str) -> PathBuf {
+    data_dir
+        .join("projects")
+        .join(project_id)
+        .join("worktrees")
+        .join(slug)
+}
+
+/// The scheme every headless host uses: [`worktree_path`] under a data
+/// directory the *host* chose.
+///
+/// `oximux serve` and the RPC service construct this directly and take no
+/// locator from a caller — that is what keeps "a client never supplies a
+/// location" true even now that a locator exists which reads a setting.
+#[derive(Debug, Clone)]
+pub struct HostDerivedLocator {
+    data_dir: PathBuf,
+}
+
+impl HostDerivedLocator {
+    pub fn new(data_dir: PathBuf) -> Self {
+        Self { data_dir }
+    }
+
+    /// The root this locator derives under.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+}
+
+impl WorktreeLocator for HostDerivedLocator {
+    /// No validation: the data directory is the host's own, and the scheme
+    /// under it is the one every existing row was created with.
+    fn locate(&self, project: &Project, slug: &str) -> Result<PathBuf, LocateError> {
+        Ok(worktree_path(&self.data_dir, &project.id, slug))
+    }
+}
+
+/// Validate a user-chosen worktree root and return it in a canonical form.
+///
+/// [`validate_worktree_root_shape`] plus a write probe of the nearest
+/// existing ancestor. The probe creates and removes a file, so this is the
+/// form for a *commit* — a create, or the settings field being saved — and
+/// the shape-only form is for feedback on every keystroke.
+///
+/// Rejects, in this order:
+///
+/// 0. a relative root — including a `~user` form nothing expanded;
+/// 1. a root equal to or inside `data_dir` — that is the location this
+///    setting exists to leave (skipped when the host has no data directory
+///    to speak of, which no shipped desktop is without);
+/// 2. a root inside a git working tree, judged from its nearest existing
+///    ancestor so a root that does not exist yet is checked against where it
+///    *would* be created;
+/// 3. a root whose nearest existing ancestor is not a writable directory.
+///
+/// The repository rule runs on the default root too: a user whose home is
+/// itself a dotfiles repository would otherwise get worktrees nested inside
+/// it, which is exactly the case the rule exists to catch.
+///
+/// The returned path is canonical as far as it exists — the deepest existing
+/// ancestor is resolved and the not-yet-created tail re-joined — so two
+/// spellings of one directory (`/tmp/x` and `/private/tmp/x` on macOS) mint
+/// one path.
+pub fn validate_worktree_root(
+    root: &Path,
+    data_dir: Option<&Path>,
+) -> Result<PathBuf, LocateError> {
+    let root = validate_worktree_root_shape(root, data_dir)?;
+    let anchor = deepest_existing_ancestor(&root);
+    if let Err(reason) = probe_writable(&anchor) {
+        return Err(LocateError::NotWritable { root, reason });
+    }
+    Ok(root)
+}
+
+/// The rules of [`validate_worktree_root`] that touch nothing on disk beyond
+/// reading it: absolute, outside the data directory, outside any git working
+/// tree. Cheap enough to run on every keystroke of the settings field, which
+/// is what it is for; the write probe is not, and a probe file created and
+/// removed in the user's home directory per keystroke is not something a
+/// settings pane should do.
+pub fn validate_worktree_root_shape(
+    root: &Path,
+    data_dir: Option<&Path>,
+) -> Result<PathBuf, LocateError> {
+    if !root.is_absolute() {
+        return Err(LocateError::NotAbsolute { root: root.to_path_buf() });
+    }
+    let root = canonicalize_lenient(root);
+    if let Some(data_dir) = data_dir
+        && root.starts_with(canonicalize_lenient(data_dir))
+    {
+        return Err(LocateError::InsideDataDir { root });
+    }
+    let anchor = deepest_existing_ancestor(&root);
+    if let Some(repository) = enclosing_repository(&anchor) {
+        return Err(LocateError::InsideRepository { root, repository });
+    }
+    Ok(root)
+}
+
+/// The directory name a project gets under a configured root.
+///
+/// Readable first: the project's name, slugified, so `~/OxiMux/worktrees/api/`
+/// is what someone browsing to it expects. Unique always: when another project
+/// in `all` slugifies to the same name, this one carries a short piece of its
+/// id (`api-3f9c2a1b`), because two repositories both called `api` must not
+/// share a directory and then collide on every slug.
+///
+/// The disambiguation is symmetric — *every* project in a name clash carries
+/// its id, not just the newcomer — because the alternative ("first one keeps
+/// the plain name") needs an ordering nothing durable records.
+pub fn project_dir_name<'a>(project: &Project, all: impl IntoIterator<Item = &'a Project>) -> String {
+    let base = derive_slug(&project.name);
+    let clashes = all
+        .into_iter()
+        .any(|other| other.id != project.id && derive_slug(&other.name) == base);
+    if clashes {
+        let tag: String = project.id.chars().filter(char::is_ascii_alphanumeric).take(8).collect();
+        format!("{base}-{tag}")
+    } else {
+        base
+    }
+}
+
+/// Resolve `path` as far as it exists: the deepest existing ancestor is
+/// canonicalized and the remaining components re-joined. A path that exists
+/// end to end is simply canonicalized; one that does not exist at all is
+/// returned as written.
+///
+/// Through `dunce`, so a Windows result is `C:\...` and not the `\\?\C:\...`
+/// verbatim form — which git would not take as a worktree path, and which
+/// `Path::starts_with` would not match against the plain spelling every
+/// other path in the app carries.
+pub fn canonicalize_lenient(path: &Path) -> PathBuf {
+    if let Ok(real) = dunce::canonicalize(path) {
+        return real;
+    }
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor = path;
+    while let Some(parent) = cursor.parent() {
+        if let Some(name) = cursor.file_name() {
+            tail.push(name.to_os_string());
+        }
+        if let Ok(real) = dunce::canonicalize(parent) {
+            let mut out = real;
+            for name in tail.iter().rev() {
+                out.push(name);
+            }
+            return out;
+        }
+        cursor = parent;
+    }
+    path.to_path_buf()
+}
+
+/// The nearest ancestor of `path` (inclusive) that exists on disk.
+fn deepest_existing_ancestor(path: &Path) -> PathBuf {
+    let mut cursor = path;
+    loop {
+        if cursor.exists() {
+            return cursor.to_path_buf();
+        }
+        match cursor.parent() {
+            Some(parent) => cursor = parent,
+            // A relative path with no existing component: the current
+            // directory is where it would be created.
+            None => return std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        }
+    }
+}
+
+/// The working tree that contains `dir`, if any.
+///
+/// Process-free on purpose: this runs from a settings field's on-change check
+/// as well as from every create. It reads exactly what git reads — a `.git`
+/// entry, directory *or* file, since a linked worktree's `.git` is a file —
+/// and walks up. A bare repository has no working tree and no `.git` entry,
+/// so it is correctly not a match.
+fn enclosing_repository(dir: &Path) -> Option<PathBuf> {
+    dir.ancestors()
+        .find(|candidate| candidate.join(".git").exists())
+        .map(Path::to_path_buf)
+}
+
+/// Whether `dir` is a directory the current user can create entries in.
+///
+/// A permissions bit is not an answer — a read-only *directory* flag means
+/// nothing on most filesystems, and ACLs, sandboxes and mounts all say no in
+/// ways `metadata` cannot see. So this asks the only way that is always
+/// right: create a file and remove it.
+///
+/// The name carries a per-process counter as well as the pid: two probes in
+/// one process — the settings field committing while a create's own
+/// `locate` runs — must not collide on `create_new` and report a writable
+/// directory as `AlreadyExists`.
+fn probe_writable(dir: &Path) -> Result<(), String> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    if !dir.is_dir() {
+        return Err(format!("{} is not a directory", dir.display()));
+    }
+    let probe = dir.join(format!(
+        ".oximux-write-probe-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+        .map_err(|err| err.to_string())?;
+    let _ = std::fs::remove_file(&probe);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(id: &str, name: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            name: name.to_string(),
+            root_path: format!("/repos/{id}"),
+            default_branch: "main".to_string(),
+            created_at: String::new(),
+            last_opened_at: None,
+            sort_order: 0.0,
+        }
+    }
+
+    #[test]
+    fn worktree_path_is_host_derived_from_the_data_dir() {
+        let path = worktree_path(Path::new("/data"), "proj-1", "feat-x");
+        assert_eq!(path, Path::new("/data/projects/proj-1/worktrees/feat-x"));
+    }
+
+    /// The whole reason `data_dir` is a parameter: two hosts, two roots.
+    #[test]
+    fn a_different_data_dir_relocates_the_worktree() {
+        let serve = worktree_path(Path::new("/srv/oximux"), "proj-1", "feat-x");
+        let desktop = worktree_path(Path::new("/home/u/Library"), "proj-1", "feat-x");
+        assert_ne!(serve, desktop);
+        assert!(serve.starts_with("/srv/oximux"));
+    }
+
+    /// The host-derived locator IS `worktree_path`; extracting the trait
+    /// changed no path anywhere.
+    #[test]
+    fn the_host_derived_locator_mints_the_same_path_the_function_always_did() {
+        let locator = HostDerivedLocator::new(PathBuf::from("/data"));
+        assert_eq!(
+            locator.locate(&project("proj-1", "Api"), "feat-x").expect("locate"),
+            worktree_path(Path::new("/data"), "proj-1", "feat-x")
+        );
+    }
+
+    /// The invariant: reclaim answers for the minted path and nothing else.
+    #[test]
+    fn may_reclaim_is_true_for_the_minted_path_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let locator = HostDerivedLocator::new(tmp.path().to_path_buf());
+        let p = project("proj-1", "Api");
+        let minted = locator.locate(&p, "feat").expect("locate");
+        std::fs::create_dir_all(&minted).expect("mkdir minted");
+        let elsewhere = tmp.path().join("mine");
+        std::fs::create_dir_all(&elsewhere).expect("mkdir elsewhere");
+
+        assert!(locator.may_reclaim(&p, "feat", &minted));
+        assert!(!locator.may_reclaim(&p, "feat", &elsewhere), "a path we did not mint");
+        assert!(!locator.may_reclaim(&p, "other", &minted), "minted, but for another slug");
+        assert!(
+            !locator.may_reclaim(&project("proj-2", "Api"), "feat", &minted),
+            "minted, but for another project"
+        );
+    }
+
+    /// "Never when canonicalization of either side fails": a minted path that
+    /// is not on disk cannot be debris, and must not be reclaimed by a literal
+    /// compare that happens to match.
+    #[test]
+    fn may_reclaim_is_false_when_the_path_does_not_exist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let locator = HostDerivedLocator::new(tmp.path().to_path_buf());
+        let p = project("proj-1", "Api");
+        let minted = locator.locate(&p, "feat").expect("locate");
+        assert!(!minted.exists());
+        assert!(!locator.may_reclaim(&p, "feat", &minted));
+    }
+
+    #[test]
+    fn a_project_dir_is_the_slugified_name_when_unique() {
+        let api = project("11111111-aaaa", "API Service");
+        let web = project("22222222-bbbb", "Web");
+        assert_eq!(project_dir_name(&api, [&api, &web]), "api-service");
+    }
+
+    /// Two repositories both called `api` must not share a directory — and
+    /// both carry the tag, so the answer does not depend on which one the
+    /// caller listed first.
+    #[test]
+    fn same_named_projects_each_carry_a_piece_of_their_id() {
+        let a = project("3f9c2a1b-1111", "api");
+        let b = project("7e0d4c5f-2222", "Api");
+        let all = [&a, &b];
+        assert_eq!(project_dir_name(&a, all), "api-3f9c2a1b");
+        assert_eq!(project_dir_name(&b, all), "api-7e0d4c5f");
+        assert_ne!(project_dir_name(&a, all), project_dir_name(&b, all));
+    }
+
+    #[test]
+    fn a_project_does_not_clash_with_itself() {
+        let a = project("3f9c2a1b-1111", "api");
+        assert_eq!(project_dir_name(&a, [&a]), "api");
+    }
+
+    #[test]
+    fn a_root_inside_the_data_dir_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).expect("mkdir");
+        let err = validate_worktree_root(&data_dir.join("worktrees"), Some(&data_dir)).unwrap_err();
+        assert!(matches!(err, LocateError::InsideDataDir { .. }), "{err}");
+        let err = validate_worktree_root(&data_dir, Some(&data_dir)).unwrap_err();
+        assert!(matches!(err, LocateError::InsideDataDir { .. }), "equal counts too: {err}");
+    }
+
+    /// `/data-x` is not inside `/data`: component-wise, never a string prefix.
+    #[test]
+    fn a_sibling_that_shares_a_string_prefix_is_not_inside_the_data_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().join("data");
+        let sibling = tmp.path().join("data-worktrees");
+        std::fs::create_dir_all(&data_dir).expect("mkdir");
+        std::fs::create_dir_all(&sibling).expect("mkdir");
+        assert!(!sibling.starts_with(&data_dir));
+        assert!(validate_worktree_root(&sibling, Some(&data_dir)).is_ok());
+    }
+
+    /// The rule the default root can trip: a home that is itself a repository.
+    #[test]
+    fn a_root_inside_a_git_working_tree_is_refused_with_the_repository_named() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(home.join(".git")).expect("fake repo");
+        let data_dir = tmp.path().join("data");
+        // The root does not exist yet — judged from where it would be created.
+        let root = home.join("OxiMux").join("worktrees");
+        let err = validate_worktree_root(&root, Some(&data_dir)).unwrap_err();
+        match err {
+            LocateError::InsideRepository { repository, .. } => {
+                assert_eq!(repository, canonicalize_lenient(&home));
+            }
+            other => panic!("expected InsideRepository, got {other}"),
+        }
+    }
+
+    /// A linked worktree's `.git` is a file, and nesting under one is just as
+    /// wrong as nesting under a primary checkout.
+    #[test]
+    fn a_git_file_counts_as_a_working_tree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let linked = tmp.path().join("linked");
+        std::fs::create_dir_all(&linked).expect("mkdir");
+        std::fs::write(linked.join(".git"), "gitdir: /elsewhere/.git/worktrees/linked\n")
+            .expect("write");
+        let err = validate_worktree_root(&linked.join("wt"), Some(&tmp.path().join("data")))
+            .unwrap_err();
+        assert!(matches!(err, LocateError::InsideRepository { .. }), "{err}");
+    }
+
+    #[test]
+    fn a_plain_writable_directory_is_accepted_and_canonicalized() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("worktrees");
+        let ok = validate_worktree_root(&root, Some(&tmp.path().join("data"))).expect("valid");
+        assert_eq!(ok, canonicalize_lenient(&root));
+        assert!(!root.exists(), "validation must not create the root");
+        assert!(
+            std::fs::read_dir(tmp.path())
+                .expect("read")
+                .all(|e| !e.expect("entry").file_name().to_string_lossy().contains("probe")),
+            "the write probe must not be left behind"
+        );
+    }
+
+    /// A relative root would be judged against the process's working
+    /// directory, which for a GUI launch is `/` — so `wt` would validate as
+    /// writable-or-not against the wrong place entirely, and `~bob/wt` would
+    /// mean a directory literally called `~bob`.
+    #[test]
+    fn a_relative_root_is_refused_before_anything_is_touched() {
+        for rel in ["wt", "./wt", "~bob/wt"] {
+            let err = validate_worktree_root(Path::new(rel), None).unwrap_err();
+            assert!(matches!(err, LocateError::NotAbsolute { .. }), "{rel}: {err}");
+        }
+    }
+
+    #[test]
+    fn a_root_whose_anchor_is_a_file_is_not_writable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("a-file");
+        std::fs::write(&file, "x").expect("write");
+        let err = validate_worktree_root(&file.join("wt"), Some(&tmp.path().join("data")))
+            .unwrap_err();
+        assert!(matches!(err, LocateError::NotWritable { .. }), "{err}");
+    }
+
+    /// The shape check is what runs per keystroke; it must reach the same
+    /// verdicts as the full check for everything but writability, and touch
+    /// nothing.
+    #[test]
+    fn the_shape_check_agrees_with_the_full_check_and_writes_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("repo").join(".git")).expect("fake repo");
+        let data_dir = tmp.path().join("data");
+        let cases = [tmp.path().join("ok"), tmp.path().join("repo").join("wt"), data_dir.join("x")];
+        for root in &cases {
+            let shape = validate_worktree_root_shape(root, Some(&data_dir));
+            let full = validate_worktree_root(root, Some(&data_dir));
+            assert_eq!(shape, full, "{}", root.display());
+        }
+        // A file at the anchor is the one thing only the probe catches.
+        let file = tmp.path().join("a-file");
+        std::fs::write(&file, "x").expect("write");
+        assert!(validate_worktree_root_shape(&file.join("wt"), None).is_ok());
+        assert!(validate_worktree_root(&file.join("wt"), None).is_err());
+    }
+
+    /// Canonical, but never verbatim: on Windows `fs::canonicalize` answers
+    /// `\\?\C:\...`, which git refuses as a worktree path. On every platform
+    /// the answer must start the way the input's real location is spelled.
+    #[test]
+    fn canonicalize_lenient_never_yields_a_verbatim_prefix() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = canonicalize_lenient(tmp.path());
+        assert!(!real.to_string_lossy().starts_with(r"\\?\"), "{}", real.display());
+        assert_eq!(real, dunce::canonicalize(tmp.path()).expect("canon"));
+    }
+
+    #[test]
+    fn canonicalize_lenient_resolves_the_existing_head_and_keeps_the_tail() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = dunce::canonicalize(tmp.path()).expect("canon");
+        let want = real.join("not").join("yet");
+        assert_eq!(canonicalize_lenient(&tmp.path().join("not").join("yet")), want);
+    }
+}

--- a/crates/worktree-ops/src/service.rs
+++ b/crates/worktree-ops/src/service.rs
@@ -2,11 +2,16 @@
 //! implementation of remote-host's [`WorktreeService`] seam.
 //!
 //! Reuses the New-Worktree flow's own pieces rather than paralleling them: the
-//! same slug validation, the same host-derived path scheme
-//! ([`worktree_path`]), the same [`create_workspace_with_rollback`] (git
+//! same slug validation, the same [`create_workspace_with_rollback`] (git
 //! worktree + branch + DB row, with rollback on storage failure), and the same
 //! pre-remove cleanup script. A worktree the CLI creates is therefore exactly
 //! the row the desktop sidebar lists, and vice versa.
+//!
+//! **The path scheme here is host-derived, unconditionally.** This service
+//! constructs its own [`HostDerivedLocator`] and takes no locator from a
+//! caller, so a client names a project and a slug and never a location — the
+//! property the remote surface promises, kept even now that the desktop's own
+//! creates resolve a configured root.
 //!
 //! No view state anywhere: everything here is durable data plus git
 //! subprocesses, which is what lets `oximux serve` host it unchanged. The
@@ -23,23 +28,36 @@ use oximux_storage::{ProjectRepo, WorkspaceRepo};
 
 use crate::branch_name;
 use crate::{
-    CreateBase, CreateOutcome, Provision, create_workspace_with_rollback,
-    run_cleanup_before_remove, worktree_path,
+    CreateBase, CreateOutcome, HostDerivedLocator, Provision, WorktreeLocator,
+    create_workspace_with_rollback, run_cleanup_before_remove,
 };
 
 /// Manages worktrees against the same repos and path scheme the desktop uses.
 pub struct RepoWorktrees {
     projects: ProjectRepo,
     workspaces: WorkspaceRepo,
-    /// The root new worktrees are derived under. The desktop passes its app
-    /// data dir; `oximux serve` passes its `--data-dir`, so a server keeps its
-    /// worktrees under its own root.
+    /// The root new worktrees are derived under, and where `git.toml` is
+    /// read from. The desktop passes its app data dir; `oximux serve` passes
+    /// its `--data-dir`, so a server keeps its worktrees under its own root.
     data_dir: PathBuf,
+    /// Host-derived, built here from `data_dir` and nowhere else.
+    locator: HostDerivedLocator,
 }
 
 impl RepoWorktrees {
     pub fn new(projects: ProjectRepo, workspaces: WorkspaceRepo, data_dir: PathBuf) -> Self {
-        Self { projects, workspaces, data_dir }
+        let locator = HostDerivedLocator::new(data_dir.clone());
+        Self { projects, workspaces, data_dir, locator }
+    }
+
+    /// Where a create for `slug` in `project` lands. Host-derived by
+    /// construction; crate-visible so a test can pin that it stays so. The
+    /// `expect` is the contract: [`HostDerivedLocator::locate`] validates
+    /// nothing and cannot refuse.
+    pub(crate) fn target_path(&self, project: &oximux_core::Project, slug: &str) -> PathBuf {
+        self.locator
+            .locate(project, slug)
+            .expect("the host-derived locator validates nothing and cannot refuse")
     }
 
     /// Resolve a client-named project root against the host's own records.
@@ -152,7 +170,7 @@ impl WorktreeService for RepoWorktrees {
         }
         // Host-derived target: `<data_dir>/projects/<project_id>/worktrees/<slug>`
         // — the client never supplies a path.
-        let target = worktree_path(&self.data_dir, &project.id, slug);
+        let target = self.target_path(&project, slug);
         // Same branch name the desktop would mint for this slug: one resolver,
         // reading the same `git.toml`. A remote-created worktree that carried
         // the hardcoded `oximux/` prefix while the sidebar minted the
@@ -181,24 +199,22 @@ impl WorktreeService for RepoWorktrees {
             }
         };
         let outcome = create_workspace_with_rollback(
-            root,
-            &project.id,
+            &project,
             slug,
             slug,
             &create_base,
             &target,
+            // The locator that minted `target`, so an interrupted create's
+            // debris there is reclaimed on retry — the slug collision check
+            // above has already established no row claims it.
+            &self.locator,
             None,
             &self.workspaces,
             // Headless: no override (the project's `auto_setup` decides) and
             // nowhere to stream a transcript. A remote client asking for a
             // worktree gets the same provisioning the desktop does; it just
             // sees the outcome instead of watching it.
-            //
-            // Reclaim is on: `target` came from `worktree_path(&self.data_dir,
-            // ..)` a few lines up, and the slug collision check above has
-            // already established no row claims it.
             &Provision::default()
-                .reclaiming_orphans()
                 .freshening_default(git_settings.keep_default_up_to_date),
         )
         .await;
@@ -466,6 +482,36 @@ mod progress_tests {
         service.set_progress(&a, None, Some("shipped")).await.expect("set");
         let rows = service.list_progress(None).await.expect("list");
         assert_eq!(rows[0].phase, "shipped");
+    }
+}
+
+#[cfg(test)]
+mod locator_tests {
+    use super::*;
+    use oximux_storage::open_memory;
+
+    /// The remote surface's guarantee, pinned: whatever the desktop configures
+    /// for its own creates, a worktree created through this service lands
+    /// under the host's data directory. There is no constructor that takes a
+    /// locator, and this is the test that notices if one appears.
+    #[test]
+    fn the_service_locator_is_host_derived_and_ignores_any_configured_root() {
+        let db = open_memory().expect("db");
+        let projects = ProjectRepo::new(db.clone());
+        let workspaces = WorkspaceRepo::new(db);
+        let project = projects.insert("api", "/repos/api", "main").expect("project");
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        // A configured root the desktop would honour; the service must not.
+        std::fs::write(
+            data_dir.path().join(oximux_settings::git::GitSettings::FILE_NAME),
+            "worktree_dir = \"/somewhere/the/user/chose\"\n",
+        )
+        .expect("write git.toml");
+        let service = RepoWorktrees::new(projects, workspaces, data_dir.path().to_path_buf());
+        assert_eq!(
+            service.target_path(&project, "feat"),
+            crate::worktree_path(data_dir.path(), &project.id, "feat")
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 6 of the worktree feature plan: a `WorktreeLocator` seam so the desktop resolves worktree locations from a user-chosen, browsable root — `~/OxiMux/worktrees/<project>/<slug>` by default, or `worktree_dir` from `git.toml` — while the RPC surface (`oximux serve`, the desktop's own remote service) keeps the host-derived scheme under its data directory.

- **Seam** — `crates/worktree-ops/src/locator.rs`: `WorktreeLocator`, `HostDerivedLocator`, `LocateError`, root validation (relative / inside data dir / inside a git working tree / unwritable), same-name project disambiguation. Canonical paths via `dunce` (no `\\?\` on Windows).
- **Reclaim rule** — `create_workspace_with_rollback` takes the project and the locator that minted the path; the `reclaim_orphan` boolean is gone. Debris from an interrupted create is reclaimed only when the locator recognises the path as its own mint, the worktree's gitdir carries the `oximux-provisioning` mark (written after `worktree add`, cleared after the row insert), and no row names the path. The mark is what stops a *finished* worktree whose row vanished later (project removed and re-added; workspace archived) from being force-deleted.
- **Desktop** — rail and chat-pill creates both use `configured_locator::desktop_locator`; the chat's sibling `oximux-wt-<slug>` path is retired. A refused root is a toast or the chat's failure banner.
- **Settings** — the Git pane's worktree-directory field is live with Browse and per-keystroke validation; a refused text is never written.
- **Existing rows keep their paths.** Nothing is moved.

## Verification

- `cargo test -p oximux-worktree-ops`: 93 unit + integration suites green.
- `apps/desktop/tests/workspace_create_rollback.rs`: 24 passed, including the new configured-root cases (interrupted-create retry, a person's directory never reclaimed, a finished worktree without a row never reclaimed, an archived worktree never reclaimed, same-named projects not colliding).
- Desktop lib suite green; `RUSTFLAGS=-D warnings cargo clippy` clean on worktree-ops, settings, cli, app; `cargo check --workspace --tests` clean.
- Live-verified in a sandboxed dev instance: pane renders, refusal fires per keystroke, a custom root commits to `git.toml`, and a ⌘⇧N create lands at `<root>/liverepo/live-verify` with the row, the git worktree, and a cleared mark.

## Open questions

- The desktop's own RPC service stays host-derived per the plan, so `oximux worktree create` against a running desktop lands in Application Support while rail creates land under `~/OxiMux/worktrees`.
- Same-name disambiguation is point-in-time: adding a second project with the same name moves the first one's next mint to `<name>-<id>`; old rows keep their paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable worktree directory in Git settings, with path entry and folder browsing.
  * Displays live validation messages and previews where new worktrees will be created.
  * New worktrees are placed under the configured directory, grouped by project, with name-collision handling.
  * Empty directory settings use the default worktree location.

* **Bug Fixes**
  * Invalid worktree locations now show an error instead of failing silently.
  * Existing worktrees remain in their current locations when the setting changes.
  * Improved recovery of interrupted worktree creation while preventing unsafe reclamation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->