### PR TITLE
test(worktree-ops): stop racing the login shell in the timeout-output test

### DIFF
--- a/crates/worktree-ops/src/setup.rs
+++ b/crates/worktree-ops/src/setup.rs
@@ -312,18 +312,32 @@ mod tests {
 
     /// Output printed before the hang survives the timeout — it is usually the
     /// only evidence of what the script was doing when it wedged.
+    ///
+    /// The bound is the test's whole wall time, and it has to cover the
+    /// script *reaching* the echo: the runner spawns a login shell (`sh -lc`),
+    /// and on a cold Windows CI runner sourcing the profile alone has taken
+    /// longer than the 500 ms this test used to allow — which failed an
+    /// unrelated PR on the echo never having run. Five seconds is an order of
+    /// magnitude over the slowest start seen; the sibling test above is the
+    /// one that pins the timeout firing promptly.
     #[tokio::test]
     async fn output_before_a_timeout_is_kept() {
         let dir = wt();
+        let start = Instant::now();
         let t = run_setup_bounded(
             dir.path(),
             "echo installing; sleep 60",
-            Duration::from_millis(500),
+            Duration::from_secs(5),
             None,
         )
         .await;
         assert_eq!(t.outcome, SetupOutcome::TimedOut);
         assert!(t.output.contains("installing"), "{:?}", t.output);
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "should return at the bound, took {:?}",
+            start.elapsed()
+        );
     }
 
     /// stdin is closed, so a prompt fails immediately instead of consuming the


### PR DESCRIPTION
## Summary

`setup::tests::output_before_a_timeout_is_kept` failed PR #14's Windows gate on a run whose changes never touched this crate, and passed on rerun. It gave the script 500 ms to reach its `echo` before a deliberate hang; the runner spawns a login shell (`sh -lc`), and on a cold Windows runner sourcing the profile alone can take longer than that, so the echo never ran.

The bound is the test's whole wall time, so it is now 5 s — an order of magnitude over the slowest start seen — with an elapsed-time guard so it still fails loudly if the timeout stops firing. `a_hanging_script_times_out_and_is_killed` remains the test that pins prompt firing.

## Verification

- `cargo test -p oximux-worktree-ops --lib -- setup::tests`: 13 passed (the suite now takes ~5 s on the timeout path).
- `RUSTFLAGS=-D warnings cargo clippy -p oximux-worktree-ops --tests` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased a timeout in a test to accommodate shell startup.
  * Added an assertion ensuring the operation completes within 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->