### PR TITLE
feat(worktree): make the row menu reachable on every row, primary included

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7868,6 +7868,7 @@ dependencies = [
  "tracing-subscriber",
  "two-face",
  "uuid",
+ "which 6.0.3",
  "widestring",
  "windows-sys 0.61.2",
  "wry",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -124,6 +124,11 @@ libc = "0.2"
 
 # Bringing the already-running instance forward: a registered broadcast message
 # and the foreground-right handoff that lets the holder honour it.
+# `Open in ▸` editor detection off-macOS walks PATH; macOS looks for app
+# bundles and never needs this.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+which = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 # Screen control, and the policing hook that is wider than it.
 #

--- a/apps/desktop/src/shell/left_rail/mod.rs
+++ b/apps/desktop/src/shell/left_rail/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod dashboard_status_menu;
 pub mod nav_section;
+pub mod open_in;
 pub mod options_menu;
 pub mod project_drag;
 pub mod project_group;

--- a/apps/desktop/src/shell/left_rail/open_in.rs
+++ b/apps/desktop/src/shell/left_rail/open_in.rs
@@ -1,0 +1,249 @@
+//! `Open in ▸` — hand a worktree directory to an external application.
+//!
+//! The list the submenu offers comes from `git.toml` (`[[open_in]]`), and when
+//! that is empty from a built-in list resolved here at menu-open time: the
+//! platform's file manager, plus whichever known editors are installed. Nothing
+//! is cached, so an editor installed after the app started shows up on the
+//! next right-click.
+//!
+//! **Binary resolution is the process environment's job, not this module's.**
+//! A Dock-launched app inherits launchd's four-directory `PATH`, under which
+//! `code` and `zed` do not exist — and `platform::login_path` repairs that
+//! once, at the top of `main`, for every `Command::new` in the process. This
+//! module spawns by name and lets that repair do its work; a second resolver
+//! here would be a second place for the rule to drift.
+
+use std::path::Path;
+
+use oximux_settings::OpenInApp;
+use oximux_settings::git::GitSettings;
+
+/// The apps the submenu should offer: the configured list, or the built-in
+/// one when nothing is configured.
+pub fn effective_apps(settings: &GitSettings) -> Vec<OpenInApp> {
+    if settings.open_in.is_empty() {
+        default_apps()
+    } else {
+        settings.open_in.clone()
+    }
+}
+
+/// The built-in list: the platform opener first, then the editors we can see.
+///
+/// On macOS an editor is "installed" when its bundle sits in `/Applications`
+/// or `~/Applications`, and it is launched through `open -a`, which needs no
+/// shell integration. Elsewhere an editor is offered when its command is on
+/// the (repaired) `PATH`.
+pub fn default_apps() -> Vec<OpenInApp> {
+    let mut apps = vec![platform_opener()];
+    apps.extend(installed_editors());
+    apps
+}
+
+/// The platform's file manager, always offered — a worktree the user cannot
+/// find on disk is the defect Phase 6 exists to close.
+fn platform_opener() -> OpenInApp {
+    #[cfg(target_os = "macos")]
+    {
+        OpenInApp { name: "Finder".into(), command: "open".into() }
+    }
+    #[cfg(windows)]
+    {
+        OpenInApp { name: "Explorer".into(), command: "explorer".into() }
+    }
+    #[cfg(not(any(target_os = "macos", windows)))]
+    {
+        OpenInApp { name: "File manager".into(), command: "xdg-open".into() }
+    }
+}
+
+/// Editors worth checking for, in menu order. Mirrors the editor header's
+/// own list so a file and a worktree open in the same set of apps.
+#[cfg(target_os = "macos")]
+const MAC_EDITORS: &[(&str, &str)] = &[
+    ("Cursor", "Cursor"),
+    ("VS Code", "Visual Studio Code"),
+    ("Windsurf", "Windsurf"),
+    ("Zed", "Zed"),
+];
+
+#[cfg(target_os = "macos")]
+fn installed_editors() -> Vec<OpenInApp> {
+    let mut roots = vec![std::path::PathBuf::from("/Applications")];
+    roots.extend(dirs::home_dir().map(|h| h.join("Applications")));
+    MAC_EDITORS
+        .iter()
+        .filter(|(_, bundle)| roots.iter().any(|r| r.join(format!("{bundle}.app")).exists()))
+        .map(|(name, bundle)| OpenInApp {
+            name: (*name).to_string(),
+            command: format!("open -a \"{bundle}\""),
+        })
+        .collect()
+}
+
+/// Editors reached by their CLI name off-macOS.
+#[cfg(not(target_os = "macos"))]
+const CLI_EDITORS: &[(&str, &str)] =
+    &[("Cursor", "cursor"), ("VS Code", "code"), ("Windsurf", "windsurf"), ("Zed", "zed")];
+
+/// The stored command is the path `which` found, not the bare name: on
+/// Windows `which` honours `PATHEXT` and matches `code.cmd`, which
+/// `std::process::Command` — resolving by appending `.exe` only — would then
+/// fail to start. Quoted, since an install path routinely contains spaces.
+#[cfg(not(target_os = "macos"))]
+fn installed_editors() -> Vec<OpenInApp> {
+    CLI_EDITORS
+        .iter()
+        .filter_map(|(name, bin)| {
+            let path = which::which(bin).ok()?;
+            Some(OpenInApp {
+                name: (*name).to_string(),
+                command: format!("\"{}\"", path.display()),
+            })
+        })
+        .collect()
+}
+
+/// Split a configured command into program + fixed arguments.
+///
+/// Whitespace-separated, with double quotes grouping an argument that
+/// contains spaces (`open -a "Visual Studio Code"`). No shell, so no
+/// expansion, no escapes beyond the quote pair. `None` when the command is
+/// blank, when a quote is left open, or when the program itself is empty
+/// (`""` or `" "` — a quoted nothing) — each is a setting the pane should
+/// have refused, and none can be launched.
+pub fn parse_command(command: &str) -> Option<(String, Vec<String>)> {
+    let mut words: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut quoted_word = false;
+    for ch in command.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                // An empty `""` is still a word; remember we saw quotes.
+                quoted_word = true;
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() || quoted_word {
+                    words.push(std::mem::take(&mut current));
+                    quoted_word = false;
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if in_quotes {
+        return None;
+    }
+    if !current.is_empty() || quoted_word {
+        words.push(current);
+    }
+    let mut it = words.into_iter();
+    let program = it.next()?;
+    if program.trim().is_empty() {
+        return None;
+    }
+    Some((program, it.collect()))
+}
+
+/// Launch `app` on `dir`. The directory is always the final argument.
+///
+/// Spawned, not waited on: the app is a long-lived editor or a file manager,
+/// and the row menu has already closed. The only failure surfaced is the
+/// spawn itself — an app that starts and then declines the directory is its
+/// own problem to report.
+pub fn launch(app: &OpenInApp, dir: &Path) -> Result<(), String> {
+    let (program, args) = parse_command(&app.command)
+        .ok_or_else(|| format!("\u{201c}{}\u{201d} has no launch command", app.name))?;
+    std::process::Command::new(&program)
+        .args(&args)
+        .arg(dir)
+        .spawn()
+        .map(drop)
+        .map_err(|err| format!("could not start {program}: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app(name: &str, command: &str) -> OpenInApp {
+        OpenInApp { name: name.into(), command: command.into() }
+    }
+
+    /// The whole point of the empty-means-built-in rule: a fresh install has
+    /// an `Open in` submenu without anyone visiting the settings pane.
+    #[test]
+    fn an_empty_configured_list_falls_back_to_the_built_in_one() {
+        let apps = effective_apps(&GitSettings::shipped());
+        assert!(!apps.is_empty(), "the platform opener is always offered");
+        assert_eq!(apps[0], platform_opener());
+    }
+
+    /// A configured list replaces the built-in one outright — it does not
+    /// merge — so removing an app in the pane removes it from the menu.
+    #[test]
+    fn a_configured_list_wins_and_is_not_merged() {
+        let settings = GitSettings { open_in: vec![app("Zed", "zed")], ..GitSettings::shipped() };
+        assert_eq!(effective_apps(&settings), vec![app("Zed", "zed")]);
+    }
+
+    #[test]
+    fn a_bare_program_has_no_arguments() {
+        assert_eq!(parse_command("code"), Some(("code".into(), vec![])));
+        assert_eq!(parse_command("  code  "), Some(("code".into(), vec![])));
+    }
+
+    /// The macOS default entries are written in exactly this shape, so this
+    /// is the case that must keep working.
+    #[test]
+    fn double_quotes_group_an_argument_with_spaces() {
+        assert_eq!(
+            parse_command("open -a \"Visual Studio Code\""),
+            Some(("open".into(), vec!["-a".into(), "Visual Studio Code".into()]))
+        );
+        // Quotes can sit inside a word too — a shell would accept this and
+        // so do we.
+        assert_eq!(
+            parse_command("open -a Visual\" \"Studio"),
+            Some(("open".into(), vec!["-a".into(), "Visual Studio".into()]))
+        );
+    }
+
+    #[test]
+    fn a_blank_or_unterminated_command_cannot_be_launched() {
+        assert_eq!(parse_command(""), None);
+        assert_eq!(parse_command("   "), None);
+        assert_eq!(parse_command("open -a \"Visual Studio"), None);
+    }
+
+    /// A quoted nothing is a word, and a word that is an empty program
+    /// would reach `Command::new("")`. Refused at the parser so the pane and
+    /// the launch path cannot disagree about it.
+    #[test]
+    fn a_quoted_empty_program_cannot_be_launched() {
+        assert_eq!(parse_command("\"\""), None);
+        assert_eq!(parse_command("\" \""), None);
+        assert_eq!(parse_command("\"\" -a Zed"), None);
+        // An empty *argument* is still fine — only the program must be real.
+        assert_eq!(parse_command("open \"\""), Some(("open".into(), vec![String::new()])));
+    }
+
+    /// An unlaunchable entry is refused with a reason that names the app the
+    /// user picked, not the empty string they never typed.
+    #[test]
+    fn launching_a_blank_command_names_the_app() {
+        let err = launch(&app("Broken", ""), Path::new("/tmp")).unwrap_err();
+        assert!(err.contains("Broken"), "{err}");
+    }
+
+    /// A program that does not exist fails at spawn, with the program named,
+    /// rather than panicking or silently succeeding.
+    #[test]
+    fn launching_a_missing_program_reports_the_program() {
+        let err = launch(&app("Nope", "oximux-no-such-program-4f2a"), Path::new("/tmp"))
+            .unwrap_err();
+        assert!(err.contains("oximux-no-such-program-4f2a"), "{err}");
+    }
+}

--- a/apps/desktop/src/shell/left_rail/open_in.rs
+++ b/apps/desktop/src/shell/left_rail/open_in.rs
@@ -68,17 +68,29 @@ const MAC_EDITORS: &[(&str, &str)] = &[
 ];
 
 #[cfg(target_os = "macos")]
+fn mac_editor(name: &str, bundle: &str) -> OpenInApp {
+    OpenInApp { name: name.to_string(), command: format!("open -a \"{bundle}\"") }
+}
+
+#[cfg(target_os = "macos")]
 fn installed_editors() -> Vec<OpenInApp> {
     let mut roots = vec![std::path::PathBuf::from("/Applications")];
     roots.extend(dirs::home_dir().map(|h| h.join("Applications")));
     MAC_EDITORS
         .iter()
         .filter(|(_, bundle)| roots.iter().any(|r| r.join(format!("{bundle}.app")).exists()))
-        .map(|(name, bundle)| OpenInApp {
-            name: (*name).to_string(),
-            command: format!("open -a \"{bundle}\""),
-        })
+        .map(|(name, bundle)| mac_editor(name, bundle))
         .collect()
+}
+
+/// Every editor this module knows how to launch, installed or not — the
+/// settings pane's preset picker, so adding one is a click rather than
+/// knowing that VS Code is `open -a "Visual Studio Code"`. The command is
+/// the platform's shape for that editor; whether it can actually start is
+/// for the click to find out, which is the same contract a typed command has.
+#[cfg(target_os = "macos")]
+pub fn presets() -> Vec<OpenInApp> {
+    MAC_EDITORS.iter().map(|(name, bundle)| mac_editor(name, bundle)).collect()
 }
 
 /// Editors reached by their CLI name off-macOS.
@@ -90,6 +102,16 @@ const CLI_EDITORS: &[(&str, &str)] =
 /// Windows `which` honours `PATHEXT` and matches `code.cmd`, which
 /// `std::process::Command` — resolving by appending `.exe` only — would then
 /// fail to start. Quoted, since an install path routinely contains spaces.
+/// See the macOS `presets`. Off-macOS the preset is the bare CLI name, which
+/// `launch` resolves through the repaired `PATH` like any typed command.
+#[cfg(not(target_os = "macos"))]
+pub fn presets() -> Vec<OpenInApp> {
+    CLI_EDITORS
+        .iter()
+        .map(|(name, bin)| OpenInApp { name: (*name).to_string(), command: (*bin).to_string() })
+        .collect()
+}
+
 #[cfg(not(target_os = "macos"))]
 fn installed_editors() -> Vec<OpenInApp> {
     CLI_EDITORS
@@ -187,6 +209,23 @@ mod tests {
     fn a_configured_list_wins_and_is_not_merged() {
         let settings = GitSettings { open_in: vec![app("Zed", "zed")], ..GitSettings::shipped() };
         assert_eq!(effective_apps(&settings), vec![app("Zed", "zed")]);
+    }
+
+    /// Every preset is launchable as written — the picker must never offer
+    /// a command the parser would refuse — and every detected editor is one
+    /// of the presets, so the two lists cannot drift apart.
+    #[test]
+    fn presets_parse_and_cover_every_detected_editor() {
+        let presets = presets();
+        assert!(!presets.is_empty());
+        for app in &presets {
+            assert!(parse_command(&app.command).is_some(), "{app:?}");
+            assert!(!app.name.is_empty());
+        }
+        let preset_names: Vec<&str> = presets.iter().map(|a| a.name.as_str()).collect();
+        for app in installed_editors() {
+            assert!(preset_names.contains(&app.name.as_str()), "{app:?} is not a preset");
+        }
     }
 
     #[test]

--- a/apps/desktop/src/shell/left_rail/open_in.rs
+++ b/apps/desktop/src/shell/left_rail/open_in.rs
@@ -19,13 +19,21 @@ use oximux_settings::OpenInApp;
 use oximux_settings::git::GitSettings;
 
 /// The apps the submenu should offer: the configured list, or the built-in
-/// one when nothing is configured.
+/// one when nothing usable is configured.
+///
+/// `git.toml` is meant to be hand-edited and `[[open_in]]` loads a missing
+/// key as an empty string, so a configured entry can have no name (a blank
+/// menu row) or no launchable command (a row that always fails). Those are
+/// dropped here rather than offered; a list that is nothing but those falls
+/// back to the built-in one, the same as an empty list.
 pub fn effective_apps(settings: &GitSettings) -> Vec<OpenInApp> {
-    if settings.open_in.is_empty() {
-        default_apps()
-    } else {
-        settings.open_in.clone()
-    }
+    let usable: Vec<OpenInApp> = settings
+        .open_in
+        .iter()
+        .filter(|app| !app.name.trim().is_empty() && parse_command(&app.command).is_some())
+        .cloned()
+        .collect();
+    if usable.is_empty() { default_apps() } else { usable }
 }
 
 /// The built-in list: the platform opener first, then the editors we can see.
@@ -226,6 +234,20 @@ mod tests {
         for app in installed_editors() {
             assert!(preset_names.contains(&app.name.as_str()), "{app:?} is not a preset");
         }
+    }
+
+    /// A hand-edited entry missing its name or command is dropped, not
+    /// offered; a list of nothing but those behaves like an empty list.
+    #[test]
+    fn unusable_configured_entries_are_dropped_and_an_all_unusable_list_falls_back() {
+        let settings = GitSettings {
+            open_in: vec![app("", "code"), app("Zed", "zed"), app("Broken", ""), app("Odd", "\"\"")],
+            ..GitSettings::shipped()
+        };
+        assert_eq!(effective_apps(&settings), vec![app("Zed", "zed")]);
+        let none_usable =
+            GitSettings { open_in: vec![app("", "code"), app("Broken", "")], ..GitSettings::shipped() };
+        assert_eq!(effective_apps(&none_usable), default_apps());
     }
 
     #[test]

--- a/apps/desktop/src/shell/left_rail/project_group.rs
+++ b/apps/desktop/src/shell/left_rail/project_group.rs
@@ -383,7 +383,10 @@ pub(crate) fn render_workspace_block(
         // The main worktree lives at the project root; that row is the
         // project's primary (the repo's main worktree). A primary
         // row with no branch is a non-git folder project → "Folder" badge.
-        let is_primary = workspace.worktree_path == project.root_path;
+        let is_primary = crate::shell::workspace::workspace_ops::is_primary_row(
+            &workspace,
+            &project.root_path,
+        );
         let is_folder = is_primary && workspace.branch.is_empty();
         let is_live = live_worktrees.contains(&workspace.worktree_path);
         // Combine the tracked session status with any live ambient reading
@@ -547,10 +550,7 @@ pub(crate) fn render_workspace_block(
             row_group,
             !active_agent_wrap,
             multi_agent,
-            crate::shell::left_rail::workspace_card::RowMenu {
-                show: !is_primary,
-                open: row_menu_open,
-            },
+            crate::shell::left_rail::workspace_card::RowMenu { open: row_menu_open },
             locate_glow_seq,
             drag_config,
             rename_config,

--- a/apps/desktop/src/shell/left_rail/row_menu.rs
+++ b/apps/desktop/src/shell/left_rail/row_menu.rs
@@ -3,16 +3,26 @@
 //! via a `WeakEntity` callback, mirroring the pattern established by the
 //! adapter / project pickers.
 //!
-//! Closed state is `workspace: None`. Open state pins the carried
-//! `Workspace` + screen-relative `(x, y)` anchor and renders the popover.
+//! Closed state is `open_for: None`. Open state pins the carried
+//! `Workspace`, its [`RowCapabilities`], and a screen-relative `(x, y)`
+//! anchor, and renders the popover.
+//!
+//! **What the menu offers is decided once, by a pure function.** [`menu_actions`]
+//! takes the row's capabilities and returns the action list, so the gating is
+//! a table of cases testable without a window — and so a primary row, which
+//! IS the project's checkout, is asserted never to be offered `Delete`,
+//! `Archive`, `Rename`, or `Merge`.
+
+use std::path::Path;
 
 use gpui::{
     Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Render,
-    Styled, WeakEntity, Window, div, px,
+    Styled, WeakEntity, Window, div, px, svg,
 };
-use oximux_core::Workspace;
-use oximux_settings::{Density, ScriptKind, Theme, Typography};
+use oximux_core::{Project, WorkPhase, Workspace};
+use oximux_settings::{Density, OpenInApp, ScriptKind, Theme, Typography};
 
+use crate::shell::left_rail::open_in;
 use crate::shell::pane_group::TabColor;
 use crate::workspace_root::WorkspaceRoot;
 
@@ -36,8 +46,34 @@ impl ScriptAvail {
     }
 }
 
-/// Width of the menu card.
-const MENU_WIDTH: f32 = 160.0;
+/// What a row can be asked to do. Derived once when the menu opens, consumed
+/// by [`menu_actions`] and by the handlers that need the row's project.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RowCapabilities {
+    /// The row's OWN project, resolved from `workspace.project_id` — never
+    /// the active one. The rail renders every project's workspaces at once,
+    /// and a handler that reached for the active project would run against
+    /// whichever repository happened to be selected. Every destructive
+    /// handler resolves the same way; this is the copy the menu labels and
+    /// the `New workspace here` action read.
+    pub project: Project,
+    /// The synthesized `primary:<project>` row — the project's main
+    /// checkout, which goes away with the project and never on its own.
+    pub is_primary: bool,
+    /// An archived row: restore-or-delete, plus the two ways of finding it.
+    pub is_archived: bool,
+    pub scripts: ScriptAvail,
+    /// Whether the project has a default branch to land the work in. The
+    /// builder still refuses a merge on a primary or archived row.
+    pub can_merge: bool,
+    /// The `Open in ▸` entries. Empty renders no submenu at all rather than
+    /// an empty one.
+    pub open_in: Vec<OpenInApp>,
+}
+
+/// Width of the menu card. Wider than the project menu's: `New workspace
+/// here` and `Merge into <branch>` are the longest labels in the rail.
+const MENU_WIDTH: f32 = 176.0;
 /// One row height. Intentionally 2px shorter than the global
 /// `density.h_overlay_item = 30` because the left-rail row menu sits
 /// inside an already-narrow rail and reads tighter at 28px. Document
@@ -45,6 +81,11 @@ const MENU_WIDTH: f32 = 160.0;
 const ROW_MENU_ITEM_H: f32 = 28.0;
 /// Horizontal padding inside each row.
 const ROW_PADDING_X: f32 = 10.0;
+/// Extra left inset for a submenu's entries, so they read as children of
+/// the header above them.
+const SUBMENU_INDENT: f32 = 12.0;
+/// The chevron / check glyph beside a submenu row.
+const GLYPH_SIZE: f32 = 12.0;
 /// Y offset below the trigger button so the menu doesn't visually overlap it.
 const ANCHOR_Y_OFFSET: f32 = 4.0;
 
@@ -54,11 +95,26 @@ pub enum WorkspaceRowAction {
     RunSetup,
     Run,
     RunCleanup,
+    /// Header of the `Open in ▸` submenu; expands rather than dispatching.
+    OpenIn,
+    CopyPath,
+    /// Header of the `Move to Status ▸` submenu; expands rather than
+    /// dispatching.
+    MoveToStatus,
+    /// Primary rows only: the project-group `+`, one right-click closer.
+    NewWorkspaceHere,
     Merge,
     Rename,
     Archive,
     Unarchive,
     Delete,
+}
+
+/// The two rows that expand in place instead of acting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Submenu {
+    OpenIn,
+    Status,
 }
 
 impl WorkspaceRowAction {
@@ -67,6 +123,10 @@ impl WorkspaceRowAction {
             Self::RunSetup => "Run setup",
             Self::Run => "Run",
             Self::RunCleanup => "Run cleanup",
+            Self::OpenIn => "Open in",
+            Self::CopyPath => "Copy Path",
+            Self::MoveToStatus => "Move to Status",
+            Self::NewWorkspaceHere => "New workspace here",
             // Never rendered: `Merge` is labelled with the real default-branch
             // name via `label_with`. A generic "Merge" would not say what it
             // merges into, which is the only thing the user needs to know
@@ -104,6 +164,15 @@ impl WorkspaceRowAction {
             _ => None,
         }
     }
+
+    /// The submenu this row opens, for the two that do.
+    fn submenu(self) -> Option<Submenu> {
+        match self {
+            Self::OpenIn => Some(Submenu::OpenIn),
+            Self::MoveToStatus => Some(Submenu::Status),
+            _ => None,
+        }
+    }
 }
 
 /// Script actions, in surface order. Filtered to the ones actually defined
@@ -114,7 +183,8 @@ const SCRIPT_ACTIONS: &[WorkspaceRowAction] = &[
     WorkspaceRowAction::RunCleanup,
 ];
 
-/// Always-present management actions, rendered below any script actions.
+/// Management actions on a live, non-primary row, rendered after the
+/// finding rows (`Open in`, `Copy Path`) and the status writer.
 const ACTIONS: &[WorkspaceRowAction] = &[
     WorkspaceRowAction::Merge,
     WorkspaceRowAction::Rename,
@@ -129,36 +199,64 @@ const ARCHIVED_ACTIONS: &[WorkspaceRowAction] =
 /// The menu's action list for one row, in surface order — the pure half of
 /// `Render`, so the gating is testable without a window.
 ///
-/// An archived row offers only `Unarchive` and `Delete`. Everything else is
-/// meaningless there: the `Run *` scripts and `Rename` act on a worktree the
-/// user cannot activate, `Archive` is a no-op on an already-archived row, and
-/// `Pin` / `Color` order and tag a row that does not appear in the live list.
-/// If triage later turns out to need one of them back, this gate is the only
-/// thing to widen.
-fn menu_actions(
-    is_archived: bool,
-    is_primary: bool,
-    avail: ScriptAvail,
-) -> Vec<WorkspaceRowAction> {
-    if is_archived {
-        return ARCHIVED_ACTIONS.to_vec();
+/// - A **primary** row is the project's main checkout. It gets only what is
+///   meaningful there: `Run setup`, the two finding rows, and `New workspace
+///   here`. Never `Rename`, `Archive`, `Delete`, or `Merge into` — each would
+///   act on the project itself. The `Run` and `Run cleanup` scripts are for
+///   a worktree's lifecycle, not the repo's, so they are withheld too.
+/// - An **archived** row offers the finding rows plus `Unarchive` and
+///   `Delete`. The `Run *` scripts and `Rename` act on a worktree the user
+///   cannot activate, `Archive` is a no-op there, and `Pin` / `Color` order
+///   and tag a row that does not appear in the live list.
+/// - A **live** row gets the defined scripts, the finding rows, the status
+///   writer, then the management actions.
+///
+/// `Open in` appears only when there is at least one app to offer.
+fn menu_actions(caps: &RowCapabilities) -> Vec<WorkspaceRowAction> {
+    let open_in = (!caps.open_in.is_empty()).then_some(WorkspaceRowAction::OpenIn);
+    let finding = open_in.into_iter().chain([WorkspaceRowAction::CopyPath]);
+
+    if caps.is_archived {
+        return finding.chain(ARCHIVED_ACTIONS.iter().copied()).collect();
     }
-    SCRIPT_ACTIONS
+
+    let scripts = SCRIPT_ACTIONS
         .iter()
         .copied()
-        .filter(|a| a.script_kind().is_some_and(|k| avail.has(k)))
+        .filter(|a| a.script_kind().is_some_and(|k| caps.scripts.has(k)))
+        // Only `Run setup` belongs on the project's own checkout.
+        .filter(|a| !caps.is_primary || *a == WorkspaceRowAction::RunSetup);
+
+    if caps.is_primary {
+        return scripts
+            .chain(finding)
+            .chain([WorkspaceRowAction::NewWorkspaceHere])
+            .collect();
+    }
+
+    scripts
+        .chain(finding)
+        .chain([WorkspaceRowAction::MoveToStatus])
         .chain(ACTIONS.iter().copied())
-        // A primary row IS the default branch's checkout. "Merge into main"
-        // on it would mean merging main into itself.
-        .filter(|a| !(is_primary && *a == WorkspaceRowAction::Merge))
+        .filter(|a| *a != WorkspaceRowAction::Merge || caps.can_merge)
         .collect()
 }
 
+/// The open menu: the row it is for, what that row can do, and where the
+/// card is anchored on screen.
+#[derive(Clone)]
+struct OpenState {
+    workspace: Workspace,
+    caps: RowCapabilities,
+    x: f32,
+    y: f32,
+}
+
 pub struct WorkspaceRowMenu {
-    /// `None` when closed; `Some` carries the target workspace, which
-    /// lifecycle scripts are defined for it, its project's default branch (the
-    /// `Merge into <x>` label), and the screen-pixel anchor.
-    open_for: Option<(Workspace, ScriptAvail, String, f32, f32)>,
+    /// `None` when closed.
+    open_for: Option<OpenState>,
+    /// Which submenu is expanded in place, if any. Reset on every open.
+    expanded: Option<Submenu>,
     weak_root: WeakEntity<WorkspaceRoot>,
     theme: Theme,
     density: Density,
@@ -174,6 +272,7 @@ impl WorkspaceRowMenu {
     ) -> Self {
         Self {
             open_for: None,
+            expanded: None,
             weak_root,
             theme,
             density,
@@ -185,25 +284,25 @@ impl WorkspaceRowMenu {
         self.open_for.is_some()
     }
 
-    /// Open the menu anchored at (x, y) for the given workspace. `avail`
-    /// is the set of lifecycle scripts defined for it (computed by the
-    /// caller from `.oximux/scripts.toml`); `default_branch` names the branch
-    /// the `Merge into <x>` row would land the work in.
+    /// Open the menu anchored at (x, y) for the given workspace. `caps` is
+    /// computed by the caller — it loads the lifecycle scripts, resolves the
+    /// row's project, and reads the `Open in` list.
     pub fn open(
         &mut self,
         workspace: Workspace,
-        avail: ScriptAvail,
-        default_branch: String,
+        caps: RowCapabilities,
         x: f32,
         y: f32,
         cx: &mut Context<Self>,
     ) {
-        self.open_for = Some((workspace, avail, default_branch, x, y + ANCHOR_Y_OFFSET));
+        self.open_for = Some(OpenState { workspace, caps, x, y: y + ANCHOR_Y_OFFSET });
+        self.expanded = None;
         cx.notify();
     }
 
     pub fn close(&mut self, cx: &mut Context<Self>) {
         self.open_for = None;
+        self.expanded = None;
         self.release_trigger_tooltip(cx);
         cx.notify();
     }
@@ -236,15 +335,20 @@ impl WorkspaceRowMenu {
     }
 
     fn dispatch(&self, action: WorkspaceRowAction, window: &mut Window, cx: &mut gpui::App) {
-        let Some((workspace, ..)) = self.open_for.clone() else {
+        let Some(state) = self.open_for.clone() else {
             return;
         };
+        let workspace = state.workspace;
         let _ = self.weak_root.update(cx, |root, cx| {
             if let Some(kind) = action.script_kind() {
                 root.run_workspace_script(workspace, kind, window, cx);
                 return;
             }
             match action {
+                WorkspaceRowAction::CopyPath => root.copy_workspace_path(&workspace, cx),
+                WorkspaceRowAction::NewWorkspaceHere => {
+                    root.new_workspace_in_project(state.caps.project, window, cx)
+                }
                 WorkspaceRowAction::Merge => {
                     root.merge_workspace_into_default(workspace, window, cx)
                 }
@@ -252,12 +356,173 @@ impl WorkspaceRowMenu {
                 WorkspaceRowAction::Archive => root.archive_workspace(workspace, cx),
                 WorkspaceRowAction::Unarchive => root.unarchive_workspace(workspace, cx),
                 WorkspaceRowAction::Delete => root.request_delete_workspace(workspace, window, cx),
-                // Script actions handled above.
+                // Script actions handled above; submenu headers expand in
+                // place (`toggle_submenu`) and never reach here.
                 WorkspaceRowAction::RunSetup
                 | WorkspaceRowAction::Run
-                | WorkspaceRowAction::RunCleanup => {}
+                | WorkspaceRowAction::RunCleanup
+                | WorkspaceRowAction::OpenIn
+                | WorkspaceRowAction::MoveToStatus => {}
             }
         });
+    }
+
+    fn toggle_submenu(&mut self, which: Submenu, cx: &mut Context<Self>) {
+        self.expanded = if self.expanded == Some(which) { None } else { Some(which) };
+        cx.notify();
+    }
+
+    /// Hand the worktree directory to `app`. A spawn failure is the one
+    /// thing worth telling the user about — the app is gone from the menu's
+    /// point of view the moment it starts.
+    fn dispatch_open_in(&self, app: &OpenInApp, cx: &mut gpui::App) {
+        let Some(state) = self.open_for.as_ref() else {
+            return;
+        };
+        if let Err(reason) = open_in::launch(app, Path::new(&state.workspace.worktree_path)) {
+            tracing::warn!(app = %app.name, %reason, "open in: launch failed");
+            let _ = self.weak_root.update(cx, |root, cx| {
+                root.push_toast(
+                    crate::shell::toast::ToastKind::Error,
+                    format!("Open in {}: {reason}", app.name),
+                    cx,
+                );
+            });
+        }
+    }
+
+    fn dispatch_phase(&self, phase: Option<WorkPhase>, cx: &mut gpui::App) {
+        let Some(state) = self.open_for.as_ref() else {
+            return;
+        };
+        let id = state.workspace.id.clone();
+        let _ = self
+            .weak_root
+            .update(cx, |root, cx| root.set_workspace_phase(&id, phase, cx));
+    }
+
+    /// One plain menu row: label, hover fill, and the given click handler.
+    fn menu_row(
+        &self,
+        id: impl Into<gpui::ElementId>,
+        indent: f32,
+        fg: gpui::Hsla,
+    ) -> gpui::Stateful<gpui::Div> {
+        let theme = self.theme;
+        div()
+            .id(id)
+            .flex()
+            .flex_row()
+            .items_center()
+            .h(px(ROW_MENU_ITEM_H))
+            .pl(px(ROW_PADDING_X + indent))
+            .pr(px(ROW_PADDING_X))
+            .rounded(px(self.density.r_xs))
+            .cursor_pointer()
+            .hover(move |s| s.bg(theme.hover_overlay))
+            .text_size(px(self.typography.t_body_md))
+            .text_color(fg)
+    }
+
+    /// A submenu header: the label with a chevron that points right when
+    /// collapsed and down when expanded. Clicking toggles the expansion —
+    /// in place, under the header, rather than as a flyout: a flyout has to
+    /// survive the pointer crossing the gap to reach it, and the rail is
+    /// narrow enough that the gap is where the pointer usually goes.
+    fn render_submenu_header(
+        &self,
+        ix: usize,
+        action: WorkspaceRowAction,
+        which: Submenu,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let theme = self.theme;
+        let expanded = self.expanded == Some(which);
+        let chevron = if expanded { "icons/chevron-down.svg" } else { "icons/chevron-right.svg" };
+        self.menu_row(("row-menu-item", ix), 0.0, theme.fg_base)
+            .justify_between()
+            .child(action.label())
+            .child(
+                svg()
+                    .path(chevron)
+                    .size(px(GLYPH_SIZE))
+                    .text_color(theme.fg_muted)
+                    .flex_shrink_0(),
+            )
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                    this.toggle_submenu(which, cx);
+                }),
+            )
+            .into_any_element()
+    }
+
+    /// The `Open in ▸` entries: one row per app, in list order.
+    fn render_open_in_entries(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
+        let Some(state) = self.open_for.as_ref() else {
+            return Vec::new();
+        };
+        state
+            .caps
+            .open_in
+            .iter()
+            .enumerate()
+            .map(|(ix, app)| {
+                let app = app.clone();
+                self.menu_row(("row-menu-open-in", ix), SUBMENU_INDENT, self.theme.fg_base)
+                    .child(app.name.clone())
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                            this.dispatch_open_in(&app, cx);
+                            this.close(cx);
+                        }),
+                    )
+                    .into_any_element()
+            })
+            .collect()
+    }
+
+    /// The `Move to Status ▸` entries: `Clear` then every phase in the order
+    /// work moves through them, with a check on the row's current value.
+    /// `Clear` carries the check when no phase is set — the choice is
+    /// radio-style, and "none" is one of the choices.
+    fn render_status_entries(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
+        let Some(state) = self.open_for.as_ref() else {
+            return Vec::new();
+        };
+        let current = WorkPhase::parse(&state.workspace.phase);
+        let theme = self.theme;
+        let choices = std::iter::once((None, "Clear"))
+            .chain(WorkPhase::ALL.iter().map(|p| (Some(*p), p.label())));
+        choices
+            .enumerate()
+            .map(|(ix, (phase, label))| {
+                let checked = phase == current;
+                let mut row = self
+                    .menu_row(("row-menu-status", ix), SUBMENU_INDENT, theme.fg_base)
+                    .justify_between()
+                    .child(label);
+                if checked {
+                    row = row.child(
+                        svg()
+                            .path("icons/check.svg")
+                            .size(px(GLYPH_SIZE))
+                            .text_color(theme.fg_base)
+                            .flex_shrink_0(),
+                    );
+                }
+                row.on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _: &MouseDownEvent, _window, cx| {
+                        this.dispatch_phase(phase, cx);
+                        this.close(cx);
+                    }),
+                )
+                .into_any_element()
+            })
+            .collect()
     }
 
     /// A single Pin / Unpin row. The label reflects the workspace's current
@@ -265,27 +530,16 @@ impl WorkspaceRowMenu {
     /// project group in every sort mode. Synthesized primary rows are omitted
     /// (the primary already anchors first).
     fn render_pin_row(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
-        let Some((workspace, ..)) = self.open_for.clone() else {
+        let Some(state) = self.open_for.clone() else {
             return div().into_any_element();
         };
         // Pinning orders a row within the live list; an archived row is not in it.
-        if workspace.id.starts_with("primary:") || workspace.archived_at.is_some() {
+        if state.caps.is_primary || state.caps.is_archived {
             return div().into_any_element();
         }
-        let theme = self.theme;
+        let workspace = state.workspace;
         let label = if workspace.pinned { "Unpin" } else { "Pin" };
-        div()
-            .id("row-menu-pin")
-            .flex()
-            .flex_row()
-            .items_center()
-            .h(px(ROW_MENU_ITEM_H))
-            .px(px(ROW_PADDING_X))
-            .rounded(px(self.density.r_xs))
-            .cursor_pointer()
-            .hover(|s| s.bg(theme.hover_overlay))
-            .text_size(px(self.typography.t_body_md))
-            .text_color(theme.fg_base)
+        self.menu_row("row-menu-pin", 0.0, self.theme.fg_base)
             .child(label)
             .on_mouse_down(
                 MouseButton::Left,
@@ -305,15 +559,16 @@ impl WorkspaceRowMenu {
     /// `set_workspace_tint` and closes the menu. The current tint gets a
     /// contrasting ring.
     fn render_color_row(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
-        let Some((workspace, ..)) = self.open_for.clone() else {
+        let Some(state) = self.open_for.clone() else {
             return div().into_any_element();
         };
         // Synthesized "primary:<proj>" rows aren't real workspace rows — tinting
         // them would no-op against the DB, so omit the picker entirely. Archived
         // rows are omitted too: the hue tags a row in the live list.
-        if workspace.id.starts_with("primary:") || workspace.archived_at.is_some() {
+        if state.caps.is_primary || state.caps.is_archived {
             return div().into_any_element();
         }
+        let workspace = state.workspace;
         let theme = self.theme;
         let current = workspace.tint.as_deref().and_then(TabColor::from_slug);
         let id = workspace.id.clone();
@@ -383,21 +638,14 @@ impl WorkspaceRowMenu {
 impl Render for WorkspaceRowMenu {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         oximux_settings::appearance::sync(&mut self.theme, &mut self.density, &mut self.typography, cx);
-        let Some((workspace, avail, default_branch, x, y)) = self.open_for.clone() else {
+        let Some(state) = self.open_for.clone() else {
             return div().into_any_element();
         };
         let theme = self.theme;
         let density = self.density;
-        let typography = self.typography.clone();
-
-        // Surface only the script rows that are actually defined for this
-        // workspace, followed by the always-present management actions — or,
-        // on an archived row, the reduced pair. See `menu_actions`.
-        let actions = menu_actions(
-            workspace.archived_at.is_some(),
-            workspace.id.starts_with("primary:"),
-            avail,
-        );
+        let default_branch = state.caps.project.default_branch.clone();
+        let actions = menu_actions(&state.caps);
+        let (x, y) = (state.x, state.y);
 
         let mut card = div()
             .flex()
@@ -414,23 +662,24 @@ impl Render for WorkspaceRowMenu {
         card = card.child(self.render_pin_row(cx));
 
         for (ix, &action) in actions.iter().enumerate() {
+            if let Some(which) = action.submenu() {
+                card = card.child(self.render_submenu_header(ix, action, which, cx));
+                if self.expanded == Some(which) {
+                    let entries = match which {
+                        Submenu::OpenIn => self.render_open_in_entries(cx),
+                        Submenu::Status => self.render_status_entries(cx),
+                    };
+                    card = card.children(entries);
+                }
+                continue;
+            }
             let fg = if action.is_destructive() {
                 theme.status_error
             } else {
                 theme.fg_base
             };
-            let row = div()
-                .id(("row-menu-item", ix))
-                .flex()
-                .flex_row()
-                .items_center()
-                .h(px(ROW_MENU_ITEM_H))
-                .px(px(ROW_PADDING_X))
-                .rounded(px(density.r_xs))
-                .cursor_pointer()
-                .hover(|s| s.bg(theme.hover_overlay))
-                .text_size(px(typography.t_body_md))
-                .text_color(fg)
+            let row = self
+                .menu_row(("row-menu-item", ix), 0.0, fg)
                 .child(action.label_with(&default_branch))
                 .on_mouse_down(
                     MouseButton::Left,
@@ -468,87 +717,218 @@ impl Render for WorkspaceRowMenu {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use WorkspaceRowAction as A;
+
+    fn project(default_branch: &str) -> Project {
+        Project {
+            id: "proj-1".into(),
+            name: "repo".into(),
+            root_path: "/tmp/repo".into(),
+            default_branch: default_branch.into(),
+            created_at: String::new(),
+            last_opened_at: None,
+            sort_order: 0.0,
+        }
+    }
+
+    fn one_app() -> Vec<OpenInApp> {
+        vec![OpenInApp { name: "Finder".into(), command: "open".into() }]
+    }
+
+    const ALL_SCRIPTS: ScriptAvail = ScriptAvail { setup: true, run: true, cleanup: true };
+
+    /// A row that can never be offered on a primary row — it would act on
+    /// the project's own checkout.
+    fn acts_on_the_worktree_itself(a: A) -> bool {
+        matches!(a, A::Merge | A::Rename | A::Archive | A::Unarchive | A::Delete)
+    }
+
+    /// A live, mergeable row with every script defined and one app.
+    fn live() -> RowCapabilities {
+        RowCapabilities {
+            project: project("main"),
+            is_primary: false,
+            is_archived: false,
+            scripts: ALL_SCRIPTS,
+            can_merge: true,
+            open_in: one_app(),
+        }
+    }
+
+    fn primary() -> RowCapabilities {
+        RowCapabilities { is_primary: true, ..live() }
+    }
+
+    fn archived() -> RowCapabilities {
+        RowCapabilities { is_archived: true, ..live() }
+    }
+
+    // ── the case table ──────────────────────────────────────────────────────
+
+    /// The guard this phase exists for: a primary row IS the project's
+    /// checkout, and the exact list — not merely "non-empty" — is what keeps
+    /// a future action from reaching it by accident.
+    #[test]
+    fn a_primary_row_offers_exactly_setup_open_in_copy_path_and_new_workspace() {
+        assert_eq!(
+            menu_actions(&primary()),
+            vec![A::RunSetup, A::OpenIn, A::CopyPath, A::NewWorkspaceHere],
+        );
+    }
 
     #[test]
-    fn destructive_flag_only_for_delete() {
-        assert!(!WorkspaceRowAction::Rename.is_destructive());
-        assert!(!WorkspaceRowAction::Archive.is_destructive());
-        assert!(WorkspaceRowAction::Delete.is_destructive());
+    fn a_primary_row_is_never_offered_a_worktree_action() {
+        for caps in [
+            primary(),
+            RowCapabilities { scripts: ScriptAvail::default(), ..primary() },
+            RowCapabilities { open_in: Vec::new(), ..primary() },
+            RowCapabilities { can_merge: false, ..primary() },
+        ] {
+            let actions = menu_actions(&caps);
+            assert!(
+                actions.iter().all(|a| !acts_on_the_worktree_itself(*a)),
+                "{actions:?}"
+            );
+            assert!(!actions.contains(&A::MoveToStatus), "{actions:?}");
+            assert!(!actions.is_empty(), "every row has at least Copy Path");
+        }
+    }
+
+    /// `Run` and `Run cleanup` describe a worktree's lifecycle. The repo's
+    /// own checkout gets `Run setup` only.
+    #[test]
+    fn a_primary_row_withholds_run_and_cleanup_even_when_defined() {
+        let actions = menu_actions(&primary());
+        assert!(actions.contains(&A::RunSetup));
+        assert!(!actions.contains(&A::Run));
+        assert!(!actions.contains(&A::RunCleanup));
+    }
+
+    #[test]
+    fn a_live_row_offers_scripts_finding_status_then_management() {
+        assert_eq!(
+            menu_actions(&live()),
+            vec![
+                A::RunSetup,
+                A::Run,
+                A::RunCleanup,
+                A::OpenIn,
+                A::CopyPath,
+                A::MoveToStatus,
+                A::Merge,
+                A::Rename,
+                A::Archive,
+                A::Delete,
+            ],
+        );
+    }
+
+    #[test]
+    fn a_live_row_without_scripts_or_apps_keeps_copy_path_status_and_management() {
+        let caps = RowCapabilities { scripts: ScriptAvail::default(), open_in: Vec::new(), ..live() };
+        assert_eq!(
+            menu_actions(&caps),
+            vec![A::CopyPath, A::MoveToStatus, A::Merge, A::Rename, A::Archive, A::Delete],
+        );
+    }
+
+    #[test]
+    fn scripts_surface_only_when_defined() {
+        let caps = RowCapabilities {
+            scripts: ScriptAvail { setup: true, run: false, cleanup: true },
+            ..live()
+        };
+        let actions = menu_actions(&caps);
+        assert_eq!(&actions[..2], &[A::RunSetup, A::RunCleanup]);
+        assert!(!actions.contains(&A::Run));
+    }
+
+    /// An archived row is restore-or-delete, plus the two ways of finding
+    /// the directory `Archive` deliberately left on disk.
+    #[test]
+    fn an_archived_row_offers_finding_rows_then_unarchive_and_delete() {
+        assert_eq!(
+            menu_actions(&archived()),
+            vec![A::OpenIn, A::CopyPath, A::Unarchive, A::Delete],
+        );
+        // The reduction does not depend on which scripts happen to be defined.
+        let no_scripts = RowCapabilities { scripts: ScriptAvail::default(), ..archived() };
+        assert_eq!(menu_actions(&no_scripts), menu_actions(&archived()));
+        // Nor on the primary flag, which an archived row cannot carry anyway.
+        let odd = RowCapabilities { is_primary: true, ..archived() };
+        assert_eq!(menu_actions(&odd), menu_actions(&archived()));
+    }
+
+    #[test]
+    fn merge_is_offered_only_when_the_row_can_merge() {
+        assert!(menu_actions(&live()).contains(&A::Merge));
+        let no_default = RowCapabilities { can_merge: false, ..live() };
+        assert_eq!(
+            menu_actions(&no_default),
+            vec![
+                A::RunSetup,
+                A::Run,
+                A::RunCleanup,
+                A::OpenIn,
+                A::CopyPath,
+                A::MoveToStatus,
+                A::Rename,
+                A::Archive,
+                A::Delete,
+            ],
+            "the merge gate must remove ONLY the merge row"
+        );
+    }
+
+    /// The gate that keeps an empty `Open in ▸` from rendering: no apps, no
+    /// header. Every row kind honours it.
+    #[test]
+    fn an_empty_app_list_renders_no_open_in_row() {
+        for caps in [live(), primary(), archived()] {
+            let caps = RowCapabilities { open_in: Vec::new(), ..caps };
+            assert!(!menu_actions(&caps).contains(&A::OpenIn), "{caps:?}");
+        }
+    }
+
+    #[test]
+    fn copy_path_is_on_every_row_kind() {
+        for caps in [live(), primary(), archived()] {
+            assert!(menu_actions(&caps).contains(&A::CopyPath), "{caps:?}");
+        }
+    }
+
+    // ── per-action properties ───────────────────────────────────────────────
+
+    #[test]
+    fn only_delete_is_destructive() {
+        for a in [
+            A::RunSetup,
+            A::Run,
+            A::RunCleanup,
+            A::OpenIn,
+            A::CopyPath,
+            A::MoveToStatus,
+            A::NewWorkspaceHere,
+            A::Merge,
+            A::Rename,
+            A::Archive,
+            A::Unarchive,
+        ] {
+            assert!(!a.is_destructive(), "{a:?}");
+        }
+        assert!(A::Delete.is_destructive());
     }
 
     #[test]
     fn labels_are_human_readable() {
-        assert_eq!(WorkspaceRowAction::Rename.label(), "Rename");
-        assert_eq!(WorkspaceRowAction::Archive.label(), "Archive");
-        assert_eq!(WorkspaceRowAction::Delete.label(), "Delete");
-    }
-
-    /// An archived row is restore-or-delete and nothing else — the gate that
-    /// keeps `Rename` and the lifecycle scripts off a worktree the user cannot
-    /// activate.
-    #[test]
-    fn archived_row_offers_only_unarchive_and_delete() {
-        let all_scripts = ScriptAvail {
-            setup: true,
-            run: true,
-            cleanup: true,
-        };
-        assert_eq!(
-            menu_actions(true, false, all_scripts),
-            vec![WorkspaceRowAction::Unarchive, WorkspaceRowAction::Delete],
-        );
-        // The reduction does not depend on which scripts happen to be defined.
-        assert_eq!(
-            menu_actions(true, false, ScriptAvail::default()),
-            menu_actions(true, false, all_scripts),
-        );
-    }
-
-    /// The archived gate must not change what a live row offers.
-    #[test]
-    fn active_row_keeps_defined_scripts_then_management_actions() {
-        let avail = ScriptAvail {
-            setup: true,
-            run: false,
-            cleanup: true,
-        };
-        assert_eq!(
-            menu_actions(false, false, avail),
-            vec![
-                WorkspaceRowAction::RunSetup,
-                WorkspaceRowAction::RunCleanup,
-                WorkspaceRowAction::Merge,
-                WorkspaceRowAction::Rename,
-                WorkspaceRowAction::Archive,
-                WorkspaceRowAction::Delete,
-            ],
-        );
-        // No scripts defined → management actions only.
-        assert_eq!(
-            menu_actions(false, false, ScriptAvail::default()),
-            ACTIONS.to_vec(),
-        );
-    }
-
-    /// `Unarchive` restores; it must never be painted in the destructive colour.
-    #[test]
-    fn unarchive_is_not_destructive() {
-        assert!(!WorkspaceRowAction::Unarchive.is_destructive());
-        assert!(WorkspaceRowAction::Unarchive.script_kind().is_none());
-        assert_eq!(WorkspaceRowAction::Unarchive.label(), "Unarchive");
-    }
-
-    #[test]
-    fn action_list_order_is_merge_rename_archive_delete() {
-        assert_eq!(
-            ACTIONS,
-            &[
-                WorkspaceRowAction::Merge,
-                WorkspaceRowAction::Rename,
-                WorkspaceRowAction::Archive,
-                WorkspaceRowAction::Delete,
-            ]
-        );
+        assert_eq!(A::Rename.label(), "Rename");
+        assert_eq!(A::Archive.label(), "Archive");
+        assert_eq!(A::Delete.label(), "Delete");
+        assert_eq!(A::Unarchive.label(), "Unarchive");
+        assert_eq!(A::CopyPath.label(), "Copy Path");
+        assert_eq!(A::OpenIn.label(), "Open in");
+        assert_eq!(A::MoveToStatus.label(), "Move to Status");
+        assert_eq!(A::NewWorkspaceHere.label(), "New workspace here");
     }
 
     /// The label has to name the branch. "Merge" alone leaves "into what?"
@@ -556,101 +936,124 @@ mod tests {
     /// only thing worth checking before clicking.
     #[test]
     fn the_merge_row_is_labelled_with_the_real_default_branch() {
-        assert_eq!(
-            WorkspaceRowAction::Merge.label_with("main"),
-            "Merge into main"
-        );
-        assert_eq!(
-            WorkspaceRowAction::Merge.label_with("develop"),
-            "Merge into develop"
-        );
+        assert_eq!(A::Merge.label_with("main"), "Merge into main");
+        assert_eq!(A::Merge.label_with("develop"), "Merge into develop");
         // Every other row ignores it.
-        assert_eq!(WorkspaceRowAction::Rename.label_with("main"), "Rename");
-        assert_eq!(WorkspaceRowAction::Delete.label_with("develop"), "Delete");
+        assert_eq!(A::Rename.label_with("main"), "Rename");
+        assert_eq!(A::Delete.label_with("develop"), "Delete");
     }
 
-    /// A primary row IS the default branch's checkout, so "Merge into main"
-    /// there would mean merging main into itself.
     #[test]
-    fn a_primary_row_is_not_offered_a_merge() {
-        let actions = menu_actions(false, true, ScriptAvail::default());
-        assert!(!actions.contains(&WorkspaceRowAction::Merge), "{actions:?}");
-        assert_eq!(
-            actions,
-            vec![
-                WorkspaceRowAction::Rename,
-                WorkspaceRowAction::Archive,
-                WorkspaceRowAction::Delete,
-            ],
-            "the primary gate must remove ONLY the merge row"
-        );
-    }
-
-    /// An archived row's reduced pair has no merge either, and gets there by a
-    /// different gate — assert it rather than assuming the two agree.
-    #[test]
-    fn an_archived_row_is_not_offered_a_merge() {
-        for primary in [false, true] {
-            let actions = menu_actions(true, primary, ScriptAvail::default());
-            assert!(!actions.contains(&WorkspaceRowAction::Merge));
+    fn exactly_the_two_headers_open_a_submenu() {
+        assert_eq!(A::OpenIn.submenu(), Some(Submenu::OpenIn));
+        assert_eq!(A::MoveToStatus.submenu(), Some(Submenu::Status));
+        for a in [A::CopyPath, A::NewWorkspaceHere, A::Merge, A::Rename, A::Delete, A::RunSetup] {
+            assert_eq!(a.submenu(), None, "{a:?}");
         }
-    }
-
-    /// Landing a branch is consequential but not destructive — it must not
-    /// paint in the delete colour.
-    #[test]
-    fn merge_is_not_destructive_and_runs_no_script() {
-        assert!(!WorkspaceRowAction::Merge.is_destructive());
-        assert!(WorkspaceRowAction::Merge.script_kind().is_none());
     }
 
     #[test]
     fn script_actions_map_to_their_kind() {
-        assert_eq!(
-            WorkspaceRowAction::RunSetup.script_kind(),
-            Some(ScriptKind::Setup)
-        );
-        assert_eq!(WorkspaceRowAction::Run.script_kind(), Some(ScriptKind::Run));
-        assert_eq!(
-            WorkspaceRowAction::RunCleanup.script_kind(),
-            Some(ScriptKind::Cleanup)
-        );
-        assert_eq!(WorkspaceRowAction::Rename.script_kind(), None);
-        assert_eq!(WorkspaceRowAction::Delete.script_kind(), None);
+        assert_eq!(A::RunSetup.script_kind(), Some(ScriptKind::Setup));
+        assert_eq!(A::Run.script_kind(), Some(ScriptKind::Run));
+        assert_eq!(A::RunCleanup.script_kind(), Some(ScriptKind::Cleanup));
+        for a in [A::Rename, A::Delete, A::Merge, A::CopyPath, A::OpenIn, A::MoveToStatus] {
+            assert_eq!(a.script_kind(), None, "{a:?}");
+        }
     }
 
     #[test]
-    fn script_actions_are_not_destructive() {
-        assert!(!WorkspaceRowAction::RunSetup.is_destructive());
-        assert!(!WorkspaceRowAction::Run.is_destructive());
-        assert!(!WorkspaceRowAction::RunCleanup.is_destructive());
+    fn action_list_order_is_merge_rename_archive_delete() {
+        assert_eq!(ACTIONS, &[A::Merge, A::Rename, A::Archive, A::Delete]);
     }
 
+    /// The status writer offers the closed vocabulary in the order work moves
+    /// through it — the same `WorkPhase::ALL` the CLI validates against, so
+    /// there is no second list to drift.
     #[test]
-    fn avail_filters_to_defined_scripts_only() {
-        let avail = ScriptAvail {
-            setup: true,
-            run: false,
-            cleanup: true,
-        };
-        let surfaced: Vec<WorkspaceRowAction> = SCRIPT_ACTIONS
-            .iter()
-            .copied()
-            .filter(|a| a.script_kind().is_some_and(|k| avail.has(k)))
+    fn the_status_submenu_is_clear_then_every_phase_in_order() {
+        let labels: Vec<&str> = std::iter::once("Clear")
+            .chain(WorkPhase::ALL.iter().map(|p| p.label()))
             .collect();
-        assert_eq!(
-            surfaced,
-            vec![WorkspaceRowAction::RunSetup, WorkspaceRowAction::RunCleanup]
-        );
+        assert_eq!(labels, vec!["Clear", "To do", "In progress", "In review", "Done"]);
     }
 
-    #[test]
-    fn avail_empty_surfaces_no_script_rows() {
-        let avail = ScriptAvail::default();
-        let count = SCRIPT_ACTIONS
-            .iter()
-            .filter(|a| a.script_kind().is_some_and(|k| avail.has(k)))
-            .count();
-        assert_eq!(count, 0);
+    // ── the painter ─────────────────────────────────────────────────────────
+
+    fn workspace(id: &str, phase: &str) -> Workspace {
+        Workspace {
+            id: id.into(),
+            project_id: "proj-1".into(),
+            branch_minted: false,
+            name: "Fix login".into(),
+            slug: "fix-login".into(),
+            branch: "oximux/fix-login".into(),
+            worktree_path: "/tmp/repo-wt/fix-login".into(),
+            status: "active".into(),
+            created_at: String::new(),
+            archived_at: None,
+            linked_issue: None,
+            tint: None,
+            sort_order: 0.0,
+            pinned: false,
+            comment: String::new(),
+            phase: phase.into(),
+        }
+    }
+
+    /// The menu paints for every row kind with each submenu expanded, through
+    /// the window's real draw cycle. A duplicate element id, a borrow fault
+    /// in a listener, or an svg with no colour is a runtime panic that no
+    /// `cargo check` and none of the table tests above can report.
+    #[gpui::test]
+    fn the_menu_paints_every_row_kind_with_each_submenu_expanded(cx: &mut gpui::TestAppContext) {
+        use gpui::AppContext as _;
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        // gpui-component reads a theme global nothing in a bare test app
+        // installs.
+        cx.update(gpui_component::init);
+        let sink: Rc<RefCell<Option<gpui::Entity<WorkspaceRowMenu>>>> = Rc::new(RefCell::new(None));
+        let out = sink.clone();
+        let w = cx.add_window(move |window, cx| {
+            let menu = cx.new(|_cx| {
+                WorkspaceRowMenu::new(
+                    Theme::default(),
+                    Density::default(),
+                    Typography::default(),
+                    // The menu has to survive a root that is gone; a test
+                    // window is one.
+                    gpui::WeakEntity::new_invalid(),
+                )
+            });
+            *out.borrow_mut() = Some(menu.clone());
+            let view: gpui::AnyView = menu.into();
+            gpui_component::Root::new(view, window, cx)
+        });
+        let menu = sink.borrow().clone().expect("the menu was built");
+        let mut vcx = gpui::VisualTestContext::from_window(w.into(), cx);
+        vcx.simulate_resize(gpui::size(px(400.0), px(700.0)));
+
+        let cases = [
+            ("live", workspace("ws-1", "in-review"), live()),
+            ("primary", workspace("primary:proj-1", ""), primary()),
+            ("archived", workspace("ws-2", "done"), archived()),
+        ];
+        for (kind, ws, caps) in cases {
+            for expanded in [None, Some(Submenu::OpenIn), Some(Submenu::Status)] {
+                menu.update(&mut vcx, |m, cx| {
+                    m.open(ws.clone(), caps.clone(), 20.0, 20.0, cx);
+                    m.expanded = expanded;
+                    cx.notify();
+                });
+                vcx.run_until_parked();
+                menu.update(&mut vcx, |m, _cx| {
+                    assert!(m.is_open(), "{kind} / {expanded:?}: still open after paint");
+                });
+            }
+        }
+        menu.update(&mut vcx, |m, cx| m.close(cx));
+        vcx.run_until_parked();
+        menu.update(&mut vcx, |m, _cx| assert!(!m.is_open()));
     }
 }

--- a/apps/desktop/src/shell/left_rail/row_menu.rs
+++ b/apps/desktop/src/shell/left_rail/row_menu.rs
@@ -217,7 +217,18 @@ fn menu_actions(caps: &RowCapabilities) -> Vec<WorkspaceRowAction> {
     let finding = open_in.into_iter().chain([WorkspaceRowAction::CopyPath]);
 
     if caps.is_archived {
-        return finding.chain(ARCHIVED_ACTIONS.iter().copied()).collect();
+        // A row at the project root can be archived (by the CLI, or before
+        // it was recognised as primary). `Unarchive` only restores the row;
+        // `Delete` on it would take the force path through the project's own
+        // checkout, so the primary rule holds here too.
+        return finding
+            .chain(
+                ARCHIVED_ACTIONS
+                    .iter()
+                    .copied()
+                    .filter(|a| !(caps.is_primary && *a == WorkspaceRowAction::Delete)),
+            )
+            .collect();
     }
 
     let scripts = SCRIPT_ACTIONS
@@ -854,9 +865,16 @@ mod tests {
         // The reduction does not depend on which scripts happen to be defined.
         let no_scripts = RowCapabilities { scripts: ScriptAvail::default(), ..archived() };
         assert_eq!(menu_actions(&no_scripts), menu_actions(&archived()));
-        // Nor on the primary flag, which an archived row cannot carry anyway.
-        let odd = RowCapabilities { is_primary: true, ..archived() };
-        assert_eq!(menu_actions(&odd), menu_actions(&archived()));
+    }
+
+    /// An archived row that is ALSO the project's checkout — possible for a
+    /// persisted row at the project root — keeps `Unarchive` (it only restores
+    /// the row) and loses `Delete` (its force path would go through the
+    /// project's own checkout).
+    #[test]
+    fn an_archived_primary_row_keeps_unarchive_but_not_delete() {
+        let actions = menu_actions(&RowCapabilities { is_primary: true, ..archived() });
+        assert_eq!(actions, vec![A::OpenIn, A::CopyPath, A::Unarchive]);
     }
 
     #[test]

--- a/apps/desktop/src/shell/left_rail/workspace_card.rs
+++ b/apps/desktop/src/shell/left_rail/workspace_card.rs
@@ -94,12 +94,16 @@ fn compact_agent_glyph(
 /// actions and restore looks absent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RowMenu {
-    /// Show the trailing `…` button at all. Primary rows suppress it — the main
-    /// worktree goes away with the project, not on its own.
-    pub show: bool,
     /// A row menu is open somewhere in the rail. Global rather than per-row
     /// because while one is open its overlay occludes every other trigger, so
     /// no other tooltip can be showing anyway.
+    ///
+    /// There is no per-row "has a menu" flag any more. Every row — primary
+    /// included — gets the `…` trigger and the right-click handler; *what*
+    /// the menu offers is decided by `row_menu::menu_actions` from the row's
+    /// capabilities, and that list is never empty (`Copy Path` is on every
+    /// row). The old primary gate hid the whole menu on the one row a fresh
+    /// install has, which made every row action unreachable in practice.
     pub open: bool,
 }
 
@@ -140,10 +144,8 @@ pub fn render_workspace_card(
     let on_menu_click_btn = on_menu_click.clone();
 
     // Trailing "…" button — invisible at rest, revealed on row hover via
-    // `group_hover`. Primary (main worktree) rows suppress this because the
-    // main worktree is removed by removing the project, not here.
-    let trailing_btn = menu.show.then(|| {
-        div()
+    // `group_hover`. On every row, primary included; see `RowMenu`.
+    let trailing_btn = div()
             .id(menu_id)
             .flex()
             .items_center()
@@ -171,8 +173,7 @@ pub fn render_workspace_card(
             .on_mouse_down(MouseButton::Left, move |ev, window, cx| {
                 cx.stop_propagation();
                 on_menu_click_btn(ev, window, cx);
-            })
-    });
+            });
 
     // Line 1 — name + optional primary badge + optional branch chip.
     let primary_badge = (plan.row.is_primary && !plan.row.is_folder).then(|| {
@@ -580,15 +581,13 @@ pub fn render_workspace_card(
                 // (agent verb / diff) is dropped to fit a single row height.
                 .when(!compact, |c| c.child(line2)),
         )
-        .children(trailing_btn)
+        .child(trailing_btn)
         .on_mouse_down(MouseButton::Left, on_row_click)
         // Right-click opens the same row popover at the cursor (DRY with the
-        // `…` button). Gated to rows that have a menu (non-primary).
-        .when(menu.show, |el| {
-            el.on_mouse_down(MouseButton::Right, move |ev, window, cx| {
-                cx.stop_propagation();
-                on_menu_click(ev, window, cx);
-            })
+        // `…` button). On every row, primary included; see `RowMenu`.
+        .on_mouse_down(MouseButton::Right, move |ev, window, cx| {
+            cx.stop_propagation();
+            on_menu_click(ev, window, cx);
         })
         // Drag-to-reorder (Manual mode, non-primary rows only). Stateless
         // idiom: the payload carries the source index, `drag_over` paints the
@@ -751,23 +750,18 @@ mod tests {
 mod row_menu_tests {
     use super::RowMenu;
 
-    /// The trigger's tooltip is what paints over the menu's first item, so the
-    /// two flags are independent: a row can show its `…` button while the
-    /// tooltip is suppressed, and that combination is the whole point.
+    /// The trigger's tooltip is what paints over the menu's first item: the
+    /// flag says "suppress it", and nothing else — the `…` button itself is
+    /// unconditional now.
     #[test]
-    fn showing_the_button_and_suppressing_its_tooltip_are_separate() {
-        let open = RowMenu { show: true, open: true };
-        assert!(open.show, "the button stays on screen while its menu is up");
-        assert!(open.open, "...and its tooltip is suppressed");
-
-        let closed = RowMenu { show: true, open: false };
-        assert!(closed.show);
-        assert!(!closed.open, "tooltip comes back once the menu closes");
+    fn open_means_the_trigger_tooltip_is_suppressed() {
+        assert!(RowMenu { open: true }.open, "tooltip suppressed while the menu is up");
+        assert!(!RowMenu { open: false }.open, "tooltip comes back once the menu closes");
     }
 
-    /// A primary row has no menu at all, so nothing to suppress.
+    /// At rest no menu is open, so nothing is suppressed.
     #[test]
-    fn a_row_without_a_menu_defaults_to_no_suppression() {
-        assert_eq!(RowMenu::default(), RowMenu { show: false, open: false });
+    fn the_default_suppresses_nothing() {
+        assert_eq!(RowMenu::default(), RowMenu { open: false });
     }
 }

--- a/apps/desktop/src/shell/settings_modal/mod.rs
+++ b/apps/desktop/src/shell/settings_modal/mod.rs
@@ -613,7 +613,8 @@ impl SettingsModal {
         self.git_open_in_name_input =
             Some(cx.new(|cx| InputState::new(window, cx).placeholder("Name, e.g. VS Code")));
         self.git_open_in_cmd_input = Some(cx.new(|cx| {
-            InputState::new(window, cx).placeholder("Command, e.g. code  or  open -a \"Zed\"")
+            InputState::new(window, cx)
+                .placeholder("Command, as typed in a terminal: code, cursor, zed")
         }));
         self.refresh_open_in_shown();
 
@@ -977,6 +978,27 @@ impl SettingsModal {
                 cx.notify();
             }
         }
+    }
+
+    /// The preset picker: drop a known editor's name and command into the
+    /// add form, ready for `Add`. Prefilled rather than added outright so the
+    /// label can still be changed and so a preset the user then thinks
+    /// better of costs nothing to abandon.
+    pub(super) fn prefill_open_in_app(
+        &mut self,
+        app: &oximux_settings::OpenInApp,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let (Some(name_input), Some(cmd_input)) =
+            (self.git_open_in_name_input.clone(), self.git_open_in_cmd_input.clone())
+        else {
+            return;
+        };
+        name_input.update(cx, |s, cx| s.set_value(app.name.clone(), window, cx));
+        cmd_input.update(cx, |s, cx| s.set_value(app.command.clone(), window, cx));
+        self.git_open_in_notice = None;
+        cx.notify();
     }
 
     /// Remove the `idx`-th app of the list the pane is showing. Removing

--- a/apps/desktop/src/shell/settings_modal/mod.rs
+++ b/apps/desktop/src/shell/settings_modal/mod.rs
@@ -51,6 +51,8 @@ use gpui::{
     Subscription, Window, point, px,
 };
 use gpui_component::input::{InputEvent, InputState};
+
+use crate::shell::left_rail::open_in;
 use oximux_settings::{
     AgentLaunchSettings, CommitMessageAiSettings, ComputerUseSettings, Density, DictationSettings,
     TerminalSettings, Theme, Typography,
@@ -118,6 +120,17 @@ pub struct SettingsModal {
     /// same validator the create path runs, so the reason arrives while the
     /// user is looking at the field — and a refused text is never written.
     pub(super) git_dir_notice: Option<String>,
+    /// The `Open in` add form's two fields, lazily built on `open()`.
+    pub(super) git_open_in_name_input: Option<Entity<InputState>>,
+    pub(super) git_open_in_cmd_input: Option<Entity<InputState>>,
+    /// Why the last `Add` was refused, rendered under the form; cleared by
+    /// the next successful edit.
+    pub(super) git_open_in_notice: Option<String>,
+    /// The apps the `Open in` rows show — the effective list, resolved once
+    /// at `open()` and after each edit rather than per frame: resolving the
+    /// built-in list stats application bundles (or walks `PATH`), which is
+    /// not a thing to do on every paint.
+    pub(super) git_open_in_shown: Vec<oximux_settings::OpenInApp>,
     /// Working copy of the rate-limit retry settings.
     pub(crate) retry: oximux_settings::agent_retry::AgentRetrySettings,
     /// Working copy of the per-agent launch defaults; reseeded from the live
@@ -365,6 +378,10 @@ impl SettingsModal {
             _git_dir_sub: None,
             git_dir_seed: String::new(),
             git_dir_notice: None,
+            git_open_in_name_input: None,
+            git_open_in_cmd_input: None,
+            git_open_in_notice: None,
+            git_open_in_shown: Vec::new(),
             retry: oximux_settings::agent_retry::AgentRetrySettings::shipped(),
             agent_launch: AgentLaunchSettings::default(),
             dictation: DictationSettings::default(),
@@ -589,6 +606,16 @@ impl SettingsModal {
             },
         ));
         self.git_dir_input = Some(dir_input);
+
+        // The `Open in` add form: two plain fields read on `Add`, so neither
+        // needs a subscription. Nothing is written until the chip is clicked.
+        self.git_open_in_notice = None;
+        self.git_open_in_name_input =
+            Some(cx.new(|cx| InputState::new(window, cx).placeholder("Name, e.g. VS Code")));
+        self.git_open_in_cmd_input = Some(cx.new(|cx| {
+            InputState::new(window, cx).placeholder("Command, e.g. code  or  open -a \"Zed\"")
+        }));
+        self.refresh_open_in_shown();
 
         // Agents pane's environment editor. Reset the selection first: a reopen
         // must not land on a profile deleted since, which would silently edit
@@ -821,6 +848,11 @@ impl SettingsModal {
         }
         self.git_dir_input = None;
         self._git_dir_sub = None;
+        // The add form holds nothing until `Add` is clicked, so dropping it
+        // loses nothing that was ever going to be saved.
+        self.git_open_in_name_input = None;
+        self.git_open_in_cmd_input = None;
+        self.git_open_in_notice = None;
         // Same flush-before-drop hazard as custom words: the working copy is
         // synced on every keystroke, but only blur/Enter writes the file, and
         // clicking dead space doesn't blur a gpui input. Without this, typing an
@@ -919,6 +951,54 @@ impl SettingsModal {
         self.git.worktree_dir = (!text.is_empty()).then(|| text.clone());
         self.git_dir_seed = text;
         self.persist_git(cx);
+    }
+
+    /// The `Open in` add form's `Add`: validate both fields, append the app,
+    /// write `git.toml`, and clear the form. A refusal stays under the form
+    /// with its reason and writes nothing.
+    pub(super) fn add_open_in_app(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let (Some(name_input), Some(cmd_input)) =
+            (self.git_open_in_name_input.clone(), self.git_open_in_cmd_input.clone())
+        else {
+            return;
+        };
+        let name = name_input.read(cx).value().to_string();
+        let command = cmd_input.read(cx).value().to_string();
+        match pane_git::add_open_in(&mut self.git.open_in, &name, &command, open_in::default_apps) {
+            Ok(()) => {
+                self.git_open_in_notice = None;
+                self.refresh_open_in_shown();
+                name_input.update(cx, |s, cx| s.set_value("", window, cx));
+                cmd_input.update(cx, |s, cx| s.set_value("", window, cx));
+                self.persist_git(cx);
+            }
+            Err(reason) => {
+                self.git_open_in_notice = Some(reason);
+                cx.notify();
+            }
+        }
+    }
+
+    /// Remove the `idx`-th app of the list the pane is showing. Removing
+    /// from the built-in list materialises it first, so the removal sticks.
+    pub(super) fn remove_open_in_app(&mut self, idx: usize, cx: &mut Context<Self>) {
+        pane_git::remove_open_in(&mut self.git.open_in, idx, open_in::default_apps);
+        self.git_open_in_notice = None;
+        self.refresh_open_in_shown();
+        self.persist_git(cx);
+    }
+
+    /// Drop the configured list and go back to the built-in one.
+    pub(super) fn reset_open_in_apps(&mut self, cx: &mut Context<Self>) {
+        self.git.open_in.clear();
+        self.git_open_in_notice = None;
+        self.refresh_open_in_shown();
+        self.persist_git(cx);
+    }
+
+    /// Re-resolve the list the `Open in` rows show from the working copy.
+    pub(super) fn refresh_open_in_shown(&mut self) {
+        self.git_open_in_shown = open_in::effective_apps(&self.git);
     }
 
     /// Open a native folder picker and drop the chosen path into the
@@ -1493,6 +1573,58 @@ mod env_editor_tests {
     /// The editor's current text, as the user would see it.
     fn editor_text(m: &SettingsModal, cx: &App) -> String {
         m.env_input.as_ref().expect("env editor built").read(cx).value().to_string()
+    }
+
+    /// The Git pane paints with the `Open in` editor in it — the add form
+    /// with both fields, one row per app, and the reset row once the list is
+    /// the user's own — through the window's real draw cycle, for the same
+    /// reason as the Agents-pane test below. Both list states are painted:
+    /// the built-in one and a configured one, since each renders a different
+    /// hint and only the second has a `Reset` row.
+    #[gpui::test]
+    fn the_git_pane_paints_with_the_open_in_editor(cx: &mut TestAppContext) {
+        let (w, m) = modal(cx);
+        w.update(cx, |_root, window, cx| {
+            m.update(cx, |m, cx| {
+                m.open(window, cx);
+                m.selected = SettingsPane::Git;
+                assert!(m.git_open_in_name_input.is_some(), "open() builds the name field");
+                assert!(m.git_open_in_cmd_input.is_some(), "open() builds the command field");
+                m.git_open_in_notice = Some("Give the app a name.".into());
+            });
+        })
+        .expect("open on the Git pane");
+
+        let mut vcx = gpui::VisualTestContext::from_window(w.into(), cx);
+        vcx.simulate_resize(gpui::size(px(1100.0), px(800.0)));
+        vcx.run_until_parked();
+
+        // Now the user's own list: a different hint, and the `Reset` row.
+        w.update(&mut vcx.cx, |_root, _window, cx| {
+            m.update(cx, |m, cx| {
+                m.git.open_in = vec![
+                    oximux_settings::OpenInApp { name: "Zed".into(), command: "zed".into() },
+                    oximux_settings::OpenInApp {
+                        name: "VS Code".into(),
+                        command: "open -a \"Visual Studio Code\"".into(),
+                    },
+                ];
+                m.git_open_in_notice = None;
+                m.refresh_open_in_shown();
+                cx.notify();
+            });
+        })
+        .expect("switch to a configured list");
+        vcx.run_until_parked();
+
+        w.update(&mut vcx.cx, |_root, _window, cx| {
+            m.update(cx, |m, cx| {
+                m.close(cx);
+                assert!(m.git_open_in_name_input.is_none(), "close() drops the add form");
+                assert!(m.git_open_in_cmd_input.is_none());
+            });
+        })
+        .expect("close");
     }
 
     /// The Agents pane paints with the new card in it, through the window's

--- a/apps/desktop/src/shell/settings_modal/mod.rs
+++ b/apps/desktop/src/shell/settings_modal/mod.rs
@@ -965,7 +965,11 @@ impl SettingsModal {
         };
         let name = name_input.read(cx).value().to_string();
         let command = cmd_input.read(cx).value().to_string();
-        match pane_git::add_open_in(&mut self.git.open_in, &name, &command, open_in::default_apps) {
+        // Materialise from what the pane is showing, not a fresh discovery:
+        // an app installed since the pane opened would otherwise appear in
+        // the list the user did not see themselves edit.
+        let shown = self.git_open_in_shown.clone();
+        match pane_git::add_open_in(&mut self.git.open_in, &name, &command, move || shown) {
             Ok(()) => {
                 self.git_open_in_notice = None;
                 self.refresh_open_in_shown();
@@ -1004,7 +1008,10 @@ impl SettingsModal {
     /// Remove the `idx`-th app of the list the pane is showing. Removing
     /// from the built-in list materialises it first, so the removal sticks.
     pub(super) fn remove_open_in_app(&mut self, idx: usize, cx: &mut Context<Self>) {
-        pane_git::remove_open_in(&mut self.git.open_in, idx, open_in::default_apps);
+        // `idx` indexes the list the pane showed; materialise THAT, not a
+        // fresh discovery whose order may have shifted.
+        let shown = self.git_open_in_shown.clone();
+        pane_git::remove_open_in(&mut self.git.open_in, idx, move || shown);
         self.git_open_in_notice = None;
         self.refresh_open_in_shown();
         self.persist_git(cx);

--- a/apps/desktop/src/shell/settings_modal/pane_git.rs
+++ b/apps/desktop/src/shell/settings_modal/pane_git.rs
@@ -6,7 +6,14 @@
 //! global — which is what lets it answer on the same frame as the keystroke,
 //! while still running the resolver the create path runs.
 
-use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px};
+use gpui::{
+    Anchor, AnyElement, ClickEvent, Entity, IntoElement, ParentElement, SharedString, Styled, div,
+    px,
+};
+use gpui_component::button::Button;
+// A plain `Button` carrying its own menu, not `DropdownButton` — see the
+// schedules pane for why: that widget hangs the menu off the chevron alone.
+use gpui_component::menu::{DropdownMenu as _, PopupMenuItem};
 use gpui_component::{Sizable as _, input::Input};
 use oximux_settings::{
     Density, OpenInApp, Theme, Typography, git::BranchPrefixMode, git::GitSettings,
@@ -243,6 +250,7 @@ fn open_in_entries(
                         .into_any_element(),
                 ),
             )
+            .child(presets_dropdown(cx.entity()))
             .child(value_chip(
                 "git-open-in-add",
                 "Add",
@@ -308,6 +316,37 @@ fn open_in_entries(
     }
 
     rows
+}
+
+/// The `Presets ▾` dropdown beside the add form: one row per editor this
+/// build knows how to launch. Picking one fills the two fields; `Add` is
+/// still the commit.
+fn presets_dropdown(entity: Entity<SettingsModal>) -> AnyElement {
+    let presets = open_in::presets();
+    Button::new(SharedString::from("git-open-in-presets"))
+        .label("Presets")
+        .small()
+        .outline()
+        .dropdown_caret(true)
+        .dropdown_menu_with_anchor(Anchor::TopRight, move |mut menu, window, _cx| {
+            for app in presets.clone() {
+                let entity = entity.clone();
+                let label = app.name.clone();
+                menu = menu.item(
+                    PopupMenuItem::element(move |_w, _cx| {
+                        div().min_w(px(96.0)).child(label.clone())
+                    })
+                    .on_click(window.listener_for(
+                        &entity,
+                        move |m: &mut SettingsModal, _ev: &ClickEvent, window, cx| {
+                            m.prefill_open_in_app(&app, window, cx);
+                        },
+                    )),
+                );
+            }
+            menu
+        })
+        .into_any_element()
 }
 
 /// Append `name` / `command` to `list`, materialising the built-in list

--- a/apps/desktop/src/shell/settings_modal/pane_git.rs
+++ b/apps/desktop/src/shell/settings_modal/pane_git.rs
@@ -8,7 +8,9 @@
 
 use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px};
 use gpui_component::{Sizable as _, input::Input};
-use oximux_settings::{Density, Theme, Typography, git::BranchPrefixMode, git::GitSettings};
+use oximux_settings::{
+    Density, OpenInApp, Theme, Typography, git::BranchPrefixMode, git::GitSettings,
+};
 
 use super::SettingsModal;
 use super::controls::{toggle_switch, value_chip};
@@ -16,6 +18,7 @@ use super::layout::{
     SettingEntry, entries_card, entry, entry_stacked, entry_stacked_hinted, hint_text, notice_text,
 };
 use super::segmented::{Segment, segmented};
+use crate::shell::left_rail::open_in;
 use crate::shell::workspace::configured_locator::{ConfiguredLocator, DEFAULT_ROOT_UNDER_HOME};
 
 /// Render the Git pane: the settings rows plus a quiet save-location caption.
@@ -196,7 +199,159 @@ pub(super) fn entries(
         keep_fresh,
     ));
 
+    rows.extend(open_in_entries(modal, theme, density, typography, cx));
+
     rows
+}
+
+/// The `Open in` section: the add form under its own label, then one row per
+/// app the workspace row menu will offer, each with `Remove`.
+///
+/// The rows show the *effective* list — the built-in one until the user
+/// edits it — so what the pane lists is what the menu offers. The first
+/// edit materialises the built-in list into `git.toml`; `Reset` empties it
+/// again, which is the spelling of "use the built-in list".
+fn open_in_entries(
+    modal: &SettingsModal,
+    theme: Theme,
+    density: Density,
+    typography: &Typography,
+    cx: &mut gpui::Context<SettingsModal>,
+) -> Vec<SettingEntry> {
+    let mut rows: Vec<SettingEntry> = Vec::new();
+    let configured = !modal.git.open_in.is_empty();
+
+    if let (Some(name), Some(command)) =
+        (modal.git_open_in_name_input.as_ref(), modal.git_open_in_cmd_input.as_ref())
+    {
+        let form = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .w_full()
+            .gap(px(8.0))
+            .child(
+                div().flex_1().min_w_0().child(
+                    Input::new(name).small().text_size(px(typography.t_body_sm)).into_any_element(),
+                ),
+            )
+            .child(
+                div().flex_1().min_w_0().child(
+                    Input::new(command)
+                        .small()
+                        .text_size(px(typography.t_body_sm))
+                        .into_any_element(),
+                ),
+            )
+            .child(value_chip(
+                "git-open-in-add",
+                "Add",
+                theme,
+                density,
+                typography,
+                |this: &mut SettingsModal, window, cx| this.add_open_in_app(window, cx),
+                cx,
+            ));
+        let under = match &modal.git_open_in_notice {
+            Some(reason) => notice_text(false, reason.clone(), theme, typography),
+            None if configured => hint_text(
+                "Your own list. Remove every app, or Reset, to go back to the built-in one.",
+                theme,
+                typography,
+            ),
+            None => hint_text(
+                "The built-in list: your file manager plus the editors found on this machine. \
+                 Adding or removing an app makes the list your own.",
+                theme,
+                typography,
+            ),
+        };
+        rows.push(entry_stacked_hinted(
+            "Open in",
+            "Apps a workspace row's Open in \u{25b8} menu offers. The worktree directory is \
+             passed as the last argument; wrap an argument with spaces in double quotes.",
+            form,
+            under,
+        ));
+    }
+
+    for (idx, app) in modal.git_open_in_shown.iter().enumerate() {
+        rows.push(entry(
+            app.name.clone(),
+            app.command.clone(),
+            value_chip(
+                ("git-open-in-remove", idx),
+                "Remove",
+                theme,
+                density,
+                typography,
+                move |this: &mut SettingsModal, _w, cx| this.remove_open_in_app(idx, cx),
+                cx,
+            ),
+        ));
+    }
+
+    if configured {
+        rows.push(entry(
+            "Built-in list",
+            "Forget the apps above and offer the built-in list again.",
+            value_chip(
+                "git-open-in-reset",
+                "Reset",
+                theme,
+                density,
+                typography,
+                |this: &mut SettingsModal, _w, cx| this.reset_open_in_apps(cx),
+                cx,
+            ),
+        ));
+    }
+
+    rows
+}
+
+/// Append `name` / `command` to `list`, materialising the built-in list
+/// first when `list` is empty so the addition lands *beside* the defaults
+/// rather than replacing them. Refuses a blank name, a blank command, or a
+/// command that cannot be split into a program (an unterminated quote).
+pub(super) fn add_open_in(
+    list: &mut Vec<OpenInApp>,
+    name: &str,
+    command: &str,
+    defaults: impl FnOnce() -> Vec<OpenInApp>,
+) -> Result<(), String> {
+    let name = name.trim();
+    let command = command.trim();
+    if name.is_empty() {
+        return Err("Give the app a name.".to_string());
+    }
+    if command.is_empty() {
+        return Err("Give the app a command.".to_string());
+    }
+    if open_in::parse_command(command).is_none() {
+        return Err("The command needs a program name, with every quote closed.".to_string());
+    }
+    if list.is_empty() {
+        *list = defaults();
+    }
+    list.push(OpenInApp { name: name.to_string(), command: command.to_string() });
+    Ok(())
+}
+
+/// Remove the `idx`-th app of the effective list, materialising the built-in
+/// list first when `list` is empty — the index the pane clicked is an index
+/// into what it showed. Out of range is a no-op.
+pub(super) fn remove_open_in(
+    list: &mut Vec<OpenInApp>,
+    idx: usize,
+    defaults: impl FnOnce() -> Vec<OpenInApp>,
+) {
+    if list.is_empty() {
+        *list = defaults();
+    }
+    if idx < list.len() {
+        list.remove(idx);
+    }
 }
 
 /// The placeholder for an empty directory field: the default root, spelled
@@ -242,4 +397,89 @@ fn landing_hint(text: &str) -> String {
         })
         .unwrap_or_else(default_root_placeholder);
     format!("New worktrees go to {root}/<project>/<slug>.")
+}
+
+#[cfg(test)]
+mod open_in_tests {
+    use super::*;
+
+    fn app(name: &str, command: &str) -> OpenInApp {
+        OpenInApp { name: name.into(), command: command.into() }
+    }
+
+    fn built_in() -> Vec<OpenInApp> {
+        vec![app("Finder", "open"), app("Zed", "zed")]
+    }
+
+    /// Adding to an untouched list keeps the built-in apps: the user asked
+    /// for one more editor, not for a list with only that editor in it.
+    #[test]
+    fn the_first_add_materialises_the_built_in_list_beside_the_new_app() {
+        let mut list = Vec::new();
+        add_open_in(&mut list, "Cursor", "cursor", built_in).expect("added");
+        assert_eq!(list, vec![app("Finder", "open"), app("Zed", "zed"), app("Cursor", "cursor")]);
+    }
+
+    #[test]
+    fn a_later_add_appends_without_touching_the_defaults() {
+        let mut list = vec![app("Only", "only")];
+        add_open_in(&mut list, " Cursor ", " cursor ", || panic!("defaults not consulted"))
+            .expect("added");
+        assert_eq!(list, vec![app("Only", "only"), app("Cursor", "cursor")]);
+    }
+
+    #[test]
+    fn a_blank_name_or_command_is_refused_and_writes_nothing() {
+        let mut list = Vec::new();
+        assert!(add_open_in(&mut list, "", "code", built_in).is_err());
+        assert!(add_open_in(&mut list, "VS Code", "   ", built_in).is_err());
+        assert!(list.is_empty(), "a refused add must not materialise the defaults");
+    }
+
+    /// The one command shape `launch` cannot split is refused here, so the
+    /// menu never offers an entry that fails on click.
+    #[test]
+    fn an_unterminated_quote_is_refused() {
+        let mut list = Vec::new();
+        let err = add_open_in(&mut list, "Code", "open -a \"Visual Studio", built_in).unwrap_err();
+        assert!(err.contains("quote"), "{err}");
+        assert!(list.is_empty());
+    }
+
+    /// `""` and `" "` are non-blank text whose program is nothing; the
+    /// parser refuses them, so the pane must too rather than adding an entry
+    /// that fails on click.
+    #[test]
+    fn a_quoted_empty_program_is_refused() {
+        let mut list = Vec::new();
+        assert!(add_open_in(&mut list, "App", "\"\"", built_in).is_err());
+        assert!(add_open_in(&mut list, "App", "\" \"", built_in).is_err());
+        assert!(list.is_empty());
+    }
+
+    /// Removing from the built-in list must remove the app the user clicked,
+    /// which means materialising the same list the pane showed.
+    #[test]
+    fn removing_from_the_built_in_list_materialises_it_first() {
+        let mut list = Vec::new();
+        remove_open_in(&mut list, 0, built_in);
+        assert_eq!(list, vec![app("Zed", "zed")]);
+    }
+
+    #[test]
+    fn removing_out_of_range_is_a_no_op() {
+        let mut list = vec![app("Only", "only")];
+        remove_open_in(&mut list, 5, || panic!("defaults not consulted"));
+        assert_eq!(list, vec![app("Only", "only")]);
+    }
+
+    /// Removing the last app empties the list, and an empty list means the
+    /// built-in one — the documented way back, stated in the pane's hint.
+    #[test]
+    fn removing_the_last_app_returns_to_the_built_in_list() {
+        let mut list = vec![app("Only", "only")];
+        remove_open_in(&mut list, 0, || panic!("defaults not consulted"));
+        assert!(list.is_empty());
+        assert_eq!(open_in::effective_apps(&GitSettings::shipped()), open_in::default_apps());
+    }
 }

--- a/apps/desktop/src/shell/workspace/merge_ops.rs
+++ b/apps/desktop/src/shell/workspace/merge_ops.rs
@@ -194,6 +194,34 @@ fn stranded_from_pop(stash: Option<&StashRef>, pop_failed: bool) -> Option<Notic
     (stash.is_some() && pop_failed).then_some(NoticeReason::PopFailed)
 }
 
+/// Everything a merge needs to name, resolved from the row.
+///
+/// Same reason `WorkspaceDeleteTarget` exists: `merge_workspace_into_default`
+/// is GPUI-bound and cannot be driven from a unit test, so the wrong-repository
+/// guard needs a seam the test can hold — and a revert of the handler to
+/// `self.active_project` has to delete this function to compile.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MergeTarget {
+    /// The row's OWN project.
+    pub(crate) project: Project,
+    /// Its root — the repository the merge runs in.
+    pub(crate) project_root: PathBuf,
+    /// The branch the work lands in.
+    pub(crate) default_branch: String,
+}
+
+/// Resolve what a merge of `workspace` should operate on, or `None` when its
+/// owning project is not open (decline rather than fall back).
+pub(crate) fn merge_target(projects: &[Project], workspace: &Workspace) -> Option<MergeTarget> {
+    let project =
+        crate::shell::workspace_ops::resolve_project_for_workspace(projects, workspace)?;
+    Some(MergeTarget {
+        project_root: PathBuf::from(&project.root_path),
+        default_branch: project.default_branch.clone(),
+        project,
+    })
+}
+
 impl WorkspaceRoot {
     /// Directories with a live **agent** in them, across every project whose
     /// panes this window has built.
@@ -303,18 +331,15 @@ impl WorkspaceRoot {
         // The ROW's project, never the active one: the rail shows every
         // project's rows at once, and merging into the wrong repository's
         // default branch is the same mistake Phase 1 had to fix for Delete.
-        let Some(project) = crate::shell::workspace_ops::resolve_project_for_workspace(
-            &self.app_state.recent_projects,
-            &workspace,
-        ) else {
+        let Some(MergeTarget { project, project_root, default_branch }) =
+            merge_target(&self.app_state.recent_projects, &workspace)
+        else {
             tracing::info!(
                 workspace_id = %workspace.id,
                 "merge: workspace's project not open, ignoring"
             );
             return;
         };
-        let project_root = PathBuf::from(&project.root_path);
-        let default_branch = project.default_branch.clone();
         let holders = self.agent_holders(cx);
         let weak: WeakEntity<WorkspaceRoot> = cx.weak_entity();
         let ws = workspace.clone();
@@ -778,5 +803,69 @@ impl WorkspaceRoot {
             });
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(id: &str, root: &str, default_branch: &str) -> Project {
+        Project {
+            id: id.into(),
+            name: id.into(),
+            root_path: root.into(),
+            default_branch: default_branch.into(),
+            created_at: String::new(),
+            last_opened_at: None,
+            sort_order: 0.0,
+        }
+    }
+
+    fn workspace_in(project_id: &str) -> Workspace {
+        Workspace {
+            id: format!("ws-{project_id}"),
+            project_id: project_id.into(),
+            branch_minted: true,
+            name: "fix".into(),
+            slug: "fix".into(),
+            branch: "oximux/fix".into(),
+            worktree_path: format!("/repos/{project_id}-wt/fix"),
+            status: "active".into(),
+            created_at: String::new(),
+            archived_at: None,
+            linked_issue: None,
+            tint: None,
+            sort_order: 0.0,
+            pinned: false,
+            comment: String::new(),
+            phase: String::new(),
+        }
+    }
+
+    /// The rail renders every open project's rows at once, so `Merge into` can
+    /// be reached while a DIFFERENT project is active. Resolution must follow
+    /// the row: otherwise landing `api`'s branch while `web` is active runs the
+    /// merge inside `web` and into `web`'s default branch.
+    #[test]
+    fn merge_target_resolves_the_rows_own_project_not_the_active_one() {
+        let api = project("api", "/repos/api", "main");
+        let web = project("web", "/repos/web", "develop");
+        // `web` is first — an "active project" fallback would pick it.
+        let open = vec![web.clone(), api.clone()];
+
+        let target = merge_target(&open, &workspace_in("api")).expect("merge target");
+        assert_eq!(target.project_root, PathBuf::from("/repos/api"));
+        assert_eq!(target.default_branch, "main");
+        assert_eq!(target.project.id, "api");
+        assert_ne!(target.project_root, PathBuf::from(&web.root_path), "never the active project's");
+    }
+
+    /// A row whose project is not open is declined, not merged into whatever
+    /// happens to be active.
+    #[test]
+    fn a_row_with_no_open_project_has_no_merge_target() {
+        let open = vec![project("web", "/repos/web", "main")];
+        assert_eq!(merge_target(&open, &workspace_in("api")), None);
     }
 }

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -1587,12 +1587,28 @@ impl WorkspaceRoot {
         // The ROW's project's panes, not the active project's: the rail shows
         // every project's rows, and a script for `api`'s worktree must not
         // land as a tab in `web`'s pane group because `web` happened to be
-        // on screen. A project with no panes in this window is declined.
-        let Some(panes) = self.project_panes_by_project.get(&workspace.project_id).cloned()
-        else {
+        // on screen. A project that has never been activated in this window
+        // has no panes yet, so activate it first — that builds them and puts
+        // the terminal where the user will see it, which is what running a
+        // script from its row asks for anyway.
+        let mut panes = self.project_panes_by_project.get(&workspace.project_id).cloned();
+        if panes.is_none() {
+            let Some(project) =
+                resolve_project_for_workspace(&self.app_state.recent_projects, &workspace)
+            else {
+                tracing::warn!(
+                    project_id = %workspace.project_id,
+                    "run_workspace_script: row's project is not open"
+                );
+                return;
+            };
+            self.set_active_project(project, window, cx);
+            panes = self.project_panes_by_project.get(&workspace.project_id).cloned();
+        }
+        let Some(panes) = panes else {
             tracing::warn!(
                 project_id = %workspace.project_id,
-                "run_workspace_script: row's project has no panes in this window"
+                "run_workspace_script: row's project built no panes on activation"
             );
             return;
         };

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -21,7 +21,8 @@ use oximux_git::{Repository, derive_slug, validate_slug};
 use oximux_settings::{Density, ScriptKind, Theme, Typography};
 use oximux_storage::{AgentSessionRepo, ProjectRepo, WorkspaceRepo};
 
-use crate::shell::left_rail::row_menu::ScriptAvail;
+use crate::shell::left_rail::open_in;
+use crate::shell::left_rail::row_menu::{RowCapabilities, ScriptAvail};
 
 use crate::project_panes_factory::{
     build_project_panes, load_persisted_tabs,
@@ -359,6 +360,20 @@ pub(crate) fn resolve_project_for_workspace(
         .iter()
         .find(|p| p.id == workspace.project_id)
         .cloned()
+}
+
+/// Whether `workspace` is its project's primary row — the repo's main
+/// checkout, which goes away with the project and never on its own.
+///
+/// **One predicate, shared by the rail and the row menu.** The rail paints the
+/// primary badge for a row whose worktree path IS the project root; the
+/// desktop synthesizes such a row with a `primary:<project>` id, but a real
+/// database row at the project root (an adopted checkout, a hand-edited row)
+/// must be treated the same way — it would otherwise paint as primary and
+/// still be offered `Delete`, which is the one case the row menu's gate
+/// exists to prevent. Either signal is enough.
+pub(crate) fn is_primary_row(workspace: &Workspace, project_root: &str) -> bool {
+    workspace.id.starts_with("primary:") || workspace.worktree_path == project_root
 }
 
 
@@ -1504,16 +1519,39 @@ impl WorkspaceRoot {
             run: scripts.script(ScriptKind::Run).is_some(),
             cleanup: scripts.script(ScriptKind::Cleanup).is_some(),
         };
-        // The `Merge into <x>` row is labelled with the row's OWN project's
-        // default branch, not the active project's — the rail shows every
-        // project's workspaces at once, and merging into the wrong repository's
-        // main is the mistake Phase 1 already had to fix once for Delete.
-        let default_branch =
+        // The menu carries the row's OWN project, not the active one — the
+        // rail shows every project's workspaces at once, and acting on the
+        // wrong repository is the mistake Phase 1 already had to fix once for
+        // Delete. A row whose project is not open gets no menu rather than a
+        // menu that would fall back to whichever project is active.
+        let Some(project) =
             resolve_project_for_workspace(&self.app_state.recent_projects, &workspace)
-                .map(|p| p.default_branch)
-                .unwrap_or_default();
+        else {
+            // Should be unreachable — the rail pairs rows with this same
+            // project list — but a right-click that silently does nothing is
+            // the worst possible symptom if it ever is, so say so.
+            tracing::warn!(
+                workspace_id = %workspace.id,
+                project_id = %workspace.project_id,
+                "open_row_menu: row's project is not open; declining"
+            );
+            self.push_toast(
+                crate::shell::toast::ToastKind::Error,
+                format!("\u{201c}{}\u{201d}: its project is not open", workspace.name),
+                cx,
+            );
+            return;
+        };
+        let caps = RowCapabilities {
+            is_primary: is_primary_row(&workspace, &project.root_path),
+            is_archived: workspace.archived_at.is_some(),
+            scripts: avail,
+            can_merge: !project.default_branch.is_empty(),
+            open_in: open_in::effective_apps(&crate::git_settings::settings(cx)),
+            project,
+        };
         self.row_menu
-            .update(cx, |m, cx| m.open(workspace, avail, default_branch, x, y, cx));
+            .update(cx, |m, cx| m.open(workspace, caps, x, y, cx));
         // The rail suppresses the `…` trigger's tooltip while this is up. An
         // already-visible tooltip is sticky — `occlude` stops new hovers, but
         // clearing a live one needs a hover-out, which needs a mouse move, and
@@ -2611,6 +2649,68 @@ impl WorkspaceRoot {
         );
     }
 
+    /// Copy a workspace's absolute worktree path to the clipboard. On a
+    /// primary row that is the project root — the same path `copy_project_path`
+    /// copies, reached from the row instead of the project header.
+    pub(crate) fn copy_workspace_path(&self, workspace: &Workspace, cx: &mut Context<Self>) {
+        cx.write_to_clipboard(gpui::ClipboardItem::new_string(workspace.worktree_path.clone()));
+        self.push_toast(crate::shell::toast::ToastKind::Success, "Copied worktree path", cx);
+    }
+
+    /// The row menu's `Move to Status ▸`: write a worktree's phase, or clear
+    /// it with `None`.
+    ///
+    /// Same vocabulary and same store as `oximux worktree set --phase`: the
+    /// picker offers `WorkPhase::ALL` and writes each value's canonical
+    /// spelling, which is exactly what the CLI normalises typed input to.
+    /// There is no second validator because a `WorkPhase` cannot hold
+    /// anything the CLI would refuse. The rail re-reads the row on the next
+    /// render, so the chip updates without a restart.
+    ///
+    /// Deliberately does not touch the comment: a live agent's prompt still
+    /// outranks the comment on the card's second line, and the phase chip is
+    /// on the first.
+    pub(crate) fn set_workspace_phase(
+        &mut self,
+        workspace_id: &str,
+        phase: Option<oximux_core::WorkPhase>,
+        cx: &mut Context<Self>,
+    ) {
+        let stored = phase.map(|p| p.as_str()).unwrap_or("");
+        match self.app_state.workspace_repo.set_phase(workspace_id, stored) {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(workspace_id, "set_workspace_phase: no such row");
+                return;
+            }
+            Err(err) => {
+                tracing::warn!(?err, workspace_id, "set_workspace_phase failed");
+                self.push_toast(
+                    crate::shell::toast::ToastKind::Error,
+                    format!("Could not set status: {err}"),
+                    cx,
+                );
+                return;
+            }
+        }
+        self.mark_rail_dirty(cx);
+        cx.notify();
+    }
+
+    /// The primary row's `New workspace here`: what the project-group `+`
+    /// does, from the row. Activates the project first so the create dialog
+    /// opens with it preselected — the single code path every entry point
+    /// shares.
+    pub(crate) fn new_workspace_in_project(
+        &mut self,
+        project: Project,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_active_project(project, window, cx);
+        window.dispatch_action(Box::new(crate::actions::OpenWorkspaceCreate), cx);
+    }
+
     /// Opt `project` in or out of the computer-use tools — the per-project half
     /// of the two switches that decide whether its agents get them.
     ///
@@ -2754,7 +2854,8 @@ impl WorkspaceRoot {
 #[cfg(test)]
 mod nav_history_tests {
     use super::{
-        WorkspaceNavRef, push_nav_entry, resolve_project_for_workspace, workspace_delete_target,
+        WorkspaceNavRef, is_primary_row, push_nav_entry, resolve_project_for_workspace,
+        workspace_delete_target,
         workspace_path_for_ambient_terminal,
     };
     use oximux_core::{Project, Workspace};
@@ -2836,6 +2937,32 @@ mod nav_history_tests {
     /// GPUI-bound and cannot be driven from here, so binding the test to the
     /// function it actually uses is what makes a revert to `self.active_project`
     /// fail rather than pass — that revert has to delete this function.
+    /// The rail decides "primary" by path and the desktop synthesizes the row
+    /// with a `primary:` id; the menu's gate must honour both, or a real row at
+    /// the project root paints as primary and is still offered `Delete`.
+    #[test]
+    fn a_row_is_primary_by_synthesized_id_or_by_living_at_the_project_root() {
+        let synthesized = Workspace {
+            id: "primary:api".into(),
+            worktree_path: "/repos/api".into(),
+            ..workspace_in("api", "main")
+        };
+        assert!(is_primary_row(&synthesized, "/repos/api"));
+        // A real database row whose worktree IS the project root.
+        let adopted = Workspace {
+            id: "ws-adopted".into(),
+            worktree_path: "/repos/api".into(),
+            ..workspace_in("api", "main")
+        };
+        assert!(is_primary_row(&adopted, "/repos/api"));
+        // An ordinary worktree row is not.
+        let ordinary = Workspace {
+            worktree_path: "/repos/api-wt/fix".into(),
+            ..workspace_in("api", "oximux/fix")
+        };
+        assert!(!is_primary_row(&ordinary, "/repos/api"));
+    }
+
     #[test]
     fn delete_target_resolves_the_rows_own_project_not_the_active_one() {
         let api = project("api", "/repos/api");

--- a/apps/desktop/src/shell/workspace/workspace_ops.rs
+++ b/apps/desktop/src/shell/workspace/workspace_ops.rs
@@ -1584,8 +1584,16 @@ impl WorkspaceRoot {
         };
         let title = format!("{}: {}", kind.as_str(), workspace.name);
         let script = script.to_string();
-        let Some(panes) = self.active_project_panes() else {
-            tracing::warn!("run_workspace_script: no active project panes");
+        // The ROW's project's panes, not the active project's: the rail shows
+        // every project's rows, and a script for `api`'s worktree must not
+        // land as a tab in `web`'s pane group because `web` happened to be
+        // on screen. A project with no panes in this window is declined.
+        let Some(panes) = self.project_panes_by_project.get(&workspace.project_id).cloned()
+        else {
+            tracing::warn!(
+                project_id = %workspace.project_id,
+                "run_workspace_script: row's project has no panes in this window"
+            );
             return;
         };
         panes.update(cx, |p, cx| {

--- a/crates/settings/src/git.rs
+++ b/crates/settings/src/git.rs
@@ -52,6 +52,22 @@ impl BranchPrefixMode {
     }
 }
 
+/// One entry of the row menu's `Open in ▸` submenu: a display name and the
+/// command that receives the worktree directory as its final argument.
+///
+/// `command` is a program followed by any fixed arguments, split on
+/// whitespace; an argument containing spaces is wrapped in double quotes,
+/// as in `open -a "Visual Studio Code"`. No shell is involved, so nothing
+/// in it expands. The desktop resolves the program through the process
+/// `PATH`, which a GUI launch has already repaired from the login shell —
+/// the same environment every agent CLI is spawned with.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct OpenInApp {
+    pub name: String,
+    pub command: String,
+}
+
 /// Git and source-control preferences, persisted to `git.toml`.
 ///
 /// `#[serde(default)]` per field so a file written by an older build — or
@@ -84,6 +100,17 @@ pub struct GitSettings {
     /// the new worktree starts from current work rather than from whatever was
     /// last pulled. Off by default: it makes creation touch the network.
     pub keep_default_up_to_date: bool,
+    /// The applications offered by the row menu's `Open in ▸`. **Empty means
+    /// the built-in list** — the platform's file manager plus whichever
+    /// known editors are installed — resolved by the desktop at menu-open
+    /// time so an app installed after the pane was last saved still
+    /// appears. The pane materialises the built-in list into this field the
+    /// first time the user edits it, so a removal sticks.
+    ///
+    /// **Keep this the last field.** It serializes as a TOML array of tables,
+    /// and `toml` refuses to emit a plain value after one — a scalar added
+    /// below it fails `to_toml_string` at runtime, not at compile time.
+    pub open_in: Vec<OpenInApp>,
 }
 
 impl Default for GitSettings {
@@ -104,6 +131,7 @@ impl GitSettings {
             custom_prefix: DEFAULT_PREFIX.to_string(),
             worktree_dir: None,
             keep_default_up_to_date: false,
+            open_in: Vec::new(),
         }
     }
 
@@ -159,6 +187,7 @@ mod tests {
         assert_eq!(s.custom_prefix, "oximux");
         assert_eq!(s.worktree_dir, None);
         assert!(!s.keep_default_up_to_date);
+        assert!(s.open_in.is_empty(), "empty = the built-in Open-in list");
     }
 
     #[test]
@@ -169,6 +198,13 @@ mod tests {
                 custom_prefix: "team".to_string(),
                 worktree_dir: Some("/tmp/wt".to_string()),
                 keep_default_up_to_date: true,
+                open_in: vec![
+                    OpenInApp { name: "VS Code".into(), command: "code".into() },
+                    OpenInApp {
+                        name: "Finder".into(),
+                        command: "open".into(),
+                    },
+                ],
             };
             assert_eq!(GitSettings::from_toml_str(&s.to_toml_string()).expect("parses"), s);
         }
@@ -224,10 +260,28 @@ mod tests {
             custom_prefix: "kept".to_string(),
             worktree_dir: None,
             keep_default_up_to_date: true,
+            open_in: Vec::new(),
         };
         std::fs::write(dir.path().join(GitSettings::FILE_NAME), want.to_toml_string())
             .expect("write");
         assert_eq!(GitSettings::load_from_dir(dir.path()), want);
+    }
+
+    /// The list is written as TOML array-of-tables, which is the shape a
+    /// person hand-editing `git.toml` would reach for — and an entry missing
+    /// one key loads with that key empty rather than failing the file.
+    #[test]
+    fn open_in_apps_are_an_array_of_tables_with_lenient_entries() {
+        let s = GitSettings::from_toml_str(
+            "[[open_in]]\nname = \"Zed\"\ncommand = \"zed\"\n\n[[open_in]]\ncommand = \"code\"\n",
+        )
+        .expect("parses");
+        assert_eq!(s.open_in.len(), 2);
+        assert_eq!(s.open_in[0], OpenInApp { name: "Zed".into(), command: "zed".into() });
+        assert_eq!(s.open_in[1].name, "");
+        assert_eq!(s.open_in[1].command, "code");
+        // And the field round-trips through the writer in that same shape.
+        assert!(s.to_toml_string().contains("[[open_in]]"));
     }
 
     #[test]

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -39,7 +39,7 @@ pub use appearance::{Appearance, DensityPreset, ThemeChoice, UiScale, UsageDetai
 pub use auto_update::AutoUpdateSettings;
 pub use autosave::AutosaveSettings;
 pub use commit_message_ai::{AgentSettings, CommitMessageAiMode, CommitMessageAiSettings};
-pub use git::{BranchPrefixMode, GitSettings};
+pub use git::{BranchPrefixMode, GitSettings, OpenInApp};
 pub use computer_use::{AppGrant, ComputerUseSettings};
 pub use custom_commands::{CustomCommand, CustomCommandsFile, load_and_merge};
 pub use density::Density;

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -95,6 +95,11 @@ src/
     │   ├── workspace_card.rs render_workspace_card — two-line card painter consuming WorkspaceCardPlan;
     │   │                   CARD_HEIGHT_MULT = 2.2 × h_row (design-guidelines approved exception)
     │   ├── project_group.rs renders project groups; threads diff_counts snapshot into card builder; on_drag/drag_over/on_drop wired for reorder
+    │   ├── row_menu.rs     WorkspaceRowMenu popover (`…` / right-click, EVERY row incl. primary);
+    │   │                   RowCapabilities (row's OWN project) → menu_actions (pure, case-table tested);
+    │   │                   in-place submenus: Open in ▸ (apps), Move to Status ▸ (WorkPhase::ALL + Clear)
+    │   ├── open_in.rs      Open in ▸ app list: git.toml `[[open_in]]` or the built-in list (platform opener +
+    │   │                   installed editors); spawns by name — PATH is repaired once in platform::login_path
     │   ├── project_drag.rs drag payloads, insertion_side, paint_insertion_line (2px accent line),
     │   │                   SidebarDragPreview ghost chip, WorkspaceDragConfig, reorder_slot_value
     │   └── toolbar.rs      Add Project + settings (stubs)


### PR DESCRIPTION
## Summary

Phase 7 of the worktree feature plan. The row menu was gated to non-primary rows, so a fresh install — where every row is primary — had no reachable row menu at all. Every row now gets the `…` button and right-click; *what* the menu offers is decided by a pure builder from the row's capabilities.

- **`RowCapabilities` + `menu_actions`** — `left_rail/row_menu.rs`. The struct carries the row's OWN project (never the active one); the builder is a pure function with a case table. A primary row gets exactly `Run setup` (when defined), `Open in ▸`, `Copy Path`, `New workspace here` — never `Rename`, `Archive`, `Delete`, or `Merge into`. An archived row gets the two finding rows plus `Unarchive` / `Delete`.
- **One "primary" predicate** — `workspace_ops::is_primary_row` (synthesized `primary:` id OR worktree at the project root), shared by the rail and the menu. Found in review: the two had different definitions, and a real row at the project root would have painted as primary yet been offered `Delete`.
- **`Open in ▸`** — `left_rail/open_in.rs`. Apps from `git.toml [[open_in]]` (`OpenInApp { name, command }`); empty means the built-in list — platform opener plus editors found on the machine — resolved at menu-open time. No second binary resolver: the process PATH is repaired once at boot. Off-macOS the stored command is the path `which` found, quoted, since `Command` will not resolve `code.cmd`.
- **Git pane editor** — add form with a `Presets ▾` dropdown that prefills a known editor, per-app `Remove`, and `Reset` to the built-in list. The first edit materialises the built-in list so a removal sticks. The effective list is cached at open and after edits, not resolved per frame.
- **`Copy Path`** — absolute worktree path, with a toast.
- **`Move to Status ▸`** — `WorkPhase::ALL` plus `Clear`, radio-checked, written through the same store and vocabulary as `oximux worktree set --phase`. No second validator: a `WorkPhase` cannot hold anything the CLI would refuse.
- **`New workspace here`** — the project-group `+`, from the primary row.
- **Merge regression seam** — `merge_ops::merge_target` plus a non-active-project test, matching the guard `Delete` already had.
- Submenus expand in place under their header rather than as a flyout: the rail is too narrow for the pointer to reliably cross a flyout gap.

## Verification

- `RUSTFLAGS=-D warnings cargo clippy --workspace --tests` clean; `cargo test -p oximux-app --lib` 2008 passed; `cargo test -p oximux-settings` 212 passed; `oximux-worktree-ops` and `workspace_create_rollback` green.
- New tests: the menu case table (primary exact list, archived, scripts, merge gate, empty app list), a GPUI paint test drawing the menu for every row kind with each submenu expanded, a Git-pane paint test for both list states, `parse_command` / `add_open_in` / `remove_open_in` edge cases (quoted-empty program refused), `is_primary_row`, `merge_target`, presets parse and cover every detected editor.
- Live-verified in a sandboxed dev instance with a seeded project: primary-row menu, `Open in ▸` expanding to Finder + installed editors (Finder opened at the path), `Copy Path` (clipboard + toast), `New workspace here` (dialog with the project preselected), the full worktree-row menu, `Move to Status ▸` writing `in-progress` with the chip painting on the next tick, the Git pane editor round-tripping to `git.toml`, and the `Presets ▾` prefill.

## Open questions

- Removing every `Open in` app returns to the built-in list — a user cannot have zero apps. Stated in the pane hint.
- `run_workspace_script` opens its terminal tab in the ACTIVE project's panes even for another project's row (pre-existing; now reachable from primary rows).
- Rename resolves the row's own project too but has no test seam like Delete and Merge; its resolution is inline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace row menus with actions for copying paths, changing status, creating workspaces, and opening directories in external apps.
  * Added configurable **Open in** applications in Git settings, including built-in file manager and editor presets.
  * Added support for custom editor commands and platform-aware editor detection.
* **Bug Fixes**
  * Workspace actions, scripts, and merge operations now consistently use the selected workspace’s project context.
  * Improved handling of invalid **Open in** entries by falling back to built-in options.
* **Documentation**
  * Documented workspace menus and **Open in** configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->